### PR TITLE
Update all the dependencies to the latest version and make relevent changes to fix test cases for python3 branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ gevent==21.1.2
 gunicorn==20.1.0
 #for testing
 selenium==3.14.1
-django-oauth-toolkit==1.3.2
+django-oauth-toolkit==1.5.0
 django-rest-framework-social-oauth2==1.1.0
 -e git://github.com/spdx/spdx-license-matcher.git@v2.1#egg=spdx-license-matcher

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ djangorestframework==3.11.0
 bs4==0.0.1
 requests==2.24
 lxml==4.6.3
+webdriver-manager==3.4.2
 social-auth-core==4.1.0
 social-auth-app-django==4.0.0
 python-dotenv==0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
-Django==2.2.14
-jpype1==1.2.0
-numpy==1.19.0
-djangorestframework==3.11.0
+Django==3.2.4
+jpype1==1.3.0
+numpy==1.20.3
+djangorestframework==3.12.2
 bs4==0.0.1
-requests==2.24
+requests==2.25
 lxml==4.6.3
 webdriver-manager==3.4.2
 social-auth-core==4.1.0
 social-auth-app-django==4.0.0
-python-dotenv==0.14.0
-gevent==20.6.2
-gunicorn==20.0.4
+python-dotenv==0.17.1
+gevent==21.1.2
+gunicorn==20.1.0
 #for testing
 selenium==3.14.1
 django-oauth-toolkit==1.3.2

--- a/src/app/generateXml.py
+++ b/src/app/generateXml.py
@@ -140,7 +140,7 @@ def generateLicenseXml(licenseOsi, licenseIdentifier, licenseName, listVersionAd
         licenseOsi = "true"
     else:
         licenseOsi = "false"
-    license = ET.SubElement(root, "license", isOsiApproved=licenseOsi, licenseId=licenseIdentifier, name=licenseName, listVersionAdded=listVersionAdded)
+    license = ET.SubElement(root, "license", isOsiApproved=licenseOsi, licenseId=licenseIdentifier, listVersionAdded=listVersionAdded, name=licenseName)
     crossRefs = ET.SubElement(license, "crossRefs")
     for sourceUrl in licenseSourceUrls:
         ET.SubElement(crossRefs, "crossRef").text = sourceUrl

--- a/src/app/templates/400.html
+++ b/src/app/templates/400.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 
 <p><h1>

--- a/src/app/templates/403.html
+++ b/src/app/templates/403.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 
 <p><h1>

--- a/src/app/templates/404.html
+++ b/src/app/templates/404.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 
 <p><h1>

--- a/src/app/templates/500.html
+++ b/src/app/templates/500.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 
 <p><h1>

--- a/src/app/templates/app/about.html
+++ b/src/app/templates/app/about.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 <div class ="col-md-6 col-sm-6">
 <img src={% static "images/logo_spdx.png" %} alt="SPDX Logo"/>

--- a/src/app/templates/app/archive_namespace_requests.html
+++ b/src/app/templates/app/archive_namespace_requests.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 
 <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.16/css/jquery.dataTables.css">

--- a/src/app/templates/app/archive_requests.html
+++ b/src/app/templates/app/archive_requests.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 
 <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.16/css/jquery.dataTables.css">

--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 {% load static %}
-{% load staticfiles %}
 <html lang="en">
   <head>
     <meta charset="utf-8">

--- a/src/app/templates/app/check_license.html
+++ b/src/app/templates/app/check_license.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 <div id="messages" class="messages">
 </div>

--- a/src/app/templates/app/compare.html
+++ b/src/app/templates/app/compare.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 
 {% block head_block %}
   <link href="{% static 'css/dragdrop.css' %}" rel="stylesheet" type="text/css">

--- a/src/app/templates/app/convert.html
+++ b/src/app/templates/app/convert.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 
 {% block head_block %}
   <link href="{% static 'css/dragdrop.css' %}" rel="stylesheet" type="text/css">

--- a/src/app/templates/app/editor.html
+++ b/src/app/templates/app/editor.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 
 {% block head_block %}
     <link href="{% static 'css/editor.css' %}" rel="stylesheet" type="text/css">

--- a/src/app/templates/app/index.html
+++ b/src/app/templates/app/index.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 <img src={% static "images/logo_spdx.png" %} alt="SPDX Logo"/>
 <hr>

--- a/src/app/templates/app/license_information.html
+++ b/src/app/templates/app/license_information.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 
 <div id="messages" class="messages">

--- a/src/app/templates/app/license_namespace_information.html
+++ b/src/app/templates/app/license_namespace_information.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 
 <div id="messages" class="messages">

--- a/src/app/templates/app/license_namespace_requests.html
+++ b/src/app/templates/app/license_namespace_requests.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 
 <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.16/css/jquery.dataTables.css">

--- a/src/app/templates/app/license_requests.html
+++ b/src/app/templates/app/license_requests.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 
 <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.16/css/jquery.dataTables.css">

--- a/src/app/templates/app/login.html
+++ b/src/app/templates/app/login.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 {% if invalid %}
 <div id="messages" class="messages">

--- a/src/app/templates/app/ns_editor.html
+++ b/src/app/templates/app/ns_editor.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 
 {% block head_block %}
     <link href="{% static 'css/editor.css' %}" rel="stylesheet" type="text/css">

--- a/src/app/templates/app/profile.html
+++ b/src/app/templates/app/profile.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 {% if user.is_authenticated %}
 {% if success %}

--- a/src/app/templates/app/promoted_namespace_requests.html
+++ b/src/app/templates/app/promoted_namespace_requests.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 
 <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.16/css/jquery.dataTables.css">

--- a/src/app/templates/app/register.html
+++ b/src/app/templates/app/register.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
 <div id="messages" class="messages">
 </div>

--- a/src/app/templates/app/submit_new_license.html
+++ b/src/app/templates/app/submit_new_license.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 
 {% block head_block %}
     <link href="{% static 'css/editor.css' %}" rel="stylesheet" type="text/css">

--- a/src/app/templates/app/submit_new_license_namespace.html
+++ b/src/app/templates/app/submit_new_license_namespace.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 {% block body1 %}
     {% include "app/modal.html" %}
 {% endblock %}

--- a/src/app/templates/app/validate.html
+++ b/src/app/templates/app/validate.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 
 {% block head_block %}
   <link href="{% static 'css/dragdrop.css' %}" rel="stylesheet" type="text/css">

--- a/src/app/templates/app/xml_upload.html
+++ b/src/app/templates/app/xml_upload.html
@@ -1,6 +1,5 @@
 {% extends 'app/base.html' %}
 {% load static %}
-{% load staticfiles %}
 
 {% block head_block %}
   <link href="{% static 'css/dragdrop.css' %}" rel="stylesheet" type="text/css">

--- a/src/app/tests.py
+++ b/src/app/tests.py
@@ -395,7 +395,7 @@ class ConvertViewsTestCase(TestCase):
     def test_convert_xlsxtotag(self):
         """POST Request for convert spreadsheet to tag"""
         self.client.force_login(User.objects.get_or_create(username='converttestuser')[0])
-        self.xls_file = open("examples/SPDXSpreadsheetExample-2.0.xls")
+        self.xls_file = open("examples/SPDXSpreadsheetExample-2.0.xls", "rb")
         resp = self.client.post(reverse("convert"),{'cfilename': "xlsxtest" ,'cfileformat': ".spdx",'from_format' : "XLS", 'to_format' : "TAG", 'file' : self.xls_file},follow=True)
         self.assertTrue(resp.status_code==406 or resp.status_code == 200)
         self.assertIn("medialink",resp.context)
@@ -409,7 +409,7 @@ class ConvertViewsTestCase(TestCase):
     def test_convert_xlsxtordf(self):
         """POST Request for convert spreadsheet to rdf"""
         self.client.force_login(User.objects.get_or_create(username='converttestuser')[0])
-        self.xls_file = open("examples/SPDXSpreadsheetExample-2.0.xls")
+        self.xls_file = open("examples/SPDXSpreadsheetExample-2.0.xls", "rb")
         resp = self.client.post(reverse("convert"),{'cfilename': "xlsxtest" ,'cfileformat': ".rdf",'from_format' : "XLS", 'to_format' : "RDFXML", 'file' : self.xls_file},follow=True)
         self.assertTrue(resp.status_code==406 or resp.status_code == 200)
         self.assertIn("medialink",resp.context)
@@ -423,15 +423,15 @@ class ConvertViewsTestCase(TestCase):
     def test_other_convert_formats(self):
         """POST Request for converting invalid formats"""
         self.client.force_login(User.objects.get_or_create(username='converttestuser')[0])
-        self.xls_file = open(getExamplePath("SPDXSpreadsheetExample-2.0.xls"))
+        self.xls_file = open(getExamplePath("SPDXSpreadsheetExample-2.0.xls"), "rb")
         resp = self.client.post(reverse("convert"),{'cfilename': "xlsxtest" ,'cfileformat': ".html",'from_format' : "Spreadsheet", 'to_format' : "HTML", 'file' : self.xls_file},follow=True)
         self.assertEqual(resp.status_code,400)
         self.assertIn("error", resp.context)
-        self.rdf_file = open(getExamplePath("SPDXRdfExample-v2.0.rdf"))
+        self.rdf_file = open(getExamplePath("SPDXRdfExample-v2.0.rdf"), "rb")
         resp = self.client.post(reverse("convert"),{'cfilename': "rdftest" ,'cfileformat': ".pdf",'from_format' : "RDF", 'to_format' : "PDF", 'file' : self.rdf_file},follow=True)
         self.assertEqual(resp.status_code,400)
         self.assertIn("error", resp.context)
-        self.tv_file = open(getExamplePath("SPDXTagExample-v2.0.spdx"))
+        self.tv_file = open(getExamplePath("SPDXTagExample-v2.0.spdx"), "rb")
         resp = self.client.post(reverse("convert"),{'cfilename': "tagtest" ,'cfileformat': ".txt",'from_format' : "Tag", 'to_format' : "text", 'file' : self.tv_file},follow=True,secure=True)
         self.assertEqual(resp.status_code,400)
         self.assertIn("error", resp.context)

--- a/src/app/tests.py
+++ b/src/app/tests.py
@@ -16,6 +16,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.firefox.options import Options
+from webdriver_manager.firefox import GeckoDriverManager
 import time
 
 from app.models import UserID
@@ -646,7 +647,7 @@ class LicenseXMLEditorTestCase(StaticLiveServerTestCase):
     def setUp(self):
         options = Options()
         options.add_argument('-headless')
-        self.selenium = webdriver.Firefox(firefox_options=options)
+        self.selenium = webdriver.Firefox(executable_path=GeckoDriverManager().install(), firefox_options=options)
         self.initialXML = '<?xml version="1.0" encoding="UTF-8"?><SPDXLicenseCollection xmlns="http://www.spdx.org/license"><license></license></SPDXLicenseCollection>'
         self.invalidXML = '<?xml version="1.0" encoding="UTF-8"?><SPDXLicenseCollection xmlns="http://www.spdx.org/license"><license></license>'
         super(LicenseXMLEditorTestCase, self).setUp()
@@ -1078,7 +1079,7 @@ class ArchiveLicenseRequestsViewsTestCase(StaticLiveServerTestCase):
     def setUp(self):
         options = Options()
         options.add_argument('-headless')
-        self.selenium = webdriver.Firefox(firefox_options=options)
+        self.selenium = webdriver.Firefox(executable_path=GeckoDriverManager().install(), firefox_options=options)
         super(ArchiveLicenseRequestsViewsTestCase, self).setUp()
 
     def tearDown(self):
@@ -1270,7 +1271,7 @@ class PromoteLicenseNamespaceViewsTestCase(StaticLiveServerTestCase):
     def setUp(self):
         options = Options()
         options.add_argument('-headless')
-        self.selenium = webdriver.Firefox(firefox_options=options)
+        self.selenium = webdriver.Firefox(executable_path=GeckoDriverManager().install(), firefox_options=options)
         #login
         TEST_LOGIN_INFO = {
         "provider": "github",
@@ -1345,7 +1346,7 @@ class ArchiveLicenseNamespaceViewsTestCase(StaticLiveServerTestCase):
     def setUp(self):
         options = Options()
         options.add_argument('-headless')
-        self.selenium = webdriver.Firefox(firefox_options=options)
+        self.selenium = webdriver.Firefox(executable_path=GeckoDriverManager().install(), firefox_options=options)
         super(ArchiveLicenseNamespaceViewsTestCase, self).setUp()
 
     def tearDown(self):

--- a/src/app/utils.py
+++ b/src/app/utils.py
@@ -47,6 +47,9 @@ NORMAL:  settings.NAMESPACE_REPO_URL,
 TESTS: settings.NAMESPACE_DEV_REPO_URL,
 }
 
+logging.basicConfig(filename="error.log", format="%(levelname)s : %(asctime)s : %(message)s")
+logger = logging.getLogger()
+
 # For license namespace utils
 def licenseNamespaceUtils():
     return {
@@ -66,8 +69,6 @@ def checkPermission(user):
         return False
 
 def makePullRequest(username, token, branchName, updateUpstream, fileName, commitMessage, prTitle, prBody, xmlText, is_ns):
-    logging.basicConfig(filename="error.log", format="%(levelname)s : %(asctime)s : %(message)s")
-    logger = logging.getLogger()
 
     if not xmlText:
         logger.error("Error occurred while getting xml text. The xml text is empty")

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -13,7 +13,7 @@
 
 
 
-from django.shortcuts import render,render_to_response
+from django.shortcuts import render
 from django.http import HttpResponse,HttpResponseRedirect
 from django.contrib.auth import authenticate,login ,logout,update_session_auth_hash
 from django.conf import settings
@@ -566,7 +566,7 @@ def validate_xml(request):
                     if not os.path.isdir(str(settings.MEDIA_ROOT +"/"+ folder)):
                         os.makedirs(str(settings.MEDIA_ROOT +"/"+ folder))
                     uploaded_file_url = settings.MEDIA_ROOT + '/' + folder + '/' + 'xmlFile.xml'
-                    with open(uploaded_file_url, 'wt', encoding='utf-8') as f:
+                    with open(uploaded_file_url, 'wb') as f:
                         f.write(xmlText)
                     """ Get schema text from GitHub,
                     if it fails use the file in examples folder """
@@ -874,8 +874,8 @@ def convert(request):
                     else :
                         cfileformat = getFileFormat(option2)
                     convertfile =  request.POST["cfilename"] + cfileformat
-                    fromFileFormat = serFileTypeEnum.valueOf(option1);
-                    toFileFormat = serFileTypeEnum.valueOf(option2);
+                    fromFileFormat = serFileTypeEnum.valueOf(option1)
+                    toFileFormat = serFileTypeEnum.valueOf(option2)
                     """ Call the java function with parameters as list """
                     spdxConverter.convert(str(settings.APP_DIR+uploaded_file_url),str(settings.MEDIA_ROOT+"/"+folder+"/"+"/"+convertfile), fromFileFormat, toFileFormat)
                     warnings = verifyclass.verify(str(settings.MEDIA_ROOT+"/"+folder+"/"+"/"+convertfile), toFileFormat)
@@ -1840,22 +1840,17 @@ def post_to_github(request):
         return HttpResponse(dumps({"message": "User should be logged in to use this feature"}), status=400)
 
 def handler400(request, exception=None):
-    return render_to_response('app/400.html',
-        context_instance = RequestContext(request)
-    )
+    context = {}
+    return render(request, 'app/400.html', context)
 
 def handler403(request, exception=None):
-    return render_to_response('app/403.html',
-        context_instance = RequestContext(request)
-    )
+    context = {}
+    return render(request, 'app/403.html', context)
 
 def handler404(request, exception=None):
-    return render_to_response('app/404.html',
-        context_instance = RequestContext(request),
-        status=404
-    )
+    context = {}
+    return render(request, 'app/404.html', context)
 
 def handler500(request, exception=None):
-    return render_to_response('app/500.html',
-        context_instance = RequestContext(request)
-    )
+    context = {}
+    return render(request, 'app/500.html', context)

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -690,11 +690,11 @@ def compare(request):
                                 else :
                                     filelist.append(myfile.name)
                                     errorlist.append("No errors found")
-                            except jpype.JavaException as ex :
+                            except jpype.JException as ex :
                                 """ Error raised by verifyclass.verifyRDFFile without exiting the application"""
                                 erroroccurred = True
                                 filelist.append(myfile.name)
-                                errorlist.append(jpype.JavaException.message(ex))
+                                errorlist.append(jpype.JException.message(ex))
                             except :
                                 """ Other Exceptions"""
                                 erroroccurred = True

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,0 @@
-Django==2.1.2
-djangorestframework==3.8.2
-JPype1==0.6.3
-pytz==2018.5

--- a/src/src/settings.py
+++ b/src/src/settings.py
@@ -215,6 +215,9 @@ REST_FRAMEWORK = {
     ),
 }
 
+# To avoid unwanted migrations in the future, either explicitly set DEFAULT_AUTO_FIELD to AutoField
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 # Absolute Path for tool.jar
 # The online tool uses spdx-tools-2.1.6-SNAPSHOT-jar-with-dependencies.jar from the compiled target folder of java tools
 # renamed (for now) as tool.jar in the main src directory of spdx-online tool


### PR DESCRIPTION
**Summary of the changes made:**
* Update all the dependencies to the latest version.
* Removed staticfiles tag as the staticfiles tag library was deprecated in django 2.1 and removed in django 3. Read [here](https://stackoverflow.com/questions/55929472/django-templatesyntaxerror-staticfiles-is-not-a-registered-tag-library) for more info.
* Use render in place of render_to_response shortcut as the render_to_response shortcut was deprecated in Django 2.0, and removed in Django 3.0.
* Add DEFAULT_AUTOFIELD to settings.py file to specify the type of primary key to use and suppress warning while running the server.
* Fix the app test cases.
* Add a new package webdriver-manager to dependencies which ease the process of manually setting up the geckodriver setup which is necessary to run test cases. The package automatically downloads the firefox version based on the user's firefox version, extracts it and also add the geckodriver to the path variable.
* Replace remaining JavaException to JException.