### PR TITLE
License text field format

### DIFF
--- a/src/app/templates/app/license_information.html
+++ b/src/app/templates/app/license_information.html
@@ -41,7 +41,7 @@
     </div>
     <div class="licenseField col-sm-12">
         <p class="fieldName">Text</p>
-        <p>{{licenseInformation.text}}</p>
+        <p>{{licenseInformation.text|safe}}</p>
     </div>
     <div class="licenseField col-sm-12">
         <p class="fieldName">Submission Date</p>


### PR DESCRIPTION
I have made some changes on the way the license **text field** is displayed on the license information view:
- HTML tags are supported on the license text field without creating any conflicts with the license XML creation.
- Linefeeds have been replaced with `<br>` tags.
- The unnecessary `<text>` tag surrouding the text field has been removed.

Please let me know any change/suggestion @rtgdk @goneall . I think my solution could follow cleanner approach.
