### PR TITLE
Remove the namespace menu items

### DIFF
--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -147,7 +147,8 @@ div p {
                 <li><a href="/app/archive_requests/" id="archiverequestspage">Archive Requests</a></li>
               </ul>
             </li>
-            <li>
+            <!-- Remove the namespace menu until we decide on the specific functionality
+			<li>
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="licensenamespace">License namespaces
                 <span class="caret"></span>
               </a>
@@ -156,7 +157,8 @@ div p {
                 <li><a href="/app/license_namespace_requests/" id="licensenamespacerequests">License namespaces</a></li>
                 <li><a href="/app/archive_namespace_requests/" id="archivenamespacerequestspage">Archived namespaces</a></li>
               </ul>
-            </li>
+            </li> 
+			-->
 		  </ul>
 		  <ul class="nav navbar-nav navbar-right" style="margin-right: 25px;font-size: 12px;">
 			{% if user.is_authenticated %}


### PR DESCRIPTION
Removing the namespace feature for now since the namespace functionality has not be decided.

Once we decide on the namespace functionality, we can re-enable the menu.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>