### PR TITLE
Fix #241: Added automatic filename in convert

### DIFF
--- a/src/app/templates/app/convert.html
+++ b/src/app/templates/app/convert.html
@@ -120,7 +120,7 @@
   function checkFile(file){
     if(file){
       $(".file-name").html("<b>Selected File: </b>"+file.name);
-      $("#cfilename").val(file.name.split(".")[0]);
+      $("#cfilename").val(file.name.split('.').slice(0,-1).join('.'));
       selected_file = file;
     }
     else{

--- a/src/app/templates/app/convert.html
+++ b/src/app/templates/app/convert.html
@@ -120,6 +120,7 @@
   function checkFile(file){
     if(file){
       $(".file-name").html("<b>Selected File: </b>"+file.name);
+      $("#cfilename").val(file.name.split(".")[0]);
       selected_file = file;
     }
     else{

--- a/src/app/templates/app/convert.html
+++ b/src/app/templates/app/convert.html
@@ -120,7 +120,7 @@
   function checkFile(file){
     if(file){
       $(".file-name").html("<b>Selected File: </b>"+file.name);
-      $("#cfilename").val(file.name.split('.').slice(0,-1).join('.'));
+      $("#cfilename").val(file.name.split('.').slice(0,-1).join('.') || file.name);
       selected_file = file;
     }
     else{


### PR DESCRIPTION
Fixes #241
This PR adds automatic filename in url `app/convert/` according to the file entered after removing the extension of the file.
Example: `test.extension` will have default Converted File Name as `test`