### PR TITLE
Added button to check license diff on Submit new License Page #346

### DIFF
--- a/src/app/static/js/utils.js
+++ b/src/app/static/js/utils.js
@@ -1,0 +1,83 @@
+function doRequest(dict1) {
+  $.ajax({
+    ...dict1,
+    success: function (data) {
+      console.log("SUCCESS : ", data);
+      var matchType = data.matchType;
+      var matchIds = data.matchIds;
+      if (matchType == "Close match") {
+        $("#modal-header").addClass("yellow-modal");
+        var inputLicenseText = data.inputLicenseText.replace(/\r\n/g, "\n");
+        var originalLicenseText = data.originalLicenseText;
+        var matchingGuidelinesUrl =
+          "https://spdx.org/spdx-license-list/matching-guidelines";
+        var message = `Close match found! The license closely matches with the license ID(s): <strong>${matchIds}</strong> based on the SPDX Matching guidelines. Press show differences to continue.`;
+        $("#modal-header").removeClass("red-modal green-modal");
+        $("#modal-header").addClass("yellow-modal");
+        $(".modal-footer").html(
+          `<a href=${matchingGuidelinesUrl} target="_blank"><button class="btn btn-success btn-space" id="matchingguidelines"><span class="glyphicon glyphicon-link"></span> SPDX Matching Guidelines</button></a><button class="btn btn-success btn-space" id="showDiff"><span class="glyphicon glyphicon-link"></span> Show differences</button>`
+        );
+        $("#modal-body").html(message);
+        $("#myModal").modal({
+          backdrop: "static",
+          keyboard: true,
+          show: true,
+        });
+        $(document).on("click", "button#ok", function (event) {
+          $("#myModal").modal("hide");
+        });
+        $(document)
+          .off()
+          .on("click", "button#showDiff", function (event) {
+            generate_text_diff(
+              originalLicenseText.split("\n\n"),
+              inputLicenseText.split("\n\n")
+            );
+          });
+      } else if (
+        matchType == "Perfect match" ||
+        matchType == "Standard License match"
+      ) {
+        var message = `Perfect match found! The license matches with the license ID(s): <strong>${matchIds}</strong>`;
+        $("#modal-header").addClass("green-modal");
+        $("#modal-title").html("Found!");
+        $("#modal-body").html(message);
+      } else {
+        $("#modal-header").addClass("red-modal");
+        $("#modal-title").html("Not Found!");
+        var message = "The given license was not found in the SPDX database.";
+        $("#modal-body").html("<h3>" + message + "</h3>");
+      }
+      $("#myModal").modal({
+        backdrop: "static",
+        keyboard: true,
+        show: true,
+      });
+      $("#licensediffbutton").text("License diff");
+      $("#licensediffbutton").prop("disabled", false);
+    },
+    error: function (e) {
+      console.log("ERROR : ", e);
+      $("#modal-header").removeClass("green-modal");
+      try {
+        var obj = JSON.parse(e.responseText);
+        $("#modal-header").addClass("red-modal");
+        $("#modal-title").html("Error!");
+        $("#modal-body").text(obj.data);
+      } catch (e) {
+        $("#modal-header").addClass("red-modal");
+        $("#modal-title").html("Error!");
+        $("#modal-body").text(
+          "The application could not be connected. Please try later."
+        );
+      }
+      $("#myModal").modal({
+        backdrop: "static",
+        keyboard: true,
+        show: true,
+      });
+      $("#licensediffbutton").text("Check License");
+      $("#licensediffbutton").prop("disabled", false);
+    },
+  });
+}

--- a/src/app/templates/app/license_diff.html
+++ b/src/app/templates/app/license_diff.html
@@ -25,6 +25,7 @@
 </div>
 {% endblock %}
 {% block script_block %}
+<script src="{% static 'js/utils.js' %}"></script>
 <script type="text/javascript">
 $(document).ready(function () {
     $("#licensediffpage").addClass('linkactive');
@@ -53,84 +54,17 @@ function checkform() {
       $("#licensediffbutton").prop('disabled', true);
       $("#messages").html("");
       var form = new FormData($("#diffform")[0]);
-      $.ajax({
-              type: "POST",
-              enctype: 'multipart/form-data',
-              url: "/app/diff/",
-              processData: false,
-              contentType: false,
-              cache: false,
-              dataType: 'json',
-              data: form,
-              success: function (data) {
-                  console.log("SUCCESS : ", data);
-                  var matchType = data.matchType;
-                  var matchIds = data.matchIds;
-                  if(matchType == "Close match"){
-                    $("#modal-header").addClass("yellow-modal");
-                    var inputLicenseText = data.inputLicenseText.replace(/\r\n/g,'\n');
-                    var originalLicenseText = data.originalLicenseText;
-                    var matchingGuidelinesUrl = 'https://spdx.org/spdx-license-list/matching-guidelines'
-                    var message = `Close match found! The license closely matches with the license ID(s): <strong>${matchIds}</strong> based on the SPDX Matching guidelines. Press show differences to continue.`
-                    $("#modal-header").removeClass("red-modal green-modal");
-		                $("#modal-header").addClass("yellow-modal");
-		                $(".modal-footer").html(`<a href=${matchingGuidelinesUrl} target="_blank"><button class="btn btn-success btn-space" id="matchingguidelines"><span class="glyphicon glyphicon-link"></span> SPDX Matching Guidelines</button></a><button class="btn btn-success btn-space" id="showDiff"><span class="glyphicon glyphicon-link"></span> Show differences</button>`);
-		                $("#modal-body").html(message);
-                    $("#myModal").modal({
-                      backdrop: 'static',
-                      keyboard: true,
-                      show: true
-                    });
-                    $(document).on('click','button#ok', function(event){
-                      $("#myModal").modal("hide");
-                    });
-                    $(document).off().on('click','button#showDiff', function(event){
-                      generate_text_diff(originalLicenseText.split('\n\n'), inputLicenseText.split('\n\n'));
-                    });
-				          }
-                  else if (matchType == "Perfect match" || matchType == "Standard License match") {
-                    var message = `Perfect match found! The license matches with the license ID(s): <strong>${matchIds}</strong>`
-                    $("#modal-header").addClass("green-modal");
-                    $("#modal-title").html("Found!");
-                    $("#modal-body").html(message);
-                  }
-                  else {
-                    $("#modal-header").addClass("red-modal");
-                    $("#modal-title").html("Not Found!");
-                    var message = "The given license was not found in the SPDX database.";
-                    $("#modal-body").html("<h3>" + message + "</h3>");
-                  }
-                  $("#myModal").modal({
-                        backdrop: 'static',
-                        keyboard: true, 
-                        show: true
-                    });
-                  $("#licensediffbutton").text("License diff");
-                  $("#licensediffbutton").prop('disabled', false);
-              },
-              error: function (e) {
-                  console.log("ERROR : ", e);
-                  $("#modal-header").removeClass("green-modal");
-                  try {
-                    var obj = JSON.parse(e.responseText);
-                    $("#modal-header").addClass("red-modal");
-                    $("#modal-title").html("Error!");
-                    $("#modal-body").text(obj.data);
-                  }
-                  catch (e){
-                    $("#modal-header").addClass("red-modal");
-                    $("#modal-title").html("Error!");
-                    $("#modal-body").text("The application could not be connected. Please try later.");
-                  }
-                  $("#myModal").modal({
-                          backdrop: 'static',
-                          keyboard: true, 
-                          show: true
-                  });
-                  $("#licensediffbutton").text("Check License");
-                  $("#licensediffbutton").prop('disabled', false);
-              }
-          });
+      var dict1 = {
+        type: "POST",
+        enctype: "multipart/form-data",
+        url: "/app/diff/",
+        processData: false,
+        contentType: false,
+        cache: false,
+        dataType: "json",
+        data: form,
+      };
+      doRequest(dict1);
     }
     else{
       $("#messages").html('<div class="alert alert-danger alert-dismissable fade in"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a><strong>Error! </strong>'+check+'</div>');

--- a/src/app/templates/app/submit_new_license.html
+++ b/src/app/templates/app/submit_new_license.html
@@ -617,10 +617,10 @@ async function generate_text_diff(base, newtxt){
 <script type="text/javascript">
   // Add an event listener to the "Check License Text" button
   document.getElementById('check-license-btn').addEventListener('click', function() {
-    // Get the license text from the textarea
+    // Get the license text from the request
     const licenseText = document.getElementById('{{ form.text.id_for_label }}').value;
     var csrftoken = $('input[name=csrfmiddlewaretoken]').val();
-    var dict1 = {
+    var request =  {
       url: '/app/diff/',
       type: 'POST',
       data: {licensetext: licenseText},
@@ -628,7 +628,7 @@ async function generate_text_diff(base, newtxt){
         'X-CSRFToken': csrftoken
       }
     }
-    doRequest(dict1);
+    doRequest(request);
     // const licenseText = "Test-Apache 2.0";
     
     // Make an AJAX call to your Django view to match the license text with existing licenses

--- a/src/app/templates/app/submit_new_license.html
+++ b/src/app/templates/app/submit_new_license.html
@@ -131,8 +131,6 @@ Once you have submitted a license, please follow the <a href="https://github.com
         </div>
           <!-- <a href="/app/diff" target="_blank">Check License Diff</a> -->
       </div>
-      <!-- License diff result will be displayed in this div -->
-      <div id="license-diff-result"></div>
 
     </div>
 
@@ -628,15 +626,76 @@ async function generate_text_diff(base, newtxt){
       url: '/app/diff/',
       type: 'POST',
       data: {licensetext: licenseText},
-      success: function(result) {
-        // Display the license diff result in the "license-diff-result" div
-        document.getElementById('license-diff-result').innerHTML = result;
-      },
-      error: function() {
-        // Display an error message if the AJAX call fails
-        document.getElementById('license-diff-result').innerHTML = 'Failed to check license text. Please try again later.';
-      }
+      success: function (data) {
+        console.log("SUCCESS : ", data);
+        var matchType = data.matchType;
+        var matchIds = data.matchIds;
+        if(matchType == "Close match"){
+          $("#modal-header").addClass("yellow-modal");
+          var inputLicenseText = data.inputLicenseText.replace(/\r\n/g,'\n');
+          var originalLicenseText = data.originalLicenseText;
+          var matchingGuidelinesUrl = 'https://spdx.org/spdx-license-list/matching-guidelines'
+          var message = `Close match found! The license closely matches with the license ID(s): <strong>${matchIds}</strong> based on the SPDX Matching guidelines. Press show differences to continue.`
+          $("#modal-header").removeClass("red-modal green-modal");
+          $("#modal-header").addClass("yellow-modal");
+          $(".modal-footer").html(`<a href=${matchingGuidelinesUrl} target="_blank"><button class="btn btn-success btn-space" id="matchingguidelines"><span class="glyphicon glyphicon-link"></span> SPDX Matching Guidelines</button></a><button class="btn btn-success btn-space" id="showDiff"><span class="glyphicon glyphicon-link"></span> Show differences</button>`);
+          $("#modal-body").html(message);
+          $("#myModal").modal({
+            backdrop: 'static',
+            keyboard: true,
+            show: true
+          });
+          $(document).on('click','button#ok', function(event){
+            $("#myModal").modal("hide");
+          });
+          $(document).off().on('click','button#showDiff', function(event){
+            generate_text_diff(originalLicenseText.split('\n\n'), inputLicenseText.split('\n\n'));
+          });
+        }
+        else if (matchType == "Perfect match" || matchType == "Standard License match") {
+          var message = `Perfect match found! The license matches with the license ID(s): <strong>${matchIds}</strong>`
+          $("#modal-header").addClass("green-modal");
+          $("#modal-title").html("Found!");
+          $("#modal-body").html(message);
+        }
+        else {
+          $("#modal-header").addClass("red-modal");
+          $("#modal-title").html("Not Found!");
+          var message = "The given license was not found in the SPDX database.";
+          $("#modal-body").html("<h3>" + message + "</h3>");
+        }
+        $("#myModal").modal({
+              backdrop: 'static',
+              keyboard: true, 
+              show: true
+          });
+        $("#licensediffbutton").text("License diff");
+        $("#licensediffbutton").prop('disabled', false);
+    },
+    error: function (e) {
+        console.log("ERROR : ", e);
+        $("#modal-header").removeClass("green-modal");
+        try {
+          var obj = JSON.parse(e.responseText);
+          $("#modal-header").addClass("red-modal");
+          $("#modal-title").html("Error!");
+          $("#modal-body").text(obj.data);
+        }
+        catch (e){
+          $("#modal-header").addClass("red-modal");
+          $("#modal-title").html("Error!");
+          $("#modal-body").text("The application could not be connected. Please try later.");
+        }
+        $("#myModal").modal({
+                backdrop: 'static',
+                keyboard: true, 
+                show: true
+        });
+        $("#licensediffbutton").text("Check License");
+        $("#licensediffbutton").prop('disabled', false);
+    }
     });
+  
   });
 </script>
 <script type="text/javascript" src="{% static 'js/editor/difflib.js' %}"></script>

--- a/src/app/templates/app/submit_new_license.html
+++ b/src/app/templates/app/submit_new_license.html
@@ -617,7 +617,8 @@ async function generate_text_diff(base, newtxt){
   // Add an event listener to the "Check License Text" button
   document.getElementById('check-license-btn').addEventListener('click', function() {
     // Get the license text from the textarea
-    const licenseText = document.getElementById('{{ form.text.id_for_label }}').value;;
+    const licenseText = document.getElementById('{{ form.text.id_for_label }}').value;
+    console.log(licenseText)
     // const licenseText = "Test-Apache 2.0";
     
     // Make an AJAX call to your Django view to match the license text with existing licenses

--- a/src/app/templates/app/submit_new_license.html
+++ b/src/app/templates/app/submit_new_license.html
@@ -164,6 +164,7 @@ Once you have submitted a license, please follow the <a href="https://github.com
 {% endblock %}
 
 {% block script_block %}
+<script src="{% static 'js/utils.js' %}"></script>
 <script type="text/javascript">
 $(document).ready(function () {
     var is_touch_device = "ontouchstart" in document.documentElement;
@@ -618,90 +619,20 @@ async function generate_text_diff(base, newtxt){
   document.getElementById('check-license-btn').addEventListener('click', function() {
     // Get the license text from the textarea
     const licenseText = document.getElementById('{{ form.text.id_for_label }}').value;
-    console.log(licenseText)
     var csrftoken = $('input[name=csrfmiddlewaretoken]').val();
-    console.log(csrftoken)
-    // const licenseText = "Test-Apache 2.0";
-    
-    // Make an AJAX call to your Django view to match the license text with existing licenses
-    // Replace the URL with the URL of your Django view
-    $.ajax({
+    var dict1 = {
       url: '/app/diff/',
       type: 'POST',
       data: {licensetext: licenseText},
       headers: {
         'X-CSRFToken': csrftoken
-      },
-      success: function (data) {
-        console.log("SUCCESS : ", data);
-        var matchType = data.matchType;
-        var matchIds = data.matchIds;
-        if(matchType == "Close match"){
-          $("#modal-header").addClass("yellow-modal");
-          var inputLicenseText = data.inputLicenseText.replace(/\r\n/g,'\n');
-          var originalLicenseText = data.originalLicenseText;
-          var matchingGuidelinesUrl = 'https://spdx.org/spdx-license-list/matching-guidelines'
-          var message = `Close match found! The license closely matches with the license ID(s): <strong>${matchIds}</strong> based on the SPDX Matching guidelines. Press show differences to continue.`
-          $("#modal-header").removeClass("red-modal green-modal");
-          $("#modal-header").addClass("yellow-modal");
-          $(".modal-footer").html(`<a href=${matchingGuidelinesUrl} target="_blank"><button class="btn btn-success btn-space" id="matchingguidelines"><span class="glyphicon glyphicon-link"></span> SPDX Matching Guidelines</button></a><button class="btn btn-success btn-space" id="showDiff"><span class="glyphicon glyphicon-link"></span> Show differences</button>`);
-          $("#modal-body").html(message);
-          $("#myModal").modal({
-            backdrop: 'static',
-            keyboard: true,
-            show: true
-          });
-          $(document).on('click','button#ok', function(event){
-            $("#myModal").modal("hide");
-          });
-          $(document).off().on('click','button#showDiff', function(event){
-            generate_text_diff(originalLicenseText.split('\n\n'), inputLicenseText.split('\n\n'));
-          });
-        }
-        else if (matchType == "Perfect match" || matchType == "Standard License match") {
-          var message = `Perfect match found! The license matches with the license ID(s): <strong>${matchIds}</strong>`
-          $("#modal-header").addClass("green-modal");
-          $("#modal-title").html("Found!");
-          $("#modal-body").html(message);
-        }
-        else {
-          $("#modal-header").addClass("red-modal");
-          $("#modal-title").html("Not Found!");
-          var message = "The given license was not found in the SPDX database.";
-          $("#modal-body").html("<h3>" + message + "</h3>");
-        }
-        $("#myModal").modal({
-              backdrop: 'static',
-              keyboard: true, 
-              show: true
-          });
-        $("#licensediffbutton").text("License diff");
-        $("#licensediffbutton").prop('disabled', false);
-    },
-    error: function (e) {
-        console.log("ERROR : ", e);
-        $("#modal-header").removeClass("green-modal");
-        try {
-          var obj = JSON.parse(e.responseText);
-          $("#modal-header").addClass("red-modal");
-          $("#modal-title").html("Error!");
-          $("#modal-body").text(obj.data);
-        }
-        catch (e){
-          $("#modal-header").addClass("red-modal");
-          $("#modal-title").html("Error!");
-          $("#modal-body").text("The application could not be connected. Please try later.");
-        }
-        $("#myModal").modal({
-                backdrop: 'static',
-                keyboard: true, 
-                show: true
-        });
-        $("#licensediffbutton").text("Check License");
-        $("#licensediffbutton").prop('disabled', false);
+      }
     }
-    });
-  
+    doRequest(dict1);
+    // const licenseText = "Test-Apache 2.0";
+    
+    // Make an AJAX call to your Django view to match the license text with existing licenses
+    // Replace the URL with the URL of your Django view
   });
 </script>
 <script type="text/javascript" src="{% static 'js/editor/difflib.js' %}"></script>

--- a/src/app/templates/app/submit_new_license.html
+++ b/src/app/templates/app/submit_new_license.html
@@ -123,7 +123,7 @@ Once you have submitted a license, please follow the <a href="https://github.com
 
     <div class = "form-group">
       <div class="col-sm-12">
-      <label class="control-label col-sm-3">Text of license
+      <label class="control-label col-sm-3" for="{{form.text.id_for_label}}">Text of license
       </label>
         <div class="col-sm-6">
           {{ form.text }}
@@ -619,8 +619,8 @@ async function generate_text_diff(base, newtxt){
   // Add an event listener to the "Check License Text" button
   document.getElementById('check-license-btn').addEventListener('click', function() {
     // Get the license text from the textarea
-    // const licenseText = document.getElementById('license-text').value;
-    const licenseText = "Test-Apache 2.0";
+    const licenseText = document.getElementById('{{ form.text.id_for_label }}').value;;
+    // const licenseText = "Test-Apache 2.0";
     
     // Make an AJAX call to your Django view to match the license text with existing licenses
     // Replace the URL with the URL of your Django view

--- a/src/app/templates/app/submit_new_license.html
+++ b/src/app/templates/app/submit_new_license.html
@@ -127,6 +127,7 @@ Once you have submitted a license, please follow the <a href="https://github.com
       </label>
         <div class="col-sm-6">
           {{ form.text }}
+          <button type="button" id="check-license-btn">Check License Text</button>
         </div>
           <!-- <a href="/app/diff" target="_blank">Check License Diff</a> -->
       </div>

--- a/src/app/templates/app/submit_new_license.html
+++ b/src/app/templates/app/submit_new_license.html
@@ -123,7 +123,7 @@ Once you have submitted a license, please follow the <a href="https://github.com
 
     <div class = "form-group">
       <div class="col-sm-12">
-      <label class="control-label col-sm-3" >Text of license
+      <label class="control-label col-sm-3">Text of license
       </label>
         <div class="col-sm-6">
           {{ form.text }}
@@ -131,6 +131,8 @@ Once you have submitted a license, please follow the <a href="https://github.com
         </div>
           <!-- <a href="/app/diff" target="_blank">Check License Diff</a> -->
       </div>
+      <!-- License diff result will be displayed in this div -->
+      <div id="license-diff-result"></div>
 
     </div>
 
@@ -612,6 +614,30 @@ async function generate_text_diff(base, newtxt){
       makeIssue(LicenseData.data);
     });
   }
+</script>
+<script type="text/javascript">
+  // Add an event listener to the "Check License Text" button
+  document.getElementById('check-license-btn').addEventListener('click', function() {
+    // Get the license text from the textarea
+    // const licenseText = document.getElementById('license-text').value;
+    const licenseText = "Test-Apache 2.0";
+    
+    // Make an AJAX call to your Django view to match the license text with existing licenses
+    // Replace the URL with the URL of your Django view
+    $.ajax({
+      url: '/app/diff/',
+      type: 'POST',
+      data: {licensetext: licenseText},
+      success: function(result) {
+        // Display the license diff result in the "license-diff-result" div
+        document.getElementById('license-diff-result').innerHTML = result;
+      },
+      error: function() {
+        // Display an error message if the AJAX call fails
+        document.getElementById('license-diff-result').innerHTML = 'Failed to check license text. Please try again later.';
+      }
+    });
+  });
 </script>
 <script type="text/javascript" src="{% static 'js/editor/difflib.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/editor/diffview.js' %}"></script>

--- a/src/app/templates/app/submit_new_license.html
+++ b/src/app/templates/app/submit_new_license.html
@@ -619,6 +619,8 @@ async function generate_text_diff(base, newtxt){
     // Get the license text from the textarea
     const licenseText = document.getElementById('{{ form.text.id_for_label }}').value;
     console.log(licenseText)
+    var csrftoken = $('input[name=csrfmiddlewaretoken]').val();
+    console.log(csrftoken)
     // const licenseText = "Test-Apache 2.0";
     
     // Make an AJAX call to your Django view to match the license text with existing licenses
@@ -627,6 +629,9 @@ async function generate_text_diff(base, newtxt){
       url: '/app/diff/',
       type: 'POST',
       data: {licensetext: licenseText},
+      headers: {
+        'X-CSRFToken': csrftoken
+      },
       success: function (data) {
         console.log("SUCCESS : ", data);
         var matchType = data.matchType;

--- a/src/app/templates/app/submit_new_license.html
+++ b/src/app/templates/app/submit_new_license.html
@@ -629,10 +629,6 @@ async function generate_text_diff(base, newtxt){
       }
     }
     doRequest(request);
-    // const licenseText = "Test-Apache 2.0";
-    
-    // Make an AJAX call to your Django view to match the license text with existing licenses
-    // Replace the URL with the URL of your Django view
   });
 </script>
 <script type="text/javascript" src="{% static 'js/editor/difflib.js' %}"></script>

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -22,7 +22,6 @@ from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
-from django.views.decorators.csrf import csrf_exempt
 from src.version import spdx_online_tools_version
 from src.version import java_tools_version
 from src.version import ntia_conformance_checker_version
@@ -653,7 +652,6 @@ def check_license(request):
     else:
         return HttpResponseRedirect(settings.LOGIN_URL)
 
-@csrf_exempt
 def license_diff(request):
     """ View for diff section tool
     returns license_diff.html template

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -661,7 +661,6 @@ def license_diff(request):
     if request.user.is_authenticated or settings.ANONYMOUS_LOGIN_ENABLED:
         context_dict = {}
         if request.method == 'POST':
-            print("inside this")
             result = core.license_diff_helper(request)
             return JsonResponse(result)
         else:

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -22,6 +22,7 @@ from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
 from src.version import spdx_online_tools_version
 from src.version import java_tools_version
 from src.version import ntia_conformance_checker_version
@@ -652,7 +653,7 @@ def check_license(request):
     else:
         return HttpResponseRedirect(settings.LOGIN_URL)
 
-
+@csrf_exempt
 def license_diff(request):
     """ View for diff section tool
     returns license_diff.html template
@@ -660,6 +661,7 @@ def license_diff(request):
     if request.user.is_authenticated or settings.ANONYMOUS_LOGIN_ENABLED:
         context_dict = {}
         if request.method == 'POST':
+            print("inside this")
             result = core.license_diff_helper(request)
             return JsonResponse(result)
         else:


### PR DESCRIPTION
- Added new `check license diff` button on the `submit new license` page itself so that the user does not need to change the tab
- Solves #346 
- Changed the `submit_new_license.html` to handle this and call the `license_diff` function