### PR TITLE
Increase modal view to remove overflowing errors.

### DIFF
--- a/src/app/templates/app/modal.html
+++ b/src/app/templates/app/modal.html
@@ -1,6 +1,6 @@
 <!-- Modal -->
 <div id="myModal" class="modal fade" role="dialog">
-  <div class="modal-dialog">
+  <div class="modal-dialog" style="width: 70rem;">
 
     <!-- Modal content-->
     <div class="modal-content">


### PR DESCRIPTION
I have tested for many cases and this size of modal seems to be most appropriate for any type of errors.

Current modal view:-
![2020-06-13_17-09-24-1920x1080](https://user-images.githubusercontent.com/43504292/84567832-f37e5b00-ad98-11ea-932f-5781f22e6593.png)

New modal view:-
![2020-06-13_17-08-44-1920x1080](https://user-images.githubusercontent.com/43504292/84567836-fe38f000-ad98-11ea-830a-f3f5f42fe1f4.png)

PS- Since the CSS properties of this modal are coming from bootstrap, I had to use inline CSS for it. 

Signed-off-by: shubhamgupta2956 <shubham.gupta2956@gmail.com>