### PR TITLE
Use the new tools-java adding support for JSON, YAML, XLSX, and XML file formats

### DIFF
--- a/src/api/tests.py
+++ b/src/api/tests.py
@@ -73,22 +73,22 @@ class ValidateFileUploadTests(APITestCase):
         resp2 = self.client.get(reverse("validate-api")) 
         self.assertTrue(resp2.status_code,200)
         """ Valid Tag Value File"""
-        resp3 = self.client.post(reverse("validate-api"),{"file":self.tv_file},format="multipart")
+        resp3 = self.client.post(reverse("validate-api"),{"file":self.tv_file, "format" : "TAG"},format="multipart")
         self.assertEqual(resp3.status_code,201)
         self.assertEqual(resp3.data['owner'],User.objects.get_by_natural_key(self.username).id)
         self.assertEqual(resp3.data["result"],"This SPDX Document is valid.")
         """ Valid RDF File"""
-        resp4 = self.client.post(reverse("validate-api"),{"file":self.rdf_file},format="multipart")
+        resp4 = self.client.post(reverse("validate-api"),{"file":self.rdf_file, "format" : "RDFXML"},format="multipart")
         self.assertEqual(resp4.status_code,201)
         self.assertEqual(resp4.data['owner'],User.objects.get_by_natural_key(self.username).id)
         self.assertEqual(resp4.data["result"],"This SPDX Document is valid.")
         """ Invalid Tag Value File"""
-        resp5 = self.client.post(reverse("validate-api"),{"file":self.invalid_tv_file},format="multipart")
+        resp5 = self.client.post(reverse("validate-api"),{"file":self.invalid_tv_file, "format" : "TAG"},format="multipart")
         self.assertEqual(resp5.data['owner'],User.objects.get_by_natural_key(self.username).id)
         self.assertEqual(resp5.status_code,400)
         self.assertNotEqual(resp5.data["result"],"This SPDX Document is valid.")
         """ Invalid RDF File"""
-        resp6 = self.client.post(reverse("validate-api"),{"file":self.invalid_rdf_file},format="multipart")
+        resp6 = self.client.post(reverse("validate-api"),{"file":self.invalid_rdf_file, "format" : "RDFXML"},format="multipart")
         self.assertEqual(resp6.data['owner'],User.objects.get_by_natural_key(self.username).id)
         self.assertEqual(resp6.status_code,400)
         self.assertNotEqual(resp6.data["result"],"This SPDX Document is valid.")
@@ -115,10 +115,9 @@ class ConvertFileUploadTests(APITestCase):
         u = User.objects.create_user(**self.credentials)
         u.is_staff = True
         u.save()
-        self.tag = "Tag"
-        self.rdf = "RDF"
-        self.xlsx = "Spreadsheet"
-        self.html ="HTML"
+        self.tag = "TAG"
+        self.rdf = "RDFXML"
+        self.xlsx = "XLS"
         self.tv_file = open("examples/SPDXTagExample-v2.0.spdx")
         self.rdf_file = open("examples/SPDXRdfExample-v2.0.rdf")
         self.xlsx_file = open("examples/SPDXSpreadsheetExample-2.0.xls")
@@ -173,13 +172,6 @@ class ConvertFileUploadTests(APITestCase):
         self.assertTrue(resp.data["result"].startswith(settings.MEDIA_URL))
         self.assertEqual(resp.data['owner'],User.objects.get_by_natural_key(self.username).id)
         self.client.logout()
-
-    # def test_convert_rdftohtml_api(self):
-    #     self.client.login(username=self.username,password=self.password)
-    #     resp = self.client.post(reverse("convert-api"),{"file":self.rdf_file,"from_format":self.rdf,"to_format":self.html,"cfilename":"rdftohtml-apitest"},format="multipart")
-    #     self.assertTrue(resp.status_code==406 or resp.status_code == 201)
-    #     self.assertTrue(resp.data["result"].startswith(settings.MEDIA_URL))
-    #     self.client.logout()
 
     def test_convert_xlsxtordf_api(self):
         self.client.login(username=self.username,password=self.password)

--- a/src/api/tests.py
+++ b/src/api/tests.py
@@ -146,7 +146,6 @@ class ConvertFileUploadTests(APITestCase):
         self.assertTrue(resp.status_code==406 or resp.status_code == 201)
         self.assertTrue(resp.data["result"].startswith(settings.MEDIA_URL))
         self.assertEqual(resp.data['owner'],User.objects.get_by_natural_key(self.username).id)
-        self.assertTrue(resp.data["tagToRdfFormat"]=="RDF/XML-ABBREV")
         self.client.logout()
 
     def test_convert_tagtoxlsx_api(self):

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -225,7 +225,6 @@ def convert(request):
                     option1 = request.POST["from_format"]
                     option2 = request.POST["to_format"]
                     convertfile =  request.POST["cfilename"]
-                    warningoccurred = False
                     if (extensionGiven(convertfile)==False):
                         extension = getFileFormat(option2)
                         convertfile = convertfile + extension
@@ -236,8 +235,6 @@ def convert(request):
                                 folder+sep+convertfile, fromFileFormat, toFileFormat)
                     retval = verifyclass.verify(folder+sep+convertfile, toFileFormat)
                     if (len(retval) > 0):
-                        warningoccurred = True
-                    if (warningoccurred == True ):
                         message = "The following error(s)/warning(s) were raised: " + str(retval)
                         index = folder.split(sep).index('media')
                         result = "/"+"/".join(folder.split(sep)[index:])+'/'+convertfile

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -430,7 +430,7 @@ def check_license(request):
                 jpype.startJVM(jpype.getDefaultJVMPath(),"-ea","-Djava.class.path=%s"%classpath)
             """ Attach a Thread and start processing the request """
             jpype.attachThreadToJVM()
-            package = jpype.JPackage("org.spdx.compare")
+            package = jpype.JPackage("org.spdx.utility.compare")
             compareclass = package.LicenseCompareHelper
             query = CheckLicenseFileUpload.objects.create(
                 owner=request.user,

--- a/src/app/templates/app/compare.html
+++ b/src/app/templates/app/compare.html
@@ -29,7 +29,7 @@
 			<label class="control-label col-sm-3" >Result File Name</label>
 				<div class="col-sm-6"> 
 					<input type="text" id="rfilename" placeholder="" name = "rfilename">
-					<label class="control-label" id="convertdoclabel">.xls</label>
+					<label class="control-label" id="convertdoclabel">.xlsx</label>
 				</div>
 			</div>	
 		</div>

--- a/src/app/templates/app/convert.html
+++ b/src/app/templates/app/convert.html
@@ -19,7 +19,7 @@
 		<div class = "form-group">
 		&nbsp; From &nbsp;
 			 <select name="from_format" id="from_format">
-			 	  <option value="0" name ="here" selected="">-</option>
+			 	  <option value="0" selected="">-</option>
 				  <option value="TAG">Tag</option>
 				  <option value="RDFXML">RDF</option>
 				  <option value="XLSX">XLSX Spreadsheet</option>
@@ -30,14 +30,14 @@
 			</select>
 			&nbsp; To &nbsp;
 			<select name="to_format" id="to_format">
-			 	  <option value="0" data-value="INGORE" name ="here" selected="">-</option>
-				  <option value="TAG" data-value="TAG">Tag</option>
-				  <option value="RDFXML" data-value="RDFXML">RDF</option>
-				  <option value="XLSX" data-value="XLSX">XLSX Spreadsheet</option>
-				  <option value="XLS" data-value="XLS">XLS Spreadsheet</option>
-				  <option value="JSON" data-value="JSON">JSON</option>
-				  <option value="XML" data-value="XML">XML</option>
-				  <option value="YAML" data-value="YAML">YAML</option>
+			 	  <option value="0" data-value="INGORE" data-ext="" selected="">-</option>
+				  <option value="TAG" data-value="TAG" data-ext=".spdx">Tag</option>
+				  <option value="RDFXML" data-value="RDFXML" data-ext=".rdf.xml">RDF</option>
+				  <option value="XLSX" data-value="XLSX" data-ext=".xlsx">XLSX Spreadsheet</option>
+				  <option value="XLS" data-value="XLS" data-ext=".xls">XLS Spreadsheet</option>
+				  <option value="JSON" data-value="JSON" data-ext=".json">JSON</option>
+				  <option value="XML" data-value="XML" data-ext=".xml">XML</option>
+				  <option value="YAML" data-value="YAML" data-ext=".yaml">YAML</option>
             </select>
     </div>
     <div id="drop-area" class="container">
@@ -149,76 +149,24 @@ $(document).ready(function () {
     }
 	if (id2 == id) {
 	    $('#to_format').val("0");
+	    $('#convertdoclabel').text("");
+	    $('#cfileformat').val("");
     } else {
-		$('#to_format').val(id2);
-	}
-    if (id2=="XLS"){
-      $('#convertdoclabel').text(".xls");
-      $('#cfileformat').val(".xls");
-    }
-	else if (id2=="XLSX"){
-      $('#convertdoclabel').text(".xlsx");
-      $('#cfileformat').val(".xlsx");
-    }
-    else if (id2=="RDFXML"){
-      $('#convertdoclabel').text(".rdf.xml");
-      $('#cfileformat').val(".rdf.xml");
-    }
-    else if (id2=="TAG"){
-      $('#convertdoclabel').text(".spdx");
-      $('#cfileformat').val(".spdx");
-    }
-    else if (id2=="JSON"){
-      $('#convertdoclabel').text(".json");
-      $('#cfileformat').val(".json");
-    }
-	else if (id2=="YAML"){
-      $('#convertdoclabel').text(".yaml");
-      $('#cfileformat').val(".yaml");
-    }
-	else if (id2=="XML"){
-      $('#convertdoclabel').text(".xml");
-      $('#cfileformat').val(".xml");
-    }
-    else{
-      $('#convertdoclabel').text();
-      $('#cfileformat').val("");
+	    file_ext = $('#to_format').find(':selected').attr("data-ext");
+	    $('#convertdoclabel').text(file_ext);
+	    $('#cfileformat').val(file_ext);
     }
   });
 
   $("#to_format").change(function() {
     var id2 = $('#to_format').val();
-    if (id2=="XLS"){
-      $('#convertdoclabel').text(".xls");
-      $('#cfileformat').val(".xls");
-    }
-	else if (id2=="XLSX"){
-      $('#convertdoclabel').text(".xlsx");
-      $('#cfileformat').val(".xlsx");
-    }
-    else if (id2=="RDFXML"){
-      $('#convertdoclabel').text(".rdf.xml");
-      $('#cfileformat').val(".rdf.xml");
-    }
-    else if (id2=="TAG"){
-      $('#convertdoclabel').text(".spdx");
-      $('#cfileformat').val(".spdx");
-    }
-    else if (id2=="JSON"){
-      $('#convertdoclabel').text(".json");
-      $('#cfileformat').val(".json");
-    }
-	else if (id2=="YAML"){
-      $('#convertdoclabel').text(".yaml");
-      $('#cfileformat').val(".yaml");
-    }
-	else if (id2=="XML"){
-      $('#convertdoclabel').text(".xml");
-      $('#cfileformat').val(".xml");
-    }
-    else{
-      $('#convertdoclabel').text();
-      $('#cfileformat').val("");
+    if (id2 == "0") {
+	    $('#convertdoclabel').text("");
+	    $('#cfileformat').val("");
+    } else {
+	    file_ext = $('#to_format').find(':selected').attr("data-ext");
+	    $('#convertdoclabel').text(file_ext);
+	    $('#cfileformat').val(file_ext);
     }
   });
 })

--- a/src/app/templates/app/convert.html
+++ b/src/app/templates/app/convert.html
@@ -147,7 +147,6 @@ $(document).ready(function () {
     else{
       $('#doclabel').text("Upload SPDX Document using the button or by dragging and dropping onto the dashed region");
     }
-	console.log("To format after doclabel text: "+$('#to_format').val());
 	if (id2 == id) {
 	    $('#to_format').val("0");
     } else {

--- a/src/app/templates/app/convert.html
+++ b/src/app/templates/app/convert.html
@@ -21,7 +21,7 @@
 			 <select name="from_format" id="from_format">
 			 	  <option value="0" selected="">-</option>
 				  <option value="TAG">Tag</option>
-				  <option value="RDFXML">RDF</option>
+				  <option value="RDFXML">RDF/XML</option>
 				  <option value="XLSX">XLSX Spreadsheet</option>
 				  <option value="XLS">XLS Spreadsheet</option>
 				  <option value="JSON">JSON</option>
@@ -32,7 +32,7 @@
 			<select name="to_format" id="to_format">
 			 	  <option value="0" data-value="INGORE" data-ext="" selected="">-</option>
 				  <option value="TAG" data-value="TAG" data-ext=".spdx">Tag</option>
-				  <option value="RDFXML" data-value="RDFXML" data-ext=".rdf.xml">RDF</option>
+				  <option value="RDFXML" data-value="RDFXML" data-ext=".rdf.xml">RDF/XML</option>
 				  <option value="XLSX" data-value="XLSX" data-ext=".xlsx">XLSX Spreadsheet</option>
 				  <option value="XLS" data-value="XLS" data-ext=".xls">XLS Spreadsheet</option>
 				  <option value="JSON" data-value="JSON" data-ext=".json">JSON</option>
@@ -138,7 +138,7 @@ $(document).ready(function () {
       $(this).data('options', $('#to_format option').clone());
     }
     var id = $(this).val();
-	var id2 = $('#to_format').val();
+    var id2 = $('#to_format').val();
     var options = $(this).data('options').filter('[data-value!=' + id + ']');
     $('#to_format').html(options);
     if (id!="0"){

--- a/src/app/templates/app/convert.html
+++ b/src/app/templates/app/convert.html
@@ -152,6 +152,7 @@ $(document).ready(function () {
 	    $('#convertdoclabel').text("");
 	    $('#cfileformat').val("");
     } else {
+	    $('#to_format').val(id2);
 	    file_ext = $('#to_format').find(':selected').attr("data-ext");
 	    $('#convertdoclabel').text(file_ext);
 	    $('#cfileformat').val(file_ext);

--- a/src/app/templates/app/convert.html
+++ b/src/app/templates/app/convert.html
@@ -20,30 +20,25 @@
 		&nbsp; From &nbsp;
 			 <select name="from_format" id="from_format">
 			 	  <option value="0" name ="here" selected="">-</option>
-				  <option value="Tag">Tag</option>
-				  <option value="RDF">RDF</option>
-				  <option value="Spreadsheet">Spreadsheet</option>
+				  <option value="TAG">Tag</option>
+				  <option value="RDFXML">RDF</option>
+				  <option value="XLSX">XLSX Spreadsheet</option>
+				  <option value="XLS">XLS Spreadsheet</option>
+				  <option value="JSON">JSON</option>
+				  <option value="XML">XML</option>
+				  <option value="YAML">YAML</option>
 			</select>
 			&nbsp; To &nbsp;
 			<select name="to_format" id="to_format">
-				  <option value="0" data-value="0" selected="">-</option>
-				  <option value="Spreadsheet" data-value="Tag" >Spreadsheet</option>
-				  <option value="RDF" data-value="Tag" >RDF</option>
-				  <option value="Tag" data-value="RDF">Tag</option>
-				  <option value="HTML" data-value="RDF">HTML</option>
-				  <option value="Spreadsheet" data-value="RDF">Spreadsheet</option>
-				  <option value="Tag" data-value="Spreadsheet">Tag</option>
-				  <option value="RDF" data-value="Spreadsheet">RDF</option>
-      </select>
-    </div>
-    <div class="tagToRdfOptions" style="display:block; margin:10px auto; color:grey;">
-      <span id="tagToRdfText">&nbsp; RDF Output Format &nbsp;</span>
-      <select name="tagToRdfFormat" id="tagToRdfFormat" disabled="true">
-        <option value="RDF/XML-ABBREV" selected="">RDF/XML-ABBREV</option>
-        <option value="RDF/XML">RDF/XML</option>
-        <option value="N-TRIPLET">N-TRIPLET</option>
-        <option value="TURTLE">TURTLE</option>
-      </select>
+			 	  <option value="0" data-value="INGORE" name ="here" selected="">-</option>
+				  <option value="TAG" data-value="TAG">Tag</option>
+				  <option value="RDFXML" data-value="RDFXML">RDF</option>
+				  <option value="XLSX" data-value="XLSX">XLSX Spreadsheet</option>
+				  <option value="XLS" data-value="XLS">XLS Spreadsheet</option>
+				  <option value="JSON" data-value="JSON">JSON</option>
+				  <option value="XML" data-value="XML">XML</option>
+				  <option value="YAML" data-value="YAML">YAML</option>
+            </select>
     </div>
     <div id="drop-area" class="container">
       <h4 id="doclabel">Upload SPDX Document using the button or by dragging and dropping onto the dashed region</h4>
@@ -138,14 +133,13 @@ $(document).ready(function () {
   $("#convertpage").addClass('linkactive');
 
   $("#from_format").change(function() {
-    $("#tagToRdfFormat").prop("disabled",'disabled');
-    $(".tagToRdfOptions").css("color",'grey');
     if ($(this).data('options') === undefined) {
       /*Taking an array of all options-2 and kind of embedding it on the select1*/
       $(this).data('options', $('#to_format option').clone());
     }
     var id = $(this).val();
-    var options = $(this).data('options').filter('[data-value=' + id + ']');
+	var id2 = $('#to_format').val();
+    var options = $(this).data('options').filter('[data-value!=' + id + ']');
     $('#to_format').html(options);
     if (id!="0"){
       $('#doclabel').text("Upload SPDX "+ id +" Document using the button or by dragging and dropping onto the dashed region");
@@ -153,26 +147,39 @@ $(document).ready(function () {
     else{
       $('#doclabel').text("Upload SPDX Document using the button or by dragging and dropping onto the dashed region");
     }
-    var id2 = $('#to_format').val();
-    if (id2=="Spreadsheet"){
+	console.log("To format after doclabel text: "+$('#to_format').val());
+	if (id2 == id) {
+	    $('#to_format').val("0");
+    } else {
+		$('#to_format').val(id2);
+	}
+    if (id2=="XLS"){
       $('#convertdoclabel').text(".xls");
       $('#cfileformat').val(".xls");
     }
-    else if (id2=="RDF"){
-      if(id=="Tag"){
-        $("#tagToRdfFormat").prop("disabled", false);
-        $(".tagToRdfOptions").css("color",'black');
-      }
-      $('#convertdoclabel').text(".rdf");
-      $('#cfileformat').val(".rdf");
+	else if (id2=="XLSX"){
+      $('#convertdoclabel').text(".xlsx");
+      $('#cfileformat').val(".xlsx");
     }
-    else if (id2=="Tag"){
+    else if (id2=="RDFXML"){
+      $('#convertdoclabel').text(".rdf.xml");
+      $('#cfileformat').val(".rdf.xml");
+    }
+    else if (id2=="TAG"){
       $('#convertdoclabel').text(".spdx");
       $('#cfileformat').val(".spdx");
     }
-    else if (id2=="HTML"){
-      $('#convertdoclabel').text(".html");
-      $('#cfileformat').val(".html");
+    else if (id2=="JSON"){
+      $('#convertdoclabel').text(".json");
+      $('#cfileformat').val(".json");
+    }
+	else if (id2=="YAML"){
+      $('#convertdoclabel').text(".yaml");
+      $('#cfileformat').val(".yaml");
+    }
+	else if (id2=="XML"){
+      $('#convertdoclabel').text(".xml");
+      $('#cfileformat').val(".xml");
     }
     else{
       $('#convertdoclabel').text();
@@ -181,29 +188,34 @@ $(document).ready(function () {
   });
 
   $("#to_format").change(function() {
-    $("#tagToRdfFormat").prop("disabled",'disabled');
-    $(".tagToRdfOptions").css("color",'grey');
-    var id1 = $('#from_format').val();
     var id2 = $('#to_format').val();
-    if (id2=="Spreadsheet"){
+    if (id2=="XLS"){
       $('#convertdoclabel').text(".xls");
       $('#cfileformat').val(".xls");
     }
-    else if (id2=="RDF"){
-      if(id1=="Tag"){
-        $("#tagToRdfFormat").prop("disabled",false);
-        $(".tagToRdfOptions").css("color",'black');
-      }
-      $('#convertdoclabel').text(".rdf");
-      $('#cfileformat').val(".rdf");
+	else if (id2=="XLSX"){
+      $('#convertdoclabel').text(".xlsx");
+      $('#cfileformat').val(".xlsx");
     }
-    else if (id2=="Tag"){
+    else if (id2=="RDFXML"){
+      $('#convertdoclabel').text(".rdf.xml");
+      $('#cfileformat').val(".rdf.xml");
+    }
+    else if (id2=="TAG"){
       $('#convertdoclabel').text(".spdx");
       $('#cfileformat').val(".spdx");
     }
-    else if (id2=="HTML"){
-      $('#convertdoclabel').text(".html");
-      $('#cfileformat').val(".html");
+    else if (id2=="JSON"){
+      $('#convertdoclabel').text(".json");
+      $('#cfileformat').val(".json");
+    }
+	else if (id2=="YAML"){
+      $('#convertdoclabel').text(".yaml");
+      $('#cfileformat').val(".yaml");
+    }
+	else if (id2=="XML"){
+      $('#convertdoclabel').text(".xml");
+      $('#cfileformat').val(".xml");
     }
     else{
       $('#convertdoclabel').text();

--- a/src/app/templates/app/validate.html
+++ b/src/app/templates/app/validate.html
@@ -21,7 +21,7 @@
 					  <option value="0" data-value="0" selected="">-</option>
 					  <option value="XLSXSpreadsheet">XLSX Spreadsheet</option>
 					  <option value="XLSSpreadsheet">XLS Spreadsheet</option>
-					  <option value="RDF">RDF/XML</option>
+					  <option value="RDFXML">RDF/XML</option>
 					  <option value="Tag">Tag/Value</option>
 					  <option value="JSON">JSON</option>
 					  <option value="YAML">YAML</option>

--- a/src/app/templates/app/validate.html
+++ b/src/app/templates/app/validate.html
@@ -11,17 +11,31 @@
 </div>
 <p class ="lead"> {{ error }}</p>
 <div class="panel panel-default">
-<div class="panel-heading"> <p class="lead"> Tag-Value, RDF and XML SPDX Document</p> </div>
+<div class="panel-heading"> <p class="lead">Tag-Value, RDF, JSON, Spreadsheet, XML SPDX Document</p> </div>
 <div class="panel-body">
-  <div id="drop-area" class="container">
-    <form id="validateform" enctype="multipart/form-data" class="form-horizontal" method="post">
-      {% csrf_token %}
-      <h4>Upload file using the button or by dragging and dropping onto the dashed region</h4>
-      <input type="file" id="file" onchange="handleFiles(this.files)">
-      <label class="button" for="file">Select file</label>
-      <p class="file-name">No file selected</p>
+	<form id="validateform" enctype="multipart/form-data" class="form-horizontal" method="post">
+	  {% csrf_token %}
+	  <div class = "form-group">
+			&nbsp; File Type &nbsp;
+				<select name="format" id="format">
+					  <option value="0" data-value="0" selected="">-</option>
+					  <option value="XLSXSpreadsheet">XLSX Spreadsheet</option>
+					  <option value="XLSSpreadsheet">XLS Spreadsheet</option>
+					  <option value="RDF">RDF/XML</option>
+					  <option value="Tag">Tag/Value</option>
+					  <option value="JSON">JSON</option>
+					  <option value="YAML">YAML</option>
+					  <option value="XML">XML</option>
+                </select>	
+		</div>
+		<div id="drop-area" class="container">
+		  <h4>Upload file using the button or by dragging and dropping onto the dashed region</h4>
+		  <input type="file" id="file" onchange="handleFiles(this.files)">
+		  <label class="button" for="file">Select file</label>
+		  <p class="file-name">No file selected</p>
+		</div> 
     </form>
-  </div> <hr>
+<hr>
     <button id="validatebutton" name="validatebutton" class="btn btn-md btn-info" type="submit" disabled="true">Validate</button>
   {% include "app/modal.html" %} 
   <!--
@@ -89,6 +103,9 @@
 function checkform() {
   if (selected_file == "") {
     return ("No files selected.");
+  } else if (($('#format').val() == "0")){
+    $('#formatt').focus();
+    return("Please select the file format.");
   }
   else {
     return "1";

--- a/src/app/tests.py
+++ b/src/app/tests.py
@@ -163,7 +163,7 @@ class ValidateViewsTestCase(TestCase):
         """POST Request for validate without login or ANONYMOUS_LOGIN_DISABLED """
         if not settings.ANONYMOUS_LOGIN_ENABLED :
             self.tv_file = open("examples/SPDXTagExample-v2.0.spdx")
-            resp = self.client.post(reverse("validate"),{'file' : self.tv_file},follow=True,secure=True)
+            resp = self.client.post(reverse("validate"),{'file' : self.tv_file, 'format' : 'TAG'},follow=True,secure=True)
             self.assertNotEqual(resp.redirect_chain,[])
             self.assertIn(settings.LOGIN_URL, (i[0] for i in resp.redirect_chain))
             self.tv_file.close()
@@ -182,7 +182,7 @@ class ValidateViewsTestCase(TestCase):
         """POST Request for validate validating tag value files """
         self.client.force_login(User.objects.get_or_create(username='validatetestuser')[0])
         self.tv_file = open("examples/SPDXTagExample-v2.0.spdx")
-        resp = self.client.post(reverse("validate"),{'file' : self.tv_file},follow=True,secure=True)
+        resp = self.client.post(reverse("validate"),{'file' : self.tv_file, 'format' : 'TAG'},follow=True,secure=True)
         self.assertEqual(resp.status_code,200)
         self.assertEqual(resp.content,"This SPDX Document is valid.")
         self.client.logout()
@@ -191,7 +191,7 @@ class ValidateViewsTestCase(TestCase):
         """POST Request for validate validating rdf files """
         self.client.force_login(User.objects.get_or_create(username='validatetestuser')[0])
         self.rdf_file = open("examples/SPDXRdfExample-v2.0.rdf")
-        resp = self.client.post(reverse("validate"),{'file' : self.rdf_file},follow=True,secure=True)
+        resp = self.client.post(reverse("validate"),{'file' : self.rdf_file, 'format' : 'RDFXML'},follow=True,secure=True)
         self.assertEqual(resp.status_code,200)
         self.assertEqual(resp.content,"This SPDX Document is valid.")
         self.rdf_file.close()
@@ -201,7 +201,7 @@ class ValidateViewsTestCase(TestCase):
         """POST Request for validate validating other files """
         self.client.force_login(User.objects.get_or_create(username='validatetestuser')[0])
         self.other_file = open("examples/Other.txt")
-        resp = self.client.post(reverse("validate"),{'file' : self.other_file},follow=True,secure=True)
+        resp = self.client.post(reverse("validate"),{'file' : self.other_file, 'format' : 'TAG'},follow=True,secure=True)
         self.assertTrue(resp.status_code,400)
         self.assertTrue('error' in resp.context)
         self.other_file.close()
@@ -211,7 +211,7 @@ class ValidateViewsTestCase(TestCase):
         """POST Request for validate validating tag value files """
         self.client.force_login(User.objects.get_or_create(username='validatetestuser')[0])
         self.invalid_tv_file = open("examples/SPDXTagExample-v2.0_invalid.spdx")
-        resp = self.client.post(reverse("validate"),{'file' : self.invalid_tv_file},follow=True)
+        resp = self.client.post(reverse("validate"),{'file' : self.invalid_tv_file, 'format' : 'TAG'},follow=True)
         self.assertTrue(resp.status_code,400)
         self.assertTrue('error' in resp.context)
         self.invalid_tv_file.close()
@@ -221,7 +221,7 @@ class ValidateViewsTestCase(TestCase):
         """POST Request for validate validating rdf files """
         self.client.force_login(User.objects.get_or_create(username='validatetestuser')[0])
         self.invalid_rdf_file = open("examples/SPDXRdfExample-v2.0_invalid.rdf")
-        resp = self.client.post(reverse("validate"),{'file' : self.invalid_rdf_file},follow=True)
+        resp = self.client.post(reverse("validate"),{'file' : self.invalid_rdf_file, 'format' : 'RDFXML'},follow=True)
         self.assertTrue(resp.status_code,400)
         self.assertTrue('error' in resp.context)
         self.client.logout()
@@ -335,7 +335,7 @@ class ConvertViewsTestCase(TestCase):
         """POST Request for convert tag to rdf"""
         self.client.force_login(User.objects.get_or_create(username='converttestuser')[0])
         self.tv_file = open("examples/SPDXTagExample-v2.0.spdx")
-        resp = self.client.post(reverse("convert"),{'cfilename': "tagtest" ,'cfileformat': ".rdf",'from_format' : "Tag", 'to_format' : "RDF", 'tagToRdfFormat': "TURTLE",'file' : self.tv_file},follow=True,secure=True)
+        resp = self.client.post(reverse("convert"),{'cfilename': "tagtest" ,'cfileformat': ".rdf.xml",'from_format' : "TAG", 'to_format' : "RDFXML", 'file' : self.tv_file},follow=True,secure=True)
         self.assertTrue(resp.status_code==406 or resp.status_code == 200)
         self.assertIn("medialink",resp.context)
         self.assertEqual(resp.redirect_chain,[])
@@ -349,7 +349,7 @@ class ConvertViewsTestCase(TestCase):
         """POST Request for convert tag to spreadsheet"""
         self.client.force_login(User.objects.get_or_create(username='converttestuser')[0])
         self.tv_file = open("examples/SPDXTagExample-v2.0.spdx")
-        resp = self.client.post(reverse("convert"),{'cfilename': "tagtest" ,'cfileformat': ".xls",'from_format' : "Tag", 'to_format' : "Spreadsheet", 'file' : self.tv_file},follow=True)
+        resp = self.client.post(reverse("convert"),{'cfilename': "tagtest" ,'cfileformat': ".xlsx",'from_format' : "TAG", 'to_format' : "XLSX", 'file' : self.tv_file},follow=True)
         self.assertTrue(resp.status_code==406 or resp.status_code == 200)
         self.assertIn("medialink",resp.context)
         self.assertEqual(resp.redirect_chain,[])
@@ -363,7 +363,7 @@ class ConvertViewsTestCase(TestCase):
         """POST Request for convert rdf to tag"""
         self.client.force_login(User.objects.get_or_create(username='converttestuser')[0])
         self.rdf_file = open("examples/SPDXRdfExample-v2.0.rdf")
-        resp = self.client.post(reverse("convert"),{'cfilename': "rdftest" ,'cfileformat': ".spdx",'from_format' : "RDF", 'to_format' : "Tag", 'file' : self.rdf_file},follow=True)
+        resp = self.client.post(reverse("convert"),{'cfilename': "rdftest" ,'cfileformat': ".spdx",'from_format' : "RDFXML", 'to_format' : "TAG", 'file' : self.rdf_file},follow=True)
         self.assertTrue(resp.status_code==406 or resp.status_code == 200)
         self.assertIn("medialink",resp.context)
         self.assertEqual(resp.redirect_chain,[])
@@ -377,7 +377,7 @@ class ConvertViewsTestCase(TestCase):
         """POST Request for convert rdf to spreadsheet"""
         self.client.force_login(User.objects.get_or_create(username='converttestuser')[0])
         self.rdf_file = open("examples/SPDXRdfExample-v2.0.rdf")
-        resp = self.client.post(reverse("convert"),{'cfilename': "rdftest" ,'cfileformat': ".xls",'from_format' : "RDF", 'to_format' : "Spreadsheet", 'file' : self.rdf_file},follow=True)
+        resp = self.client.post(reverse("convert"),{'cfilename': "rdftest" ,'cfileformat': ".xls",'from_format' : "RDFXML", 'to_format' : "XLS", 'file' : self.rdf_file},follow=True)
         self.assertTrue(resp.status_code==406 or resp.status_code == 200)
         self.assertIn("medialink",resp.context)
         self.assertEqual(resp.redirect_chain,[])
@@ -387,21 +387,11 @@ class ConvertViewsTestCase(TestCase):
         self.rdf_file.close()
         self.client.logout()
 
-    # def test_convert_rdftohtml(self):
-    #     """POST Request for convert rdf to html"""
-    #     self.client.force_login(User.objects.get_or_create(username='converttestuser')[0])
-    #     self.rdf_file = open("examples/SPDXRdfExample-v2.0.rdf")
-    #     resp = self.client.post(reverse("convert"),{'cfilename': "rdftest" ,'cfileformat': ".html",'from_format' : "RDF", 'to_format' : "Html", 'file' : self.rdf_file},follow=True)
-    #     self.assertEqual(resp.status_code,200)
-    #     self.assertNotEqual(resp.redirect_chain,[])
-    #     self.rdf_file.close()
-    #     self.client.logout()
-
     def test_convert_xlsxtotag(self):
         """POST Request for convert spreadsheet to tag"""
         self.client.force_login(User.objects.get_or_create(username='converttestuser')[0])
         self.xls_file = open("examples/SPDXSpreadsheetExample-2.0.xls")
-        resp = self.client.post(reverse("convert"),{'cfilename': "xlsxtest" ,'cfileformat': ".spdx",'from_format' : "Spreadsheet", 'to_format' : "Tag", 'file' : self.xls_file},follow=True)
+        resp = self.client.post(reverse("convert"),{'cfilename': "xlsxtest" ,'cfileformat': ".spdx",'from_format' : "XLS", 'to_format' : "TAG", 'file' : self.xls_file},follow=True)
         self.assertTrue(resp.status_code==406 or resp.status_code == 200)
         self.assertIn("medialink",resp.context)
         self.assertEqual(resp.redirect_chain,[])
@@ -415,7 +405,7 @@ class ConvertViewsTestCase(TestCase):
         """POST Request for convert spreadsheet to rdf"""
         self.client.force_login(User.objects.get_or_create(username='converttestuser')[0])
         self.xls_file = open("examples/SPDXSpreadsheetExample-2.0.xls")
-        resp = self.client.post(reverse("convert"),{'cfilename': "xlsxtest" ,'cfileformat': ".rdf",'from_format' : "Spreadsheet", 'to_format' : "RDF", 'file' : self.xls_file},follow=True)
+        resp = self.client.post(reverse("convert"),{'cfilename': "xlsxtest" ,'cfileformat': ".rdf",'from_format' : "XLS", 'to_format' : "RDFXML", 'file' : self.xls_file},follow=True)
         self.assertTrue(resp.status_code==406 or resp.status_code == 200)
         self.assertIn("medialink",resp.context)
         self.assertEqual(resp.redirect_chain,[])

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -671,7 +671,7 @@ def compare(request):
                         uploaded_file_url = fs.url(filename).replace("%20", " ")
                         callfunc.append(settings.APP_DIR+uploaded_file_url)
                         nameoffile, fileext = os.path.splitext(filename)
-                        if nameoffile.endswith(".rdf") and fileext == ".xml":
+                        if (nameoffile.endswith(".rdf") and fileext == ".xml") or fileext == ".rdf":
                             fileext = ".rdfxml"
                         elif fileext == ".spdx":
                             fileext = ".tag"
@@ -819,6 +819,24 @@ def getFileFormat(to_format):
         return ".xml"
     else :
         return ".invalid"
+        
+def formatToContentType(to_format):
+    if (to_format=="TAG"):
+        return "text/tag-value"
+    elif (to_format=="RDFXML"):
+        return "application/rdf+xml"
+    elif (to_format=="XLS"):
+        return "application/vnd.ms-excel"
+    elif (to_format=="XLSX"):
+        return "application/vnd.ms-excel"
+    elif (to_format=="JSON"):
+        return "application/json"
+    elif (to_format=="YAML"):
+        return "text/yaml"
+    elif (to_format=="XML"):
+        return "application/xml"
+    else :
+        return ".invalid"
 
 def convert(request):
     """ View for convert tool
@@ -848,7 +866,7 @@ def convert(request):
                     uploaded_file_url = fs.url(filename).replace("%20", " ")
                     option1 = request.POST["from_format"]
                     option2 = request.POST["to_format"]
-                    content_type =""
+                    content_type = formatToContentType(option2)
                     if "cfileformat" in request.POST :
                         cfileformat = request.POST["cfileformat"]
                     else :

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -62,8 +62,6 @@ from .forms import LicenseRequestForm, LicenseNamespaceRequestForm
 from .models import LicenseRequest, LicenseNamespace
 from spdx_license_matcher.utils import get_spdx_license_text
 
-
-
 import cgi
 
 def index(request):
@@ -460,8 +458,11 @@ def validate(request):
                         )
                     filename = fs.save(myfile.name, myfile)
                     uploaded_file_url = fs.url(filename).replace("%20", " ")
+                    formatstr = request.POST["format"]
+                    serFileTypeEnum = jpype.JClass("org.spdx.tools.SpdxToolsHelper$SerFileType")
+                    fileformat = serFileTypeEnum.valueOf(formatstr)
                     """ Call the java function with parameters """
-                    retval = verifyclass.verify(str(settings.APP_DIR+uploaded_file_url))
+                    retval = verifyclass.verify(str(settings.APP_DIR+uploaded_file_url), fileformat)
                     if (len(retval) > 0):
                         """ If any warnings are returned """
                         if (request.is_ajax()):


### PR DESCRIPTION
The new Java tools library has been significantly re-written and adds support for additional JSON file.

Note: There is some loss functionality in the convert function.  It no longer supports converting to HTML.

The HTML and JavaScript UI has been update to reflect the new files supported.

Also note that the default spreadsheet format is now XLSX rather than XLS (although XLS is also supported).