### PR TITLE
Resolve encoding exception for UTF8 encoded license texts

### DIFF
--- a/src/app/utils.py
+++ b/src/app/utils.py
@@ -504,7 +504,8 @@ def check_new_licenses_and_rejected_licenses(inputLicenseText, urlType):
 def check_spdx_license(licenseText):
     """Check the license text against the spdx license list.
     """
-    licenseText = unicode(licenseText.decode('string_escape'), 'utf-8')
+    if not isinstance(licenseText, unicode):
+        licenseText = unicode(licenseText.decode('string_escape'), 'utf-8')
     r = redis.StrictRedis(host=getRedisHost(), port=6379, db=0)
     
     # if redis is empty build the spdx license list in the redis database

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -125,7 +125,6 @@ def submitNewLicense(request):
                         urlType = request.POST["urlType"]
 
                     matchingIds, matchingType = utils.check_spdx_license(licenseText)
-                    licenseText = licenseText.decode('unicode-escape')
                     matches = ['Perfect match', 'Standard License match', 'Close match']
                     if matchingType in matches:
                         data['matchType'] = matchingType
@@ -156,7 +155,6 @@ def submitNewLicense(request):
 
                     # Check if the license text doesn't matches with the rejected as well as not yet approved licenses
                     if not matches:
-                        licenseText = licenseText.decode('unicode-escape')
                         xml = generateLicenseXml(licenseOsi, licenseIdentifier, licenseName,
                             listVersionAdded, licenseSourceUrls, licenseHeader, licenseNotes, licenseText)
                         now = datetime.datetime.now()


### PR DESCRIPTION
This  resolves issue #267 by only converting to unicode if the licenseText is not already of type unicode.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>
