### PR TITLE
Update NTIA via command line

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,6 @@ selenium==3.14.1
 django-oauth-toolkit==1.5.0
 django-rest-framework-social-oauth2==1.1.0
 spdx-tools==0.7.0
+ntia-conformance-checker==0.2.1
 -e git+https://github.com/spdx/spdx-license-matcher.git@v2.4#egg=spdx-license-matcher
--e git+https://github.com/spdx/ntia-conformance-checker.git@v0.1.0#egg=ntia-conformance-checker
+

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -27,8 +27,6 @@ from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 from src.version import spdx_online_tools_version
 from src.version import java_tools_version
-from src.version import ntia_conformance_checker_version
-from ntia_conformance_checker.cli_tools import check_anything
 
 import codecs
 import jpype
@@ -441,9 +439,7 @@ def ntia_check(request):
     if request.user.is_authenticated or settings.ANONYMOUS_LOGIN_ENABLED:
         context_dict={}
         if request.method == 'POST':
-            core.initialise_jpype()
             result = core.ntia_check_helper(request)
-            jpype.detachThreadFromJVM()
             context_dict = result.get('context', None)
             status = result.get('status', None)
             response = result.get('response', None)


### PR DESCRIPTION
Note: This initial commit is currently failing with the following error:

```
Traceback (most recent call last):
spdx_dev  |   File "/spdxonlinetools/src/app/core.py", line 218, in ntia_check_helper
spdx_dev  |     response = dumps(ajaxdict)
spdx_dev  |   File "/usr/local/lib/python3.10/json/__init__.py", line 231, in dumps
spdx_dev  |     return _default_encoder.encode(obj)
spdx_dev  |   File "/usr/local/lib/python3.10/json/encoder.py", line 199, in encode
spdx_dev  |     chunks = self.iterencode(o, _one_shot=True)
spdx_dev  |   File "/usr/local/lib/python3.10/json/encoder.py", line 257, in iterencode
spdx_dev  |     return _iterencode(o, 0)
spdx_dev  |   File "/usr/local/lib/python3.10/json/encoder.py", line 179, in default
spdx_dev  |     raise TypeError(f'Object of type {o.__class__.__name__} '
spdx_dev  | TypeError: Object of type CompletedProcess is not JSON serializable
spdx_dev  |
spdx_dev  | During handling of the above exception, another exception occurred:
spdx_dev  |
spdx_dev  | Traceback (most recent call last):
spdx_dev  |   File "/usr/local/lib/python3.10/site-packages/django/core/handlers/exception.py", line 47, in inner
spdx_dev  |     response = get_response(request)
spdx_dev  |   File "/usr/local/lib/python3.10/site-packages/django/core/handlers/base.py", line 181, in _get_response
spdx_dev  |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
spdx_dev  |   File "/spdxonlinetools/src/app/views.py", line 442, in ntia_check
spdx_dev  |     result = core.ntia_check_helper(request)
spdx_dev  |   File "/spdxonlinetools/src/app/core.py", line 273, in ntia_check_helper
spdx_dev  |     result['response'] = response
spdx_dev  | TypeError: 'CompletedProcess' object does not support item assignment
spdx_dev  | [14/Feb/2023 07:42:26] "POST /app/ntia_checker/ HTTP/1.1" 500 107033
spdx_dev  | /spdxonlinetools/src/app/core.py changed, reloading.
spdx_dev  | Watching for file changes with StatReloader
spdx_dev  | Performing system checks...
```