### PR TITLE
Add --noinput to static file generation

### DIFF
--- a/dockerfile.dev
+++ b/dockerfile.dev
@@ -29,6 +29,6 @@ EXPOSE 8000
 
 # Run migrations and start the development server on port 8000
 CMD python src/manage.py migrate && \ 
-    python src/manage.py collectstatic && \ 
+    python src/manage.py collectstatic --noinput && \ 
     python src/populate.py && \
     python src/manage.py runserver 0.0.0.0:8000

--- a/dockerfile.prod
+++ b/dockerfile.prod
@@ -58,5 +58,5 @@ EXPOSE 8000
 RUN mv ./supervisor_api.conf /etc/supervisor/conf.d
 
 # Start the supervisor
-CMD python src/manage.py collectstatic && \ 
+CMD python src/manage.py collectstatic --noinput && \ 
     /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
Resolves an issue that if there are existing files, there is a prompt to overwrite which causes the docker build to fail