### PR TITLE
Fix unicode error and modify OSI question in Submit New License

### DIFF
--- a/src/app/forms.py
+++ b/src/app/forms.py
@@ -21,8 +21,10 @@ from app.models import UserID
 
 OSI_CHOICES = (
     (0, "-"),
-    ("yes", "Yes"),
-    ("no", "No"),
+    ("Approved", "Approved"),
+    ("Not Submitted", "Not Submitted"),
+    ("Pending", "Submitted, but pending"),
+    ("Rejected", "Rejected")
 )
 
 class UserRegisterForm(forms.ModelForm):
@@ -66,7 +68,7 @@ class LicenseRequestForm(forms.Form):
     fullname = forms.CharField(label='Fullname', max_length=70)
     shortIdentifier = forms.CharField(label='Short identifier', max_length=25)
     sourceUrl = forms.CharField(label='Source / URL', required=False)
-    osiApproved = forms.CharField(label="OSI Approved", widget=forms.Select(choices=OSI_CHOICES))
+    osiApproved = forms.CharField(label="OSI Status", widget=forms.Select(choices=OSI_CHOICES))
     notes = forms.CharField(label='Notes', required=False)
     licenseHeader = forms.CharField(label='Standard License Header', widget=forms.Textarea(attrs={'rows': 3, 'cols': 40}), required=False)
     text = forms.CharField(label='Text', widget=forms.Textarea(attrs={'rows': 4, 'cols': 40}))

--- a/src/app/templates/app/submit_new_license.html
+++ b/src/app/templates/app/submit_new_license.html
@@ -23,7 +23,7 @@
 
     <div class = "form-group">
       <div class="col-sm-12">
-      <label class="control-label col-sm-3" >Full Name</label>
+      <label class="control-label col-sm-3" >License's Full Name</label>
         <div class="col-sm-4"> 
           {{ form.fullname }}
         </div>
@@ -51,7 +51,7 @@
 
     <div class = "form-group">
       <div class="col-sm-12">  
-      <label class="control-label col-sm-3" >&nbsp;OSI Approved&nbsp;</label>
+      <label class="control-label col-sm-3" >&nbsp;OSI Status&nbsp;</label>
         <div class="col-sm-4">
           {{ form.osiApproved }}
         </div>
@@ -78,7 +78,7 @@
 
     <div class = "form-group">
       <div class="col-sm-12">
-      <label class="control-label col-sm-3" >Text</label>
+      <label class="control-label col-sm-3" >License Text</label>
         <div class="col-sm-6">
           {{ form.text }}          
         </div>

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -152,6 +152,10 @@ def generateLicenseXml(licenseOsi, licenseIdentifier, licenseName, licenseSource
     returns the license xml as a string
     """
     root = ET.Element("SPDXLicenseCollection", xmlns="http://www.spdx.org/license")
+    if licenseOsi=="Approved":
+        licenseOsi = "true"
+    else:
+        licenseOsi = "false"
     license = ET.SubElement(root, "license", isOsiApproved=licenseOsi, licenseId=licenseIdentifier, name=licenseName)
     crossRefs = ET.SubElement(license, "crossRefs")
     for sourceUrl in licenseSourceUrls:
@@ -162,7 +166,7 @@ def generateLicenseXml(licenseOsi, licenseIdentifier, licenseName, licenseSource
     licenseLines = licenseText.replace('\r','').split('\n')
     for licenseLine in licenseLines:
         ET.SubElement(licenseTextElement, "p").text = licenseLine
-    xmlString = ET.tostring(root, encoding='utf8', method='xml').replace('>','>\n')
+    xmlString = ET.tostring(root, method='xml').replace('>','>\n')
     return xmlString
 
 def createIssue(licenseName, licenseIdentifier, licenseSourceUrls, licenseOsi, token):
@@ -173,7 +177,7 @@ def createIssue(licenseName, licenseIdentifier, licenseSourceUrls, licenseOsi, t
     for url in licenseSourceUrls:
         body += url
         body += '\n'
-    body += '**4.** OSI Approval: ' + licenseOsi
+    body += '**4.** OSI Status: ' + licenseOsi
     title = 'New license request: ' + licenseIdentifier + ' [SPDX-Online-Tools]'
     payload = {'title' : title, 'body': body, 'labels': ['new license/exception request']}
     headers = {'Authorization': 'token ' + token}


### PR DESCRIPTION
* Fixes: #69 #66 
* The license submission works fine now even with the unicode special charactes. 
* New choices have been added to the OSI dropdown.
* The values of the `isOSIApproved` field in the generated XML document has been changed to `true` and `false` instead of `yes` and `no`.  
Please have a look @goneall @jlovejoy  :slightly_smiling_face: 