### PR TITLE
Substitute illegal characters in filename to hyphen

### DIFF
--- a/src/app/core.py
+++ b/src/app/core.py
@@ -66,7 +66,7 @@ def license_compare_helper(request):
                 base_url=urljoin(settings.MEDIA_URL, folder+'/')
                 )
             for myfile in request.FILES.getlist("files"):
-                filename = fs.save(myfile.name, myfile)
+                filename = fs.save(utils.removeSpecialCharacters(myfile.name), myfile)
                 uploaded_file_url = fs.url(filename).replace("%20", " ")
                 callfunc.append(settings.APP_DIR+uploaded_file_url)
                 nameoffile, fileext = os.path.splitext(filename)
@@ -206,7 +206,7 @@ def ntia_check_helper(request):
             fs = FileSystemStorage(location=settings.MEDIA_ROOT + "/" + folder,
                                    base_url=urljoin(settings.MEDIA_URL, folder + '/')
                                    )
-            filename = fs.save(myfile.name, myfile)
+            filename = fs.save(utils.removeSpecialCharacters(myfile.name), myfile)
             uploaded_file_url = fs.url(filename).replace("%20", " ")
             """ Call the python SBOM Checker """
             schecker = SbomChecker(str(settings.APP_DIR + uploaded_file_url))
@@ -488,7 +488,7 @@ def license_convert_helper(request):
             folder = str(request.user) + "/" + str(int(time()))
             myfile = request.FILES['file']
             fs = FileSystemStorage(location=settings.MEDIA_ROOT +"/"+ folder,base_url=urljoin(settings.MEDIA_URL, folder+'/'))
-            filename = fs.save(myfile.name, myfile)
+            filename = fs.save(utils.removeSpecialCharacters(myfile.name), myfile)
             uploaded_file_url = fs.url(filename).replace("%20", " ")
             option1 = request.POST["from_format"]
             option2 = request.POST["to_format"]

--- a/src/app/utils.py
+++ b/src/app/utils.py
@@ -369,7 +369,7 @@ def postToGithub(message, encodedContent, filename):
 
 
 def removeSpecialCharacters(filename):
-    return unicodedata.normalize('NFKD', filename).encode('ASCII', 'ignore').decode('ASCII')
+    return re.sub(r'[#%&{}<>*?/$!\'":@+`|=]', "-", filename)
 
 
 def parseXmlString(xmlString):


### PR DESCRIPTION
Fixing #376 

Changes on top of https://github.com/spdx/spdx-online-tools/pull/460 

Works for other illegal characters as well like `SPDXTagExample-v2.2:#%rohit.spdx`

<img width="1049" alt="Screenshot 2023-06-29 at 6 45 30 PM" src="https://github.com/spdx/spdx-online-tools/assets/17159160/69a977b6-ae39-4c1e-9c27-146fd4880431">


All illegal characters list taken from - https://www.mtu.edu/umc/services/websites/writing/characters-avoid/
