### PR TITLE
Make /api/check_license more machine readable

### DIFF
--- a/src/app/core.py
+++ b/src/app/core.py
@@ -303,7 +303,7 @@ def license_check_helper(request):
     licensetext = request.POST.get('licensetext')
     licensetext = licensetext if licensetext else request.data.get('licensetext')
     try:
-        matchingId, matchingType = utils.check_spdx_license(licensetext)
+        matchingId, matchingType, _ = utils.check_spdx_license(licensetext)
         if not matchingId:
             if (request.is_ajax()):
                 ajaxdict = dict()
@@ -480,7 +480,7 @@ def license_diff_helper(request):
     licensetext = request.POST.get('licensetext')
     licensetext = licensetext if licensetext else request.data.get('licensetext')
     try:
-        matchingIds, matchingType = utils.check_spdx_license(licensetext)
+        matchingIds, matchingType, _ = utils.check_spdx_license(licensetext)
         matches = ['Perfect match', 'Standard License match', 'Close match']
         if matchingType in matches:
             data['matchType'] = matchingType

--- a/src/app/utils.py
+++ b/src/app/utils.py
@@ -518,26 +518,22 @@ def check_spdx_license(licenseText):
     spdxLicenseTexts = r.mget(spdxLicenseIds)
     licenseData = dict(list(zip(spdxLicenseIds, spdxLicenseTexts)))
     matches = get_close_matches(licenseText, licenseData)
-
     if not matches:
         matchedLicenseIds = None
         matchType = 'No match'
-    
-    elif 1.0 in list(matches.values()) or all(0.99 < score for score in list(matches.values())):
-        matchedLicenseIds = list(matches.keys())
-        matchType = 'Perfect match'
-    
     else:
-        for licenseID in matches:
-            listedLicense = getListedLicense(licenseID)
-            isTextStandard = checkTextStandardLicense(listedLicense, licenseText)
-            if not isTextStandard:
-                matchedLicenseIds = licenseID
-                matchType = 'Standard License match'
-            else:
-                matchedLicenseIds = max(matches, key=matches.get)
-                matchType = 'Close match'
-    return matchedLicenseIds, matchType
+        matchedLicenseIds = max(matches, key=matches.get)
+        if matches[matchedLicenseIds] > 0.99:
+            matchType = 'Perfect match'
+        else:
+            matchType = 'Close match'
+            for licenseID in matches:
+                listedLicense = getListedLicense(licenseID)
+                isTextDifferent = checkTextStandardLicense(listedLicense, licenseText)
+                if not isTextDifferent:
+                    matchedLicenseIds = licenseID
+                    matchType = 'Standard License match'
+    return matchedLicenseIds, matchType, matches
 
 
 def getFileFormat(to_format):

--- a/src/app/utils.py
+++ b/src/app/utils.py
@@ -523,7 +523,7 @@ def check_spdx_license(licenseText):
         matchType = 'No match'
     else:
         matchedLicenseIds = max(matches, key=matches.get)
-        if matches[matchedLicenseIds] > 0.99:
+        if matches[matchedLicenseIds] == 1.0:
             matchType = 'Perfect match'
         else:
             matchType = 'Close match'

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -127,7 +127,7 @@ def submitNewLicense(request):
                         # This is present only when executing submit license via tests
                         urlType = request.POST["urlType"]
 
-                    matchingIds, matchingType = utils.check_spdx_license(licenseText)
+                    matchingIds, matchingType, _ = utils.check_spdx_license(licenseText)
                     matches = ['Perfect match', 'Standard License match', 'Close match']
                     if matchingType in matches:
                         data['matchType'] = matchingType


### PR DESCRIPTION
Currently all the information is inside a single string. 

The new output looks like the following:
```json
{"matched_license": null, "match_type": "No match", "all_matches": {}}
```
```json
{"matched_license": "Apache-2.0", "match_type": "Standard License match", "all_matches": {"Apache-2.0": 0.9813657538916032, "SHL-0.51": 0.9398223577022127, "SHL-0.5": 0.9392793360647127, "ECL-2.0": 0.958951030238159}}
```
```json
{"matched_license": "BSL-1.0", "match_type": "Perfect match", "all_matches": {"BSL-1.0": 1.0}}
```
Is there a reason while all the uploaded files are saved on disk and in the database? This seems very unnecessary and only consumes a lot of disk space over time.  
 