### PR TITLE
Update psycopg2 version

### DIFF
--- a/dockerfile.prod
+++ b/dockerfile.prod
@@ -12,7 +12,7 @@ RUN apt-get update \
     && apt-get -y install libpq-dev gcc python-dev musl-dev
 	
 # install psycopg2
-RUN pip install psycopg2-binary==2.7.5
+RUN pip install psycopg2-binary==2.9.3
 
 # Install the python dependencies
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Resolves an incompatibility with the Python3 changes

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>