### PR TITLE
#200 - Fixing test_archive_license_requests_feature and test_unarchive_license_requests_feature

### DIFF
--- a/src/app/tests.py
+++ b/src/app/tests.py
@@ -3,6 +3,7 @@
 
 from django.test import TestCase
 from unittest import skipIf
+from unittest.mock import patch
 from src.secret import getAccessToken, getGithubUserId, getGithubUserName
 from django.contrib.auth.models import User
 from django.conf import settings
@@ -21,6 +22,7 @@ import time
 
 from app.models import UserID
 from app.models import LicenseRequest, LicenseNamespace
+import app.utils as utils
 from app.generateXml import generateLicenseXml
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate
@@ -1106,40 +1108,94 @@ class ArchiveLicenseRequestsViewsTestCase(StaticLiveServerTestCase):
     @skipIf(not getAccessToken() and not getGithubUserId() and not getGithubUserName(), "You need to set gihub parameters in the secret.py file for this test to be executed properly.")
     def test_archive_license_requests_feature(self):
         """Check if the license is shifted to archive requests when archive button is pressed"""
+        TEST_LOGIN_INFO = {
+        "provider": "github",
+        "uid": str(getGithubUserId()),
+        "access_token": getAccessToken(),
+        "login": getGithubUserName(),
+        "id": getGithubUserId(),
+        "password": 'pass'
+        }
+        # login first
+        self.user = User.objects.create(username=TEST_LOGIN_INFO["login"],
+                                        is_active=True,
+                                        is_superuser=True)
+        self.user.set_password(TEST_LOGIN_INFO["password"])
+        self.user.save()
+        social_auth = UserSocialAuth.objects.create(provider=TEST_LOGIN_INFO["provider"],
+        uid=TEST_LOGIN_INFO["uid"],
+        extra_data=TEST_LOGIN_INFO,
+        user=self.user)
+        self.user = authenticate(username=TEST_LOGIN_INFO["login"],
+                                 password=TEST_LOGIN_INFO["password"])
+        login = self.client.login(username=TEST_LOGIN_INFO["login"],
+                                  password=TEST_LOGIN_INFO["password"])
+        self.assertTrue(login)
+        cookie = self.client.cookies['sessionid']
         driver = self.selenium
-        driver.get(self.live_server_url+'/app/license_requests/')
-        table_contents = driver.find_element_by_css_selector('tbody').text
-        self.assertEqual(table_contents, "No data available in table")
-        license_obj = LicenseRequest.objects.create(fullname="BSD Zero Clause License-00", shortIdentifier="0BSD")
-        driver.refresh()
-        license_name = driver.find_element_by_css_selector('td').text
-        self.assertEqual(license_name, "BSD Zero Clause License-00")
-        self.assertEqual(LicenseRequest.objects.get(id=license_obj.id).archive, False)
-        if driver.find_element_by_id('archive_button' + str(license_obj.id)):
-            driver.find_element_by_id('archive_button' + str(license_obj.id)).click()
-            driver.find_element_by_id('confirm_archive').click()
-            self.assertEqual(LicenseRequest.objects.get(id=license_obj.id).archive, True)
-        else:
-            pass
+        with patch('app.utils.checkPermission') as mock_checkPermission:
+            mock_checkPermission.return_value = True
+            driver.get(self.live_server_url+'/app/license_requests/')
+            driver.add_cookie({'name': 'sessionid', 'value': cookie.value, 'secure': False, 'path': '/'})
+            table_contents = driver.find_element_by_css_selector('tbody').text
+            self.assertEqual(table_contents, "No data available in table")
+            license_obj = LicenseRequest.objects.create(fullname="BSD Zero Clause License-00", shortIdentifier="0BSD")
+            driver.refresh()
+            license_name = driver.find_element_by_css_selector('td').text
+            self.assertEqual(license_name, "BSD Zero Clause License-00")
+            self.assertEqual(LicenseRequest.objects.get(id=license_obj.id).archive, False)
+            if driver.find_element_by_id('archive_button' + str(license_obj.id)):
+                driver.find_element_by_id('archive_button' + str(license_obj.id)).click()
+                driver.find_element_by_id('confirm_archive').click()
+                self.assertEqual(LicenseRequest.objects.get(id=license_obj.id).archive, True)
+            else:
+                pass
 
     @skipIf(not getAccessToken() and not getGithubUserId() and not getGithubUserName(), "You need to set gihub parameters in the secret.py file for this test to be executed properly.")
     def test_unarchive_license_requests_feature(self):
         """Check if license is shifted back to license requests when unarchive button is pressed"""
+        TEST_LOGIN_INFO = {
+        "provider": "github",
+        "uid": str(getGithubUserId()),
+        "access_token": getAccessToken(),
+        "login": getGithubUserName(),
+        "id": getGithubUserId(),
+        "password": 'pass'
+        }
+        # login first
+        self.user = User.objects.create(username=TEST_LOGIN_INFO["login"],
+                                        is_active=True,
+                                        is_superuser=True)
+        self.user.set_password(TEST_LOGIN_INFO["password"])
+        self.user.save()
+        social_auth = UserSocialAuth.objects.create(provider=TEST_LOGIN_INFO["provider"],
+        uid=TEST_LOGIN_INFO["uid"],
+        extra_data=TEST_LOGIN_INFO,
+        user=self.user)
+        self.user = authenticate(username=TEST_LOGIN_INFO["login"],
+                                 password=TEST_LOGIN_INFO["password"])
+        login = self.client.login(username=TEST_LOGIN_INFO["login"],
+                                  password=TEST_LOGIN_INFO["password"])
+        self.assertTrue(login)
+        cookie = self.client.cookies['sessionid']
         driver = self.selenium
-        driver.get(self.live_server_url+'/app/archive_requests/')
-        table_contents = driver.find_element_by_css_selector('tbody').text
-        self.assertEqual(table_contents, "No data available in table")
-        archive_license_obj = LicenseRequest.objects.create(fullname="BSD Zero Clause License-00", shortIdentifier="0BSD", archive="True")
-        driver.refresh()
-        license_name = driver.find_element_by_css_selector('td').text
-        self.assertEqual(license_name, "BSD Zero Clause License-00")
-        self.assertEqual(LicenseRequest.objects.get(id=archive_license_obj.id).archive, True)
-        if driver.find_element_by_id('unarchive_button' + str(archive_license_obj.id)):
-            driver.find_element_by_id('unarchive_button' + str(archive_license_obj.id)).click()
-            driver.find_element_by_id('confirm_unarchive').click()
-            self.assertEqual(LicenseRequest.objects.get(id=archive_license_obj.id).archive, False)
-        else:
-            pass
+        with patch('app.utils.checkPermission') as mock_checkPermission:
+            mock_checkPermission.return_value = True
+            driver.get(self.live_server_url+'/app/archive_requests/')
+            driver.add_cookie({'name': 'sessionid', 'value': cookie.value, 'secure': False, 'path': '/'})
+            table_contents = driver.find_element_by_css_selector('tbody').text
+            self.assertEqual(table_contents, "No data available in table")
+            archive_license_obj = LicenseRequest.objects.create(fullname="BSD Zero Clause License-00", shortIdentifier="0BSD", archive="True")
+            driver.refresh()
+            license_name = driver.find_element_by_css_selector('td').text
+            self.assertEqual(license_name, "BSD Zero Clause License-00")
+            self.assertEqual(LicenseRequest.objects.get(id=archive_license_obj.id).archive, True)
+            if driver.find_element_by_id('unarchive_button' + str(archive_license_obj.id)):
+                driver.find_element_by_id('unarchive_button' + str(archive_license_obj.id)).click()
+                driver.find_element_by_id('confirm_unarchive').click()
+                self.assertEqual(LicenseRequest.objects.get(id=archive_license_obj.id).archive, False)
+            else:
+                pass
 
 class SubmitNewLicenseViewsTestCase(TestCase):
 

--- a/src/app/tests.py
+++ b/src/app/tests.py
@@ -22,7 +22,7 @@ import time
 
 from app.models import UserID
 from app.models import LicenseRequest, LicenseNamespace
-import app.utils as utils
+import app.utils
 from app.generateXml import generateLicenseXml
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate


### PR DESCRIPTION
- Logged in with the user setup in secrets.py
- Add client `sessionid` to selenium driver
- Mocked the app.utils.checkPermission to return true

When the `app.utils.checkPermission` returns true, `context_dict['authorized']`  becomes true and that cause archive/ unarchive buttons visible in the UI.