### PR TITLE
Remove duplicate link from navbar

### DIFF
--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -89,8 +89,7 @@
             <li><a href="/app/convert/" id="convertpage">Convert</a></li>
             <li><a href="/app/check_license/" id="checklicensepage">Check License</a></li>
             <li><a href="/app/xml_upload" id="xml-editor">XML Editor</a></li>
-			<li><a href="/app/check_license/" id="checklicensepage">Check License</a></li>
-            <li><a href="/app/submit_new_license/" id="submitnewlicensepage">Submit New License</a></li>
+			<li><a href="/app/submit_new_license/" id="submitnewlicensepage">Submit New License</a></li>
             <li><a href="/app/license_requests/" id="licenserequestspage">License Requests</a></li>
 		  </ul>
 		  <ul class="nav navbar-nav navbar-right" style="margin-right: 25px;font-size: 12px;">


### PR DESCRIPTION
The check license link appeared twice on the navbar.