### PR TITLE
Fix Python version in docker to 3.10.6

### DIFF
--- a/dockerfile.dev
+++ b/dockerfile.dev
@@ -1,5 +1,5 @@
 # Use the official python 3 base image
-FROM python:3 as python-container
+FROM python:3.10.6 as python-container
 
 # Copy the requirements.txt file into the container
 COPY requirements.txt .

--- a/dockerfile.prod
+++ b/dockerfile.prod
@@ -1,5 +1,5 @@
-# Using python3 as the base image
-FROM python:3 as base
+# Using python3.10.6 as the base image
+FROM python:3.10.6 as base
 
 # Create the folder spdx and cd to it
 WORKDIR /spdx


### PR DESCRIPTION
Fixes issue #404

Version 3.10.6 is the version of Python currently running in prod.

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>