### PR TITLE
Remove depreciated GoogleOpenId and YahooOpenId

### DIFF
--- a/src/src/settings.py
+++ b/src/src/settings.py
@@ -144,10 +144,6 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 AUTHENTICATION_BACKENDS = [
-    'social_core.backends.open_id.OpenIdAuth',
-    'social_core.backends.google.GoogleOAuth2',
-    'social_core.backends.google.GoogleOAuth',
-    'social_core.backends.twitter.TwitterOAuth',
     'social_core.backends.github.GithubOAuth2',
     'django.contrib.auth.backends.ModelBackend',
     'rest_framework_social_oauth2.backends.DjangoOAuth2',

--- a/src/src/settings.py
+++ b/src/src/settings.py
@@ -145,11 +145,9 @@ AUTH_PASSWORD_VALIDATORS = [
 
 AUTHENTICATION_BACKENDS = [
     'social_core.backends.open_id.OpenIdAuth',
-    'social_core.backends.google.GoogleOpenId',
     'social_core.backends.google.GoogleOAuth2',
     'social_core.backends.google.GoogleOAuth',
     'social_core.backends.twitter.TwitterOAuth',
-    'social_core.backends.yahoo.YahooOpenId',
     'social_core.backends.github.GithubOAuth2',
     'django.contrib.auth.backends.ModelBackend',
     'rest_framework_social_oauth2.backends.DjangoOAuth2',


### PR DESCRIPTION
Authentication Backends for GoogleOpenId and YahooOpenId are [depreciated](https://github.com/python-social-auth/social-core/issues/472) in [python-social-auth](https://github.com/python-social-auth/social-core/blob/master/CHANGELOG.md) 4.0 . Thus removing these fixes module load error in `app.tests.ProfileViewsTestCase` . 