### PR TITLE
Remove unnecessary JavaScript editor inclusion

### DIFF
--- a/src/app/templates/app/submit_new_license.html
+++ b/src/app/templates/app/submit_new_license.html
@@ -652,7 +652,6 @@ async function generate_text_diff(base, newtxt){
     });
   }
 </script>
-<script type="text/javascript" src="{% static 'js/editor/script.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/editor/difflib.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/editor/diffview.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/editor/treeview.js' %}"></script>


### PR DESCRIPTION
Remove the unnecessary CodeMirror editor from the submit new license HTML file. This does not seem to be used and causes an error to be displayed in the web browser console.

This resolves issue #264 

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>