### PR TITLE
Update docker files to use eclipse-temurin

### DIFF
--- a/README-PRODUCTION.md
+++ b/README-PRODUCTION.md
@@ -14,6 +14,8 @@ Following are the steps for updating the images:
   * replace `<aws-region>` with the AWS region
   * replace `<version>` with the specific version of the spdx-online-tools-build to be deployed
 * Build the image by running `docker-compose -f docker-compose.prod.yml build`
+* Test the image for vulnerability by running `docker scan [image]` where [image] is the image name from the docker-compose.prod.yml file
+  * Update any dependencies as needed based on the vulnerability report
 * Push the image to AWS ECR
   * Login to ECR using the AWS CLI by running `aws ecr get-login-password --region <aws-region> | docker login --username AWS --password-stdin <aws-account-id>.dkr.ecr.<aws-region>.amazonaws.com` replacing the region and account ID
   * Push the images by running `docker-compose -f docker-compose.prod.yml push`

--- a/dockerfile.dev
+++ b/dockerfile.dev
@@ -7,11 +7,10 @@ COPY requirements.txt .
 # Install the python dependencies
 RUN pip install -r requirements.txt
 
-# Use JDK 8
-FROM openjdk:slim
-
-# Copy complete python container into java container
-COPY --from=python-container / /
+# Use JDK 11
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Fetch the latest tagged licenses from Github for use in the Java license compares
 RUN apt-get update \

--- a/dockerfile.prod
+++ b/dockerfile.prod
@@ -34,11 +34,10 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
-# Use JDK 8
-FROM openjdk:slim
-
-# Copy complete python container into java container
-COPY --from=production / /
+# Use JDK 11
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11 $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Fetch the latest tagged licenses from Github for use in the Java license compares
 RUN apt-get update \


### PR DESCRIPTION
The previous OpenJDK container is deprecated and contains a number of known vulnerabilities