### PR TITLE
Fixing file path to the tools jar file

### DIFF
--- a/src/src/settings.py
+++ b/src/src/settings.py
@@ -151,7 +151,7 @@ REST_FRAMEWORK = {
 # The online tool uses spdx-tools-2.1.6-SNAPSHOT-jar-with-dependencies.jar from the compiled target folder of java tools
 # renamed (for now) as tool.jar in the main src directory of spdx-online tool
 
-JAR_ABSOLUTE_PATH =  os.path.abspath(".")+"/tool.jar"
+JAR_ABSOLUTE_PATH =  os.path.join(os.path.abspath("."),"tool.jar")
 # URL Path Variables
 
 LOGIN_REDIRECT_URL = "/app/"


### PR DESCRIPTION
Making the file path work in a platform independent manner - necessary to run on a Windows platform

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>