### PR TITLE
Change source for the spdx-license-matcher to the SPDX github repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ social-auth-app-django==2.1.0
 selenium==3.14.1
 django-oauth-toolkit==1.0.0
 django-rest-framework-social-oauth2==1.1.0
--e git://github.com/Ugtan/spdx-license-matcher.git#egg=spdx-license-matcher
+-e git://github.com/spdx/spdx-license-matcher.git#egg=spdx-license-matcher


### PR DESCRIPTION
This is currently pointing to a fork.  I verified that both are at the same commit level.
Signed-off-by: Gary O'Neall <gary@sourceauditor.com>