### PR TITLE
Bump Python version to 3.8 in the CI

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This only impacts the CI Github Action workflow.

The previous version (3.7) is no longer supported.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>