### PR TITLE
Bump lxml from 4.6.3 to 4.6.5 for python3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy==1.20.3
 djangorestframework==3.12.2
 bs4==0.0.1
 requests==2.25
-lxml==4.6.3
+lxml==4.6.5
 webdriver-manager==3.4.2
 social-auth-core==4.1.0
 social-auth-app-django==4.0.0


### PR DESCRIPTION
Duplicate of https://github.com/spdx/spdx-online-tools/pull/334 for python3 branch