### PR TITLE
Fixed API Tests for ConvertFileUploadTests #282

### DIFF
--- a/src/api/tests.py
+++ b/src/api/tests.py
@@ -32,7 +32,7 @@ from json import dumps, loads
 from api.oauth import generate_github_access_token,get_user_from_token
 from api.views import generateLicenseXml
 
-from api.models import ValidateFileUpload,ConvertFileUpload,CompareFileUpload,CheckLicenseFileUpload,SubmitLicenseModel
+from api.models import ValidateFileUpload,ConvertFileUpload,CompareFileUpload,SubmitLicenseModel
 from django.conf import settings
 import os
 
@@ -290,7 +290,6 @@ class CheckLicenseFileUploadTests(APITestCase):
             u.delete()
         except ObjectDoesNotExist:
             pass
-        CheckLicenseFileUpload.objects.all().delete()
 
     def test_checklicense_api(self):
         """Access get without login"""


### PR DESCRIPTION
- Fixes #282 
- Fixed the unit tests by removing the `CheckLicenseFileUpload` field which is not required
- The model does not exist which was causing the issue in the tests