### PR TITLE
Remove editor from submit

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,7 +29,7 @@ services:
     build:
       context: ./
       dockerfile: dockerfile.prod
-    image: 410487266669.dkr.ecr.us-west-2.amazonaws.com/spdx/online-tools:0.1.4
+    image: 410487266669.dkr.ecr.us-west-2.amazonaws.com/spdx/online-tools:0.1.5
     expose:
       - 8000
     volumes:

--- a/src/app/templates/app/submit_new_license.html
+++ b/src/app/templates/app/submit_new_license.html
@@ -652,7 +652,6 @@ async function generate_text_diff(base, newtxt){
     });
   }
 </script>
-<script type="text/javascript" src="{% static 'js/editor/script.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/editor/difflib.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/editor/diffview.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/editor/treeview.js' %}"></script>

--- a/src/app/utils.py
+++ b/src/app/utils.py
@@ -465,15 +465,17 @@ def get_license_data(issues):
     for issue in issues:
         if not issue.get('pull_request'):
             licenseInfo = issue.get('body')
-            if '[SPDX-Online-Tools]' in issue.get('title'):
-                licenseIdentifier = re.search(r'(?im)short identifier:\s([a-zA-Z0-9|.|-]+)', licenseInfo).group(1)
-                dbId = re.search(r'License Request Url:.+/app/license_requests/([0-9]+)', licenseInfo).group(1)
+            if '[SPDX-Online-Tools]' in issue.get('title'):         
                 try:
+                    licenseIdentifier = re.search(r'(?im)short identifier:\s([a-zA-Z0-9|.|-]+)', licenseInfo).group(1)
+                    dbId = re.search(r'License Request Url:.+/app/license_requests/([0-9]+)', licenseInfo).group(1)
                     licenseXml = str(LicenseRequest.objects.get(id=dbId, shortIdentifier=licenseIdentifier).xml)
                     licenseText = parseXmlString(licenseXml)['text']
                     licenseTexts.append(clean(licenseText))
                     licenseIds.append(licenseIdentifier)
                 except LicenseRequest.DoesNotExist:
+                    pass
+                except AttributeError:
                     pass
     licenseData = dict(zip(licenseIds, licenseTexts))
     return licenseData

--- a/src/src/settings.py
+++ b/src/src/settings.py
@@ -55,7 +55,7 @@ if not DEBUG:
 ALLOWED_HOSTS = ['*']
 
 if not DEBUG:
-    ALLOWED_HOSTS = ['.tools.spdx.org', '52.32.53.255']
+    ALLOWED_HOSTS = ['.tools.spdx.org', '52.32.53.255', '13.57.134.254']
 
 
 # Application definition

--- a/src/src/settings.py
+++ b/src/src/settings.py
@@ -54,6 +54,9 @@ if not DEBUG:
 
 ALLOWED_HOSTS = ['*']
 
+if not DEBUG:
+    ALLOWED_HOSTS = ['.tools.spdx.org', '52.32.53.255']
+
 
 # Application definition
 

--- a/src/src/settings.py
+++ b/src/src/settings.py
@@ -46,7 +46,7 @@ SECRET_KEY = getSecretKey()
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get(key='DEBUG', failobj=1)
+DEBUG = os.environ.get(key='DEBUG', failobj=1) == 1
 
 if not DEBUG:
     REPO_URL = PROD_REPO_URL


### PR DESCRIPTION
Remove the unnecessary CodeMirror editor from the submit new license HTML file.  This does not seem to be used and causes an error to be displayed in the web browser console.

This resolves issue #263 