### PR TITLE
Merge branch 'contributing-github' of git://tremily.us/signed-off-by into signed-off-by

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+This project tracks patch provenance and licensing using the
+[Developer Certificate of Origin][DCO] and Signed-off-by tags
+initially developed by the Linux kernel project.  Because the
+documentation for this procedure is licensed under the GPLv2, we have
+chosen not to include it in our project directly.  Instead, please see
+[SubmittingPatches][], which is stored in an external repository.
+
+[DCO]: developer-certificate-of-origin
+[SubmittingPatches]: https://github.com/wking/signed-off-by/blob/a52266b0dd55b0424ab682dc636bef6bc76e3c0d/Documentation/SubmittingPatches

--- a/developer-certificate-of-origin
+++ b/developer-certificate-of-origin
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
Add local docs to explain Signed-off-by.  The bulk of the docs are in an external repository to avoid pulling in content under too many different licenses.  The content added here is:

* `developer-certificate-of-origin` (verbatim copies only)
* `CONTRIBUTING.md` (CC0-1.0)

As requested [here][1]; CC @pombredanne.

[1]: https://github.com/spdx/spdx-online-tools/pull/21#issuecomment-375460872