### PR TITLE
Add SPDX-License-Identifier and SPDX-FileCopyrightText

### DIFF
--- a/src/api/admin.py
+++ b/src/api/admin.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-
+# SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
+# SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -10,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 
 from django.contrib import admin
 

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-
+# SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
+# SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -10,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 
 from django.contrib.auth.models import User
 from django.db import models

--- a/src/api/serializers.py
+++ b/src/api/serializers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-
+# SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
+# SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -10,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 
 from django.contrib.auth.models import User, Group          
 

--- a/src/api/tests.py
+++ b/src/api/tests.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-
+# SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
+# SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -10,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-
-
-
 
 from django.test import TestCase
 from unittest import skipIf

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-
+# SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
+# SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -10,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 
 from django.urls import path
 

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-
+# SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
+# SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -10,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 
 from rest_framework.parsers import FileUploadParser,FormParser, MultiPartParser
 from rest_framework.response import Response

--- a/src/app/admin.py
+++ b/src/app/admin.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-
+# SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
+# SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -10,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-
 
 from django.contrib import admin
 

--- a/src/app/formatxml.py
+++ b/src/app/formatxml.py
@@ -2,6 +2,7 @@
 #
 # quick-n-dirty formatter for SPDX licenses in XML format
 #
+# SPDX-FileCopyrightText: 2017 Alexios Zavras
 # Copyright (c) 2017 Alexios Zavras
 # SPDX-License-Identifier: MIT
 #

--- a/src/app/forms.py
+++ b/src/app/forms.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-
+# SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
+# SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -10,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 
 from django import forms
 from django.contrib.auth.models import User

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-
+# SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
+# SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -10,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 
 from django.db import models
 from datetime import datetime

--- a/src/app/urls.py
+++ b/src/app/urls.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-
+# SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
+# SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -10,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 
 from django.urls import path, re_path
 from django.conf.urls import url,handler400, handler403, handler404, handler500

--- a/src/app/utils.py
+++ b/src/app/utils.py
@@ -1,6 +1,7 @@
 # coding=utf-8
-
+# SPDX-FileCopyrightText: 2018 Tushar Mittal
 # Copyright (c) 2018 Tushar Mittal
+# SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-
+# SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
+# SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -10,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 
 from django.shortcuts import render
 from django.http import HttpResponse,HttpResponseRedirect

--- a/src/src/urls.py
+++ b/src/src/urls.py
@@ -1,5 +1,6 @@
-
+# SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
+# SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
Let us use our own recommendations:
* add `SPDX-License-Identifier`
* add `SPDX-FileCopyrightText`
in source files.

Signed-off-by: Marc-Etienne Vargenau <marc-etienne.vargenau@nokia.com>