### PR TITLE
Remove str.decode for license text

### DIFF
--- a/src/app/utils.py
+++ b/src/app/utils.py
@@ -506,7 +506,6 @@ def check_new_licenses_and_rejected_licenses(inputLicenseText, urlType):
 def check_spdx_license(licenseText):
     """Check the license text against the spdx license list.
     """
-    licenseText = str(licenseText.decode('string_escape'), 'utf-8')
     r = redis.StrictRedis(host=getRedisHost(), port=6379, db=0)
     
     # if redis is empty build the spdx license list in the redis database


### PR DESCRIPTION
Resolves issue when submitting a new license request.  Removes the `str.decode(...` call.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>