### PR TITLE
Change method of formatting the text to use the paragraph elements

### DIFF
--- a/src/app/templates/app/license_information.html
+++ b/src/app/templates/app/license_information.html
@@ -41,7 +41,7 @@
     </div>
     <div class="licenseField col-sm-12">
         <p class="fieldName">Text</p>
-        <p>{{licenseInformation.text}}</p>
+        <p>{{licenseInformation.text|safe}}</p>
     </div>
     <div class="licenseField col-sm-12">
         <p class="fieldName">Submission Date</p>


### PR DESCRIPTION
Signed-off-by: Gary O'Neall <gary@sourceauditor.com>

Changed the method of formatting from CData to using paragraph tags in the XML editor.

Also added linefeeds around the XML tags to format a bit better - it isn't a very good pretty printer, but it looks better than no linefeeds at all.  We should change to a better XML pretty printer once everything is merged.

@gaalocastillo If you could review the changes
@rtgdk If you could also review and if it looks OK, merge this into text-field-format, then merge text-field-format into the license-submittal branch before merging with master