### PR TITLE
#288 Create a link back to the SPDX main website

### DIFF
--- a/src/app/templates/app/about.html
+++ b/src/app/templates/app/about.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% block body1 %}
 <div class ="col-md-6 col-sm-6">
-<img src={% static "images/logo_spdx.png" %} alt="SPDX Logo"/>
+<a href="https://spdx.dev/" id="spdxhome" target="_blank"><img src={% static "images/logo_spdx.png" %} alt="SPDX Logo"/></a>
 </div>
 <div class ="col-md-6 col-sm-6">
 <img src={% static "images/GSoCLogo.jpg" %} alt="GSoC Logo" height="100%" width="100%" />

--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -119,17 +119,17 @@ div p {
   <body>
 
     <nav class="navbar navbar-inverse navbar-fixed-top">
-        <div class="navbar-header">
-          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-          <a class="navbar-brand navbar-left" id="indexpage" href="/app/">SPDX Online Tool</a>
-        </div>
-        <div id="navbar" class="collapse navbar-collapse" >
-          <ul class="nav navbar-nav" style="font-size: 12px;">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
+        <a class="navbar-brand navbar-left" id="indexpage" href="/app/">SPDX Online Tool</a>
+      </div>
+      <div id="navbar" class="collapse navbar-collapse" >
+        <ul class="nav navbar-nav" style="font-size: 12px;">
             <li><a href="/app/about/" id="aboutpage">About</a></li>
             <li><a href="/app/validate/" id="validatepage">Validate</a></li>
             <li><a href="/app/compare/" id="comparepage">Compare</a></li>
@@ -162,19 +162,24 @@ div p {
 			-->
 		  </ul>
 		  <ul class="nav navbar-nav navbar-right" style="margin-right: 25px;font-size: 12px;">
-			{% if user.is_authenticated %}
-            <!--<li><a href="/app/profile/" id="profilepage">Profile</a></li>-->
-            <li><a class="dropdown-toggle" data-toggle="dropdown" href="#">{{user}} <span class="caret"></span></a>
-            <ul class="dropdown-menu">
-              <li><a href="/app/logout/"><span class="glyphicon glyphicon-log-out"></span> Logout</a></li>
-            </ul>
-            </li>
-			 {% else %}
-			<li><a href="/app/login/" id="loginpage"><span class="glyphicon glyphicon-log-in"></span> Login</a></li>
-			{% endif %}
+        <div class="navbar-left" style="margin-top: 14px; ">
+          <a href="https://spdx.dev/" id="spdxhome" target="_blank">
+            <img class="starting-logo dark-version skip-lazy" width="80" height="20" alt="Software Package Data Exchange (SPDX)" src=https://spdx.dev/wp-content/uploads/sites/41/2021/09/spdx-white.svg>
+          </a>
+        </div>
+        {% if user.is_authenticated %}
+        <!--<li><a href="/app/profile/" id="profilepage">Profile</a></li>-->
+        <li><a class="dropdown-toggle" data-toggle="dropdown" href="#">{{user}} <span class="caret"></span></a>
+          <ul class="dropdown-menu">
+            <li><a href="/app/logout/"><span class="glyphicon glyphicon-log-out"></span> Logout</a></li>
           </ul>
-        </div><!--/.nav-collapse -->
-    </nav>
+        </li>
+        {% else %}
+        <li><a href="/app/login/" id="loginpage"><span class="glyphicon glyphicon-log-in"></span> Login</a></li>
+        {% endif %}
+      </ul>
+    </div><!--/.nav-collapse -->
+  </nav>
 
     <div class="container">
 

--- a/src/app/templates/app/index.html
+++ b/src/app/templates/app/index.html
@@ -1,7 +1,7 @@
 {% extends 'app/base.html' %}
 {% load static %}
 {% block body1 %}
-<img src={% static "images/logo_spdx.png" %} alt="SPDX Logo"/>
+<a href="https://spdx.dev/" id="spdxhome" target="_blank"><img src={% static "images/logo_spdx.png" %} alt="SPDX Logo"/></a>
 <hr>
 <p class="lead" style="color:#0097c4;"><strong>An all-in-one portal to upload and parse SPDX documents for validation, comparison and conversion and search SPDX license list.</strong></p>
 


### PR DESCRIPTION
- Added a link back to the main SPDX main page in the upper right corner instead of the upper left corner since already there is a link to the home page of _spdx-tools_ in the left corner, so confusion can occur.