### PR TITLE
Fix test_checklicense_api 

### DIFF
--- a/src/api/tests.py
+++ b/src/api/tests.py
@@ -56,7 +56,7 @@ class ValidateFileUploadTests(APITestCase):
         u.is_staff = True
         u.save()
         self.tv_file = open(getExamplePath("SPDXTagExample-v2.0.spdx"))
-        self.rdf_file = open(getExamplePath("SPDXRdfExample-v2.0.rdf"))
+        self.rdf_file = open(getExamplePath("SPDXRdfExample-v2.2.spdx.rdf"))
         self.invalid_tv_file = open(getExamplePath("SPDXTagExample-v2.0_invalid.spdx"))
         self.invalid_rdf_file = open(getExamplePath("SPDXRdfExample-v2.0_invalid.rdf"))
 
@@ -226,8 +226,8 @@ class CompareFileUploadTests(APITestCase):
         u = User.objects.create_user(**self.credentials)
         u.is_staff = True
         u.save()
-        self.rdf_file = open(getExamplePath("SPDXRdfExample-v2.0.rdf"))
-        self.rdf_file2 = open(getExamplePath("SPDXRdfExample.rdf"))
+        self.rdf_file = open(getExamplePath("SPDXRdfExample-v2.2.spdx.rdf"))
+        self.rdf_file2 = open(getExamplePath("SPDXRdfExample-v2.3.spdx.rdf"))
         self.tv_file = open(getExamplePath("SPDXTagExample-v2.0.spdx"))
 
     def tearDown(self):

--- a/src/api/tests.py
+++ b/src/api/tests.py
@@ -35,6 +35,7 @@ from api.views import generateLicenseXml
 from api.models import ValidateFileUpload,ConvertFileUpload,CompareFileUpload,SubmitLicenseModel
 from django.conf import settings
 import os
+import json
 
 def getExamplePath(filename):
     return os.path.join(settings.EXAMPLES_DIR, filename)
@@ -281,6 +282,7 @@ class CheckLicenseFileUploadTests(APITestCase):
         u = User.objects.create_user(**self.credentials)
         u.is_staff = True
         u.save()
+        self.license = "AFL-1.1"
         self.license_file = open(getExamplePath("AFL-1.1.txt"))
         self.other_file = open(getExamplePath("Other.txt"))
         
@@ -302,13 +304,17 @@ class CheckLicenseFileUploadTests(APITestCase):
         """ Valid License File"""
         resp3 = self.client.post(reverse("check_license-api"),{"file":self.license_file},format="multipart")
         self.assertEqual(resp3.status_code,200)
-        self.assertEqual(resp3.data['owner'],User.objects.get_by_natural_key(self.username).id)
-        self.assertEqual(resp3.data["result"],"The following license ID(s) match: AFL-1.1")
+        result3 = json.loads(resp3.content)
+        self.assertEqual(result3['matched_license'], self.license)
+        self.assertEqual(result3['match_type'], 'Perfect match')
+        self.assertEqual(result3["all_matches"],{self.license: 1.0})
         """ Other File"""
         resp4 = self.client.post(reverse("check_license-api"),{"file":self.other_file},format="multipart")
-        self.assertEqual(resp4.data['owner'],User.objects.get_by_natural_key(self.username).id)
-        self.assertEqual(resp4.status_code,404)
-        self.assertEqual(resp4.data["result"],"There are no matching SPDX listed licenses")
+        self.assertEqual(resp4.status_code, 404)
+        result4 = json.loads(resp4.content)
+        self.assertEqual(result4['matched_license'], None)
+        self.assertEqual(result4['match_type'], 'No match')
+        self.assertEqual(result4['all_matches'], {})
         
     def test_checklicense_without_argument(self):
         self.client.login(username=self.username,password=self.password)

--- a/src/app/core.py
+++ b/src/app/core.py
@@ -87,21 +87,22 @@ def license_compare_helper(request):
                         else :
                             filelist.append(myfile.name)
                             errorlist.append("No errors found")
-                    except jpype.JavaException as ex :
+                    except jpype.JException as ex:
                         """ Error raised by verifyclass.verifyRDFFile without exiting the application"""
                         erroroccurred = True
                         filelist.append(myfile.name)
-                        errorlist.append(jpype.JavaException.message(ex))
-                    except :
+                        errorlist.append(jpype.JException.message(ex))
+                    except Exception as ex:
                         """ Other Exceptions"""
                         erroroccurred = True
                         filelist.append(myfile.name)
                         errorlist.append(format_exc())
-                except :
+                except Exception as ex:
                     """Invalid file extension"""
                     erroroccurred = True
                     filelist.append(myfile.name)
                     errorlist.append("Invalid file extension for "+filename+".  Must be .xls, .xlsx, .xml, .json, .yaml, .spdx, .rdfxml")
+                    errorlist.append(format_exc())
             if (erroroccurred==False):
                 """ If no errors in any of the file,call the java function with parameters as list"""
                 try :
@@ -284,7 +285,7 @@ def ntia_check_helper(request):
         result['context'] = context_dict
         result['status'] = 404
         return result
-    except:
+    except Exception as ex:
         """ Other error raised """
         if (request.is_ajax()):
             ajaxdict = dict()
@@ -391,7 +392,7 @@ def license_validate_helper(request):
         result['context'] = context_dict
         result['status'] = 404
         return result
-    except :
+    except Exception as ex:
         """ Other error raised """
         if (request.is_ajax()):
             ajaxdict=dict()
@@ -458,7 +459,7 @@ def license_check_helper(request):
         result['context'] = context_dict
         result['status'] = 404
         return result
-    except :
+    except Exception as ex:
         """ Other exception raised """
         if request.is_ajax():
             ajaxdict = dict()
@@ -570,7 +571,7 @@ def license_convert_helper(request):
         result['context'] = context_dict
         result['status'] = 404
         return result
-    except :
+    except Exception as ex:
         """ Other error raised """
         if (request.is_ajax()):
             ajaxdict["type"] = "error"
@@ -625,7 +626,7 @@ def license_diff_helper(request):
         data['context'] = data
         data['status'] = 404
         return data
-    except :
+    except Exception as ex:
         """ Other exception raised """
         if (request.is_ajax()):
             ajaxdict = dict()

--- a/src/examples/SPDXRdfExample-v2.2.spdx.rdf
+++ b/src/examples/SPDXRdfExample-v2.2.spdx.rdf
@@ -1,0 +1,1983 @@
+<rdf:RDF
+    xmlns:spdx="http://spdx.org/rdf/terms#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301"
+    xmlns:doap="http://usefulinc.com/ns/doap#"
+    xmlns:ptr="http://www.w3.org/2009/pointers#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+  <spdx:Snippet rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Snippet">
+    <spdx:name>from linux kernel</spdx:name>
+    <spdx:copyrightText>Copyright 2008-2010 John Smith</spdx:copyrightText>
+    <spdx:licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</spdx:licenseComments>
+    <spdx:range>
+      <ptr:StartEndPointer>
+        <ptr:endPointer>
+          <ptr:ByteOffsetPointer>
+            <ptr:offset rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+            >420</ptr:offset>
+            <ptr:reference>
+              <spdx:File rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource">
+                <spdx:copyrightText>Copyright 2010, 2011 Source Auditor Inc.</spdx:copyrightText>
+                <spdx:fileContributor>Open Logic Inc.</spdx:fileContributor>
+                <spdx:fileName>./src/org/spdx/parser/DOAPProject.java</spdx:fileName>
+                <spdx:fileContributor>Black Duck Software In.c</spdx:fileContributor>
+                <spdx:fileContributor>Source Auditor Inc.</spdx:fileContributor>
+                <spdx:fileContributor>SPDX Technical Team Members</spdx:fileContributor>
+                <spdx:licenseConcluded>
+                  <spdx:ListedLicense rdf:about="http://spdx.org/licenses/Apache-2.0">
+                    <rdfs:comment>This license was released January 2004</rdfs:comment>
+                    <spdx:name>Apache License 2.0</spdx:name>
+                    <spdx:standardLicenseHeader>Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+
+distributed under the License is distributed on an "AS IS" BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+
+limitations under the License.</spdx:standardLicenseHeader>
+                    <spdx:crossRef>
+                      <spdx:CrossRef>
+                        <spdx:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+                        >0</spdx:order>
+                        <spdx:timestamp>2020-11-25 - 21:56:49</spdx:timestamp>
+                        <spdx:url>http://www.apache.org/licenses/LICENSE-2.0</spdx:url>
+                        <spdx:match>true</spdx:match>
+                        <spdx:isWayBackLink rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                        >false</spdx:isWayBackLink>
+                        <spdx:isValid rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                        >true</spdx:isValid>
+                        <spdx:isLive rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                        >true</spdx:isLive>
+                      </spdx:CrossRef>
+                    </spdx:crossRef>
+                    <spdx:crossRef>
+                      <spdx:CrossRef>
+                        <spdx:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+                        >1</spdx:order>
+                        <spdx:timestamp>2020-11-25 - 21:56:49</spdx:timestamp>
+                        <spdx:url>https://opensource.org/licenses/Apache-2.0</spdx:url>
+                        <spdx:match>true</spdx:match>
+                        <spdx:isWayBackLink rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                        >false</spdx:isWayBackLink>
+                        <spdx:isValid rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                        >true</spdx:isValid>
+                        <spdx:isLive rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                        >true</spdx:isLive>
+                      </spdx:CrossRef>
+                    </spdx:crossRef>
+                    <spdx:standardLicenseTemplate>&lt;&lt;beginOptional&gt;&gt; Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/&lt;&lt;endOptional&gt;&gt;&lt;&lt;beginOptional&gt;&gt; TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION&lt;&lt;endOptional&gt;&gt;
+
+   &lt;&lt;var;name="bullet";original="1.";match=".{0,20}"&gt;&gt; Definitions.
+
+      
+
+      "License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+      
+
+      "Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+      
+
+      "Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+      
+
+      "You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+      
+
+      "Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+      
+
+      "Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+      
+
+      "Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+      
+
+      "Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+      
+
+      "Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+      
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+   &lt;&lt;var;name="bullet";original="2.";match=".{0,20}"&gt;&gt; Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+   &lt;&lt;var;name="bullet";original="3.";match=".{0,20}"&gt;&gt; Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+   &lt;&lt;var;name="bullet";original="4.";match=".{0,20}"&gt;&gt; Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+      &lt;&lt;var;name="bullet";original="(a)";match=".{0,20}"&gt;&gt; You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+      &lt;&lt;var;name="bullet";original="(b)";match=".{0,20}"&gt;&gt; You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+      &lt;&lt;var;name="bullet";original="(c)";match=".{0,20}"&gt;&gt; You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+      &lt;&lt;var;name="bullet";original="(d)";match=".{0,20}"&gt;&gt; If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+   &lt;&lt;var;name="bullet";original="5.";match=".{0,20}"&gt;&gt; Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+   &lt;&lt;var;name="bullet";original="6.";match=".{0,20}"&gt;&gt; Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+   &lt;&lt;var;name="bullet";original="7.";match=".{0,20}"&gt;&gt; Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+   &lt;&lt;var;name="bullet";original="8.";match=".{0,20}"&gt;&gt; Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+   &lt;&lt;var;name="bullet";original="9.";match=".{0,20}"&gt;&gt; Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.&lt;&lt;beginOptional&gt;&gt; END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!) The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright &lt;&lt;var;name="copyright";original="[yyyy] [name of copyright owner]";match=".+"&gt;&gt;
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+
+distributed under the License is distributed on an "AS IS" BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+
+limitations under the License.&lt;&lt;endOptional&gt;&gt;</spdx:standardLicenseTemplate>
+                    <spdx:isOsiApproved rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                    >true</spdx:isOsiApproved>
+                    <spdx:isFsfLibre rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                    >true</spdx:isFsfLibre>
+                    <rdfs:seeAlso>https://opensource.org/licenses/Apache-2.0</rdfs:seeAlso>
+                    <rdfs:seeAlso>http://www.apache.org/licenses/LICENSE-2.0</rdfs:seeAlso>
+                    <spdx:standardLicenseHeaderTemplate>Copyright &lt;&lt;var;name="copyright";original="[yyyy] [name of copyright owner]";match=".+"&gt;&gt;
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+
+distributed under the License is distributed on an "AS IS" BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+
+limitations under the License.</spdx:standardLicenseHeaderTemplate>
+                    <spdx:isDeprecatedLicenseId rdf:datatype=
+                    "http://www.w3.org/2001/XMLSchema#boolean"
+                    >false</spdx:isDeprecatedLicenseId>
+                    <spdx:licenseId>Apache-2.0</spdx:licenseId>
+                    <spdx:licenseText>Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+</spdx:licenseText>
+                  </spdx:ListedLicense>
+                </spdx:licenseConcluded>
+                <spdx:fileContributor>Protecode Inc.</spdx:fileContributor>
+                <spdx:fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+                <spdx:licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+                <spdx:checksum>
+                  <spdx:Checksum>
+                    <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+                    <spdx:checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</spdx:checksumValue>
+                  </spdx:Checksum>
+                </spdx:checksum>
+              </spdx:File>
+            </ptr:reference>
+          </ptr:ByteOffsetPointer>
+        </ptr:endPointer>
+        <ptr:startPointer>
+          <ptr:ByteOffsetPointer>
+            <ptr:offset rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+            >310</ptr:offset>
+            <ptr:reference rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+          </ptr:ByteOffsetPointer>
+        </ptr:startPointer>
+      </ptr:StartEndPointer>
+    </spdx:range>
+    <spdx:snippetFromFile rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+    <spdx:licenseInfoInSnippet>
+      <spdx:ListedLicense rdf:about="http://spdx.org/licenses/GPL-2.0-only">
+        <spdx:standardLicenseHeader>Copyright (C) yyyy name of author
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; version 2.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.</spdx:standardLicenseHeader>
+        <rdfs:seeAlso>https://opensource.org/licenses/GPL-2.0</rdfs:seeAlso>
+        <rdfs:comment>This license was released: June 1991. This license identifier refers to the choice to use the code under GPL-2.0-only, as distinguished from use of code under GPL-2.0-or-later (i.e., GPL-2.0 or some later version). The license notice (as seen in the Standard License Header field below) states which of these applies to the code in the file. The example in the exhibit to the license shows the license notice for the "or later" approach.</rdfs:comment>
+        <spdx:licenseId>GPL-2.0-only</spdx:licenseId>
+        <rdfs:seeAlso>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</rdfs:seeAlso>
+        <spdx:crossRef>
+          <spdx:CrossRef>
+            <spdx:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+            >0</spdx:order>
+            <spdx:timestamp>2020-11-25 - 21:52:24</spdx:timestamp>
+            <spdx:url>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</spdx:url>
+            <spdx:match>true</spdx:match>
+            <spdx:isWayBackLink rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >false</spdx:isWayBackLink>
+            <spdx:isValid rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >true</spdx:isValid>
+            <spdx:isLive rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >true</spdx:isLive>
+          </spdx:CrossRef>
+        </spdx:crossRef>
+        <spdx:isFsfLibre rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+        >true</spdx:isFsfLibre>
+        <spdx:standardLicenseTemplate>&lt;&lt;beginOptional&gt;&gt; GNU GENERAL PUBLIC LICENSE
+
+Version 2, June 1991&lt;&lt;endOptional&gt;&gt;
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc. &lt;&lt;var;name="incComma";original="";match=",|"&gt;&gt;
+
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301&lt;&lt;beginOptional&gt;&gt;, &lt;&lt;endOptional&gt;&gt; USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users. This General Public License applies to most of the Free Software Foundation's software and to any other program whose authors commit to using it. (Some other Free Software Foundation software is covered by the GNU Lesser General Public License instead.) You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or for a fee, you must give the recipients all the rights that you have. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2) offer you this license which gives you legal permission to copy, distribute and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain that everyone understands that there is no warranty for this free software. If the software is modified by someone else and passed on, we want its recipients to know that what they have is not the original, so that any problems introduced by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that redistributors of a free program will individually obtain patent licenses, in effect making the program proprietary. To prevent this, we have made it clear that any patent must be licensed for everyone's free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+&lt;&lt;var;name="termsTitle";original="";match="GNU GENERAL PUBLIC LICENSE|"&gt;&gt; TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+   &lt;&lt;var;name="bullet";original="0.";match=".{0,20}"&gt;&gt; This License applies to any program or other work which contains a notice placed by the copyright holder saying it may be distributed under the terms of this General Public License. The "Program", below, refers to any such program or work, and a "work based on the Program" means either the Program or any derivative work under copyright law: that is to say, a work containing the Program or a portion of it, either verbatim or with modifications and/or translated into another language. (Hereinafter, translation is included without limitation in the term "modification".) Each licensee is addressed as "you".
+
+   Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running the Program is not restricted, and the output from the Program is covered only if its contents constitute a work based on the Program (independent of having been made by running the Program). Whether that is true depends on what the Program does.
+
+   &lt;&lt;var;name="bullet";original="1.";match=".{0,20}"&gt;&gt; You may copy and distribute verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and give any other recipients of the Program a copy of this License along with the Program.
+
+   You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+   &lt;&lt;var;name="bullet";original="2.";match=".{0,20}"&gt;&gt; You may modify your copy or copies of the Program or any portion of it, thus forming a work based on the Program, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+      &lt;&lt;var;name="bullet";original="a)";match=".{0,20}"&gt;&gt; You must cause the modified files to carry prominent notices stating that you changed the files and the date of any change.
+
+      &lt;&lt;var;name="bullet";original="b)";match=".{0,20}"&gt;&gt; You must cause any work that you distribute or publish, that in whole or in part contains or is derived from the Program or any part thereof, to be licensed as a whole at no charge to all third parties under the terms of this License.
+
+      &lt;&lt;var;name="bullet";original="c)";match=".{0,20}"&gt;&gt; If the modified program normally reads commands interactively when run, you must cause it, when started running for such interactive use in the most ordinary way, to print or display an announcement including an appropriate copyright notice and a notice that there is no warranty (or else, saying that you provide a warranty) and that users may redistribute the program under these conditions, and telling the user how to view a copy of this License. (Exception: if the Program itself is interactive but does not normally print such an announcement, your work based on the Program is not required to print an announcement.)
+
+   These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Program, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Program, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+   Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Program.
+
+   In addition, mere aggregation of another work not based on the Program with the Program (or with a work based on the Program) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+   &lt;&lt;var;name="bullet";original="3.";match=".{0,20}"&gt;&gt; You may copy and distribute the Program (or a work based on it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you also do one of the following:
+
+      &lt;&lt;var;name="bullet";original="a)";match=".{0,20}"&gt;&gt; Accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+
+      &lt;&lt;var;name="bullet";original="b)";match=".{0,20}"&gt;&gt; Accompany it with a written offer, valid for at least three years, to give any third party, for a charge no more than your cost of physically performing source distribution, a complete machine-readable copy of the corresponding source code, to be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+
+      &lt;&lt;var;name="bullet";original="c)";match=".{0,20}"&gt;&gt; Accompany it with the information you received as to the offer to distribute corresponding source code. (This alternative is allowed only for noncommercial distribution and only if you received the program in object code or executable form with such an offer, in accord with Subsection b above.)
+
+   The source code for a work means the preferred form of the work for making modifications to it. For an executable work, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the executable. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+   If distribution of executable or object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place counts as distribution of the source code, even though third parties are not compelled to copy the source along with the object code.
+
+   &lt;&lt;var;name="bullet";original="4.";match=".{0,20}"&gt;&gt; You may not copy, modify, sublicense, or distribute the Program except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense or distribute the Program is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+   &lt;&lt;var;name="bullet";original="5.";match=".{0,20}"&gt;&gt; You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Program or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Program (or any work based on the Program), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Program or works based on it.
+
+   &lt;&lt;var;name="bullet";original="6.";match=".{0,20}"&gt;&gt; Each time you redistribute the Program (or any work based on the Program), the recipient automatically receives a license from the original licensor to copy, distribute or modify the Program subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties to this License.
+
+   &lt;&lt;var;name="bullet";original="7.";match=".{0,20}"&gt;&gt; If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Program at all. For example, if a patent license would not permit royalty-free redistribution of the Program by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Program.
+
+   If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply and the section as a whole is intended to apply in other circumstances.
+
+   It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system, which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+   This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+   &lt;&lt;var;name="bullet";original="8.";match=".{0,20}"&gt;&gt; If the distribution and/or use of the Program is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Program under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+   &lt;&lt;var;name="bullet";original="9.";match=".{0,20}"&gt;&gt; The Free Software Foundation may publish revised and/or new versions of the General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+   Each version is given a distinguishing version number. If the Program specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of this License, you may choose any version ever published by the Free Software Foundation.
+
+   &lt;&lt;var;name="bullet";original="10.";match=".{0,20}"&gt;&gt; If you wish to incorporate parts of the Program into other free programs whose distribution conditions are different, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+   NO WARRANTY
+
+   &lt;&lt;var;name="bullet";original="11.";match=".{0,20}"&gt;&gt; BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+   &lt;&lt;var;name="bullet";original="12.";match=".{0,20}"&gt;&gt; IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.&lt;&lt;beginOptional&gt;&gt; END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+&lt;&lt;beginOptional&gt;&gt;&lt;&lt;&lt;endOptional&gt;&gt;one line to give the program's name and &lt;&lt;var;name="ideaArticle";original="an";match="a brief|an"&gt;&gt; idea of what it does.&lt;&lt;beginOptional&gt;&gt;&gt;&lt;&lt;endOptional&gt;&gt;
+
+Copyright (C)&lt;&lt;beginOptional&gt;&gt;&lt;&lt;&lt;endOptional&gt;&gt; &lt;&lt;var;name="templateYear";original="yyyy";match="yyyy|year"&gt;&gt;&lt;&lt;beginOptional&gt;&gt;&gt; &lt;&lt;endOptional&gt;&gt;&lt;&lt;beginOptional&gt;&gt; &lt;&lt;&lt;endOptional&gt;&gt;name of author&lt;&lt;beginOptional&gt;&gt;&gt;&lt;&lt;endOptional&gt;&gt;
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301&lt;&lt;beginOptional&gt;&gt;, &lt;&lt;endOptional&gt;&gt; USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this when it starts in an interactive mode:
+
+Gnomovision version 69, Copyright (C) year name of author Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'. This is free software, and you are welcome to redistribute it under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate parts of the General Public License. Of course, the commands you use may be called something other than `show w' and `show c'; they could even be mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the program, if necessary. Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in the program `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+&lt;&lt;beginOptional&gt;&gt;&lt;&lt;&lt;endOptional&gt;&gt;signature of Ty Coon&lt;&lt;beginOptional&gt;&gt; &gt;&lt;&lt;endOptional&gt;&gt;, 1 April 1989 Ty Coon, President of Vice&lt;&lt;endOptional&gt;&gt;&lt;&lt;beginOptional&gt;&gt; This General Public License does not permit incorporating your program into proprietary programs. If your program is a subroutine library, you may consider it more useful to permit linking proprietary applications with the library. If this is what you want to do, use the GNU Lesser General Public License instead of this License.&lt;&lt;endOptional&gt;&gt;</spdx:standardLicenseTemplate>
+        <spdx:isDeprecatedLicenseId rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+        >false</spdx:isDeprecatedLicenseId>
+        <spdx:name>GNU General Public License v2.0 only</spdx:name>
+        <spdx:standardLicenseHeaderTemplate>Copyright (C) &lt;&lt;var;name="copyright";original="yyyy name of author";match=".+"&gt;&gt;
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; version 2.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301&lt;&lt;beginOptional&gt;&gt;, &lt;&lt;endOptional&gt;&gt; USA.</spdx:standardLicenseHeaderTemplate>
+        <spdx:isOsiApproved rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+        >true</spdx:isOsiApproved>
+        <spdx:licenseText>GNU GENERAL PUBLIC LICENSE
+Version 2, June 1991
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users. This General Public License applies to most of the Free Software Foundation's software and to any other program whose authors commit to using it. (Some other Free Software Foundation software is covered by the GNU Lesser General Public License instead.) You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or for a fee, you must give the recipients all the rights that you have. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2) offer you this license which gives you legal permission to copy, distribute and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain that everyone understands that there is no warranty for this free software. If the software is modified by someone else and passed on, we want its recipients to know that what they have is not the original, so that any problems introduced by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that redistributors of a free program will individually obtain patent licenses, in effect making the program proprietary. To prevent this, we have made it clear that any patent must be licensed for everyone's free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains a notice placed by the copyright holder saying it may be distributed under the terms of this General Public License. The "Program", below, refers to any such program or work, and a "work based on the Program" means either the Program or any derivative work under copyright law: that is to say, a work containing the Program or a portion of it, either verbatim or with modifications and/or translated into another language. (Hereinafter, translation is included without limitation in the term "modification".) Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running the Program is not restricted, and the output from the Program is covered only if its contents constitute a work based on the Program (independent of having been made by running the Program). Whether that is true depends on what the Program does.
+
+1. You may copy and distribute verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and give any other recipients of the Program a copy of this License along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion of it, thus forming a work based on the Program, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+     a) You must cause the modified files to carry prominent notices stating that you changed the files and the date of any change.
+
+     b) You must cause any work that you distribute or publish, that in whole or in part contains or is derived from the Program or any part thereof, to be licensed as a whole at no charge to all third parties under the terms of this License.
+
+     c) If the modified program normally reads commands interactively when run, you must cause it, when started running for such interactive use in the most ordinary way, to print or display an announcement including an appropriate copyright notice and a notice that there is no warranty (or else, saying that you provide a warranty) and that users may redistribute the program under these conditions, and telling the user how to view a copy of this License. (Exception: if the Program itself is interactive but does not normally print such an announcement, your work based on the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Program, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Program, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program with the Program (or with a work based on the Program) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+3. You may copy and distribute the Program (or a work based on it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you also do one of the following:
+
+     a) Accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+
+     b) Accompany it with a written offer, valid for at least three years, to give any third party, for a charge no more than your cost of physically performing source distribution, a complete machine-readable copy of the corresponding source code, to be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+
+     c) Accompany it with the information you received as to the offer to distribute corresponding source code. (This alternative is allowed only for noncommercial distribution and only if you received the program in object code or executable form with such an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for making modifications to it. For an executable work, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the executable. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+If distribution of executable or object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place counts as distribution of the source code, even though third parties are not compelled to copy the source along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense or distribute the Program is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Program or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Program (or any work based on the Program), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the Program), the recipient automatically receives a license from the original licensor to copy, distribute or modify the Program subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Program at all. For example, if a patent license would not permit royalty-free redistribution of the Program by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system, which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Program under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+9. The Free Software Foundation may publish revised and/or new versions of the General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of this License, you may choose any version ever published by the Free Software Foundation.
+
+10. If you wish to incorporate parts of the Program into other free programs whose distribution conditions are different, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     one line to give the program's name and an idea of what it does. Copyright (C) yyyy name of author
+
+     This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+     You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA. Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this when it starts in an interactive mode:
+
+     Gnomovision version 69, Copyright (C) year name of author Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'. This is free software, and you are welcome to redistribute it under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate parts of the General Public License. Of course, the commands you use may be called something other than `show w' and `show c'; they could even be mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the program, if necessary. Here is a sample; alter the names:
+
+     Yoyodyne, Inc., hereby disclaims all copyright interest in the program `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+signature of Ty Coon, 1 April 1989 Ty Coon, President of Vice
+</spdx:licenseText>
+        <spdx:crossRef>
+          <spdx:CrossRef>
+            <spdx:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+            >1</spdx:order>
+            <spdx:timestamp>2020-11-25 - 21:52:24</spdx:timestamp>
+            <spdx:url>https://opensource.org/licenses/GPL-2.0</spdx:url>
+            <spdx:match>false</spdx:match>
+            <spdx:isWayBackLink rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >false</spdx:isWayBackLink>
+            <spdx:isValid rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >true</spdx:isValid>
+            <spdx:isLive rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >true</spdx:isLive>
+          </spdx:CrossRef>
+        </spdx:crossRef>
+      </spdx:ListedLicense>
+    </spdx:licenseInfoInSnippet>
+    <spdx:licenseConcluded rdf:resource="http://spdx.org/licenses/GPL-2.0-only"/>
+    <rdfs:comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0.</rdfs:comment>
+    <spdx:range>
+      <ptr:StartEndPointer>
+        <ptr:endPointer>
+          <ptr:LineCharPointer>
+            <ptr:lineNumber rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+            >23</ptr:lineNumber>
+            <ptr:reference rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+          </ptr:LineCharPointer>
+        </ptr:endPointer>
+        <ptr:startPointer>
+          <ptr:LineCharPointer>
+            <ptr:lineNumber rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+            >5</ptr:lineNumber>
+            <ptr:reference rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+          </ptr:LineCharPointer>
+        </ptr:startPointer>
+      </ptr:StartEndPointer>
+    </spdx:range>
+  </spdx:Snippet>
+  <spdx:SpdxDocument rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DOCUMENT">
+    <spdx:relationship>
+      <spdx:Relationship>
+        <spdx:relatedSpdxElement>
+          <spdx:Package rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package">
+            <spdx:licenseConcluded>
+              <spdx:DisjunctiveLicenseSet>
+                <spdx:member>
+                  <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-3">
+                    <rdfs:seeAlso>http://justasample.url.com</rdfs:seeAlso>
+                    <rdfs:seeAlso>http://people.apache.org/~andyc/neko/LICENSE</rdfs:seeAlso>
+                    <spdx:licenseId>LicenseRef-3</spdx:licenseId>
+                    <rdfs:comment>This is tye CyperNeko License</rdfs:comment>
+                    <spdx:extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</spdx:extractedText>
+                    <spdx:name>CyberNeko License</spdx:name>
+                  </spdx:ExtractedLicensingInfo>
+                </spdx:member>
+                <spdx:member>
+                  <spdx:ListedLicense rdf:about="http://spdx.org/licenses/LGPL-2.0-only">
+                    <spdx:licenseText>GNU LIBRARY GENERAL PUBLIC LICENSE
+
+Version 2, June 1991
+
+Copyright (C) 1991 Free Software Foundation, Inc.
+51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+[This is the first released version of the library GPL.  It is numbered 2 because it goes with version 2 of the ordinary GPL.]
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public Licenses are intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users.
+
+This license, the Library General Public License, applies to some specially designated Free Software Foundation software, and to any other libraries whose authors decide to use it. You can use it for your libraries, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library, or if you modify it.
+
+For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you link a program with the library, you must provide complete object files to the recipients so that they can relink them with the library, after making changes to the library and recompiling it. And you must show them these terms so they know their rights.
+
+Our method of protecting your rights has two steps: (1) copyright the library, and (2) offer you this license which gives you legal permission to copy, distribute and/or modify the library.
+
+Also, for each distributor's protection, we want to make certain that everyone understands that there is no warranty for this free library. If the library is modified by someone else and passed on, we want its recipients to know that what they have is not the original version, so that any problems introduced by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that companies distributing free software will individually obtain patent licenses, thus in effect transforming the program into proprietary software. To prevent this, we have made it clear that any patent must be licensed for everyone's free use or not licensed at all.
+
+Most GNU software, including some libraries, is covered by the ordinary GNU General Public License, which was designed for utility programs. This license, the GNU Library General Public License, applies to certain designated libraries. This license is quite different from the ordinary one; be sure to read it in full, and don't assume that anything in it is the same as in the ordinary license.
+
+The reason we have a separate public license for some libraries is that they blur the distinction we usually make between modifying or adding to a program and simply using it. Linking a program with a library, without changing the library, is in some sense simply using the library, and is analogous to running a utility program or application program. However, in a textual and legal sense, the linked executable is a combined work, a derivative of the original library, and the ordinary General Public License treats it as such.
+
+Because of this blurred distinction, using the ordinary General Public License for libraries did not effectively promote software sharing, because most developers did not use the libraries. We concluded that weaker conditions might promote sharing better.
+
+However, unrestricted linking of non-free programs would deprive the users of those programs of all benefit from the free status of the libraries themselves. This Library General Public License is intended to permit developers of non-free programs to use free libraries, while preserving your freedom as a user of such programs to change the free libraries that are incorporated in them. (We have not seen how to achieve this as regards changes in header files, but we have achieved it as regards changes in the actual functions of the Library.) The hope is that this will lead to faster development of free libraries.
+
+The precise terms and conditions for copying, distribution and modification follow. Pay close attention to the difference between a "work based on the library" and a "work that uses the library". The former contains code derived from the library, while the latter only works together with the library.
+
+Note that it is possible for a library to be covered by the ordinary General Public License rather than by this special one.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License Agreement applies to any software library which contains a notice placed by the copyright holder or other authorized party saying it may be distributed under the terms of this Library General Public License (also called "this License"). Each licensee is addressed as "you".
+
+A "library" means a collection of software functions and/or data prepared so as to be conveniently linked with application programs (which use some of those functions and data) to form executables.
+
+The "Library", below, refers to any such software library or work which has been distributed under these terms. A "work based on the Library" means either the Library or any derivative work under copyright law: that is to say, a work containing the Library or a portion of it, either verbatim or with modifications and/or translated straightforwardly into another language. (Hereinafter, translation is included without limitation in the term "modification".)
+
+"Source code" for a work means the preferred form of the work for making modifications to it. For a library, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the library.
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running a program using the Library is not restricted, and output from such a program is covered only if its contents constitute a work based on the Library (independent of the use of the Library in a tool for writing it). Whether that is true depends on what the Library does and what the program that uses the Library does.
+
+1. You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and distribute a copy of this License along with the Library.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Library or any portion of it, thus forming a work based on the Library, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+     a) The modified work must itself be a software library.
+
+     b) You must cause the files modified to carry prominent notices stating that you changed the files and the date of any change.
+
+     c) You must cause the whole of the work to be licensed at no charge to all third parties under the terms of this License.
+
+     d) If a facility in the modified Library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful.
+
+(For example, a function in a library to compute square roots has a purpose that is entirely well-defined independent of the application. Therefore, Subsection 2d requires that any application-supplied function or table used by this function must be optional: if the application does not supply it, the square root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Library, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Library, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library with the Library (or with a work based on the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+3. You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if you wish.) Do not make any other change in these notices.
+
+Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU General Public License applies to all subsequent copies and derivative works made from that copy.
+
+This option is useful when you wish to copy part of the code of the Library into a program that is not a library.
+
+4. You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange.
+
+If distribution of object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place satisfies the requirement to distribute the source code, even though third parties are not compelled to copy the source along with the object code.
+
+5. A program that contains no derivative of any portion of the Library, but is designed to work with the Library by being compiled or linked with it, is called a "work that uses the Library". Such a work, in isolation, is not a derivative work of the Library, and therefore falls outside the scope of this License.
+
+However, linking a "work that uses the Library" with the Library creates an executable that is a derivative of the Library (because it contains portions of the Library), rather than a "work that uses the library". The executable is therefore covered by this License. Section 6 states terms for distribution of such executables.
+
+When a "work that uses the Library" uses material from a header file that is part of the Library, the object code for the work may be a derivative work of the Library even though the source code is not. Whether this is true is especially significant if the work can be linked without the Library, or if the work is itself a library. The threshold for this to be true is not precisely defined by law.
+
+If such an object file uses only numerical parameters, data structure layouts and accessors, and small macros and small inline functions (ten lines or less in length), then the use of the object file is unrestricted, regardless of whether it is legally a derivative work. (Executables containing this object code plus portions of the Library will still fall under Section 6.)
+
+Otherwise, if the work is a derivative of the Library, you may distribute the object code for the work under the terms of Section 6. Any executables containing that work also fall under Section 6, whether or not they are linked directly with the Library itself.
+
+6. As an exception to the Sections above, you may also compile or link a "work that uses the Library" with the Library to produce a work containing portions of the Library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's own use and reverse engineering for debugging such modifications.
+
+You must give prominent notice with each copy of the work that the Library is used in it and that the Library and its use are covered by this License. You must supply a copy of this License. If the work during execution displays copyright notices, you must include the copyright notice for the Library among them, as well as a reference directing the user to the copy of this License. Also, you must do one of these things:
+
+     a) Accompany the work with the complete corresponding machine-readable source code for the Library including whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the work is an executable linked with the Library, with the complete machine-readable "work that uses the Library", as object code and/or source code, so that the user can modify the Library and then relink to produce a modified executable containing the modified Library. (It is understood that the user who changes the contents of definitions files in the Library will not necessarily be able to recompile the application to use the modified definitions.)
+
+     b) Accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of performing this distribution.
+
+     c) If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place.
+
+     d) Verify that the user has already received a copy of these materials or that you have already sent this user a copy.
+
+For an executable, the required form of the "work that uses the Library" must include any data and utility programs needed for reproducing the executable from it. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+It may happen that this requirement contradicts the license restrictions of other proprietary libraries that do not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library together in an executable that you distribute.
+
+7. You may place library facilities that are a work based on the Library side-by-side in a single library together with other library facilities not covered by this License, and distribute such a combined library, provided that the separate distribution of the work based on the Library and of the other library facilities is otherwise permitted, and provided that you do these two things:
+
+     a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities. This must be distributed under the terms of the Sections above.
+
+     b) Give prominent notice with the combined library of the fact that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+8. You may not copy, modify, sublicense, link with, or distribute the Library except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or distribute the Library is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+9. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Library or works based on it.
+
+10. Each time you redistribute the Library (or any work based on the Library), the recipient automatically receives a license from the original licensor to copy, distribute, link with or modify the Library subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties to this License.
+
+11. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license would not permit royalty-free redistribution of the Library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply, and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+12. If the distribution and/or use of the Library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Library under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+13. The Free Software Foundation may publish revised and/or new versions of the Library General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Library does not specify a license version number, you may choose any version ever published by the Free Software Foundation.
+
+14. If you wish to incorporate parts of the Library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Libraries
+
+If you develop a new library, and you want it to be of the greatest possible use to the public, we recommend making it free software that everyone can redistribute and change. You can do so by permitting redistribution under these terms (or, alternatively, under the terms of the ordinary General Public License).
+
+To apply these terms, attach the following notices to the library. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     one line to give the library's name and an idea of what it does.
+     Copyright (C) year  name of author
+
+     This library is free software; you can redistribute it and/or modify it under the terms of the GNU Library General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+     This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public License for more details.
+
+     You should have received a copy of the GNU Library General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the library, if necessary. Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in
+the library `Frob' (a library for tweaking knobs) written
+by James Random Hacker.
+
+signature of Ty Coon, 1 April 1990
+Ty Coon, President of Vice
+
+That's all there is to it!
+</spdx:licenseText> <spdx:licenseId>LGPL-2.0-only</spdx:licenseId>
+                    <rdfs:seeAlso>https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</rdfs:seeAlso>
+                    <spdx:standardLicenseTemplate>&lt;&lt;beginOptional&gt;&gt; GNU LIBRARY GENERAL PUBLIC LICENSE
+
+Version 2, June 1991&lt;&lt;endOptional&gt;&gt; &lt;&lt;var;name="copyright";original="Copyright (C) 1991 Free Software Foundation, Inc.
+
+51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA";match=".{0,1000}"&gt;&gt;
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+[This is the first released version of the library GPL. It is numbered 2 because it goes with version 2 of the ordinary GPL.]
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public Licenses are intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users.
+
+This license, the Library General Public License, applies to some specially designated Free Software Foundation software, and to any other libraries whose authors decide to use it. You can use it for your libraries, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library, or if you modify it.
+
+For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you link a program with the library, you must provide complete object files to the recipients so that they can relink them with the library, after making changes to the library and recompiling it. And you must show them these terms so they know their rights.
+
+Our method of protecting your rights has two steps: (1) copyright the library, and (2) offer you this license which gives you legal permission to copy, distribute and/or modify the library.
+
+Also, for each distributor's protection, we want to make certain that everyone understands that there is no warranty for this free library. If the library is modified by someone else and passed on, we want its recipients to know that what they have is not the original version, so that any problems introduced by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that companies distributing free software will individually obtain patent licenses, thus in effect transforming the program into proprietary software. To prevent this, we have made it clear that any patent must be licensed for everyone's free use or not licensed at all.
+
+Most GNU software, including some libraries, is covered by the ordinary GNU General Public License, which was designed for utility programs. This license, the GNU Library General Public License, applies to certain designated libraries. This license is quite different from the ordinary one; be sure to read it in full, and don't assume that anything in it is the same as in the ordinary license.
+
+The reason we have a separate public license for some libraries is that they blur the distinction we usually make between modifying or adding to a program and simply using it. Linking a program with a library, without changing the library, is in some sense simply using the library, and is analogous to running a utility program or application program. However, in a textual and legal sense, the linked executable is a combined work, a derivative of the original library, and the ordinary General Public License treats it as such.
+
+Because of this blurred distinction, using the ordinary General Public License for libraries did not effectively promote software sharing, because most developers did not use the libraries. We concluded that weaker conditions might promote sharing better.
+
+However, unrestricted linking of non-free programs would deprive the users of those programs of all benefit from the free status of the libraries themselves. This Library General Public License is intended to permit developers of non-free programs to use free libraries, while preserving your freedom as a user of such programs to change the free libraries that are incorporated in them. (We have not seen how to achieve this as regards changes in header files, but we have achieved it as regards changes in the actual functions of the Library.) The hope is that this will lead to faster development of free libraries.
+
+The precise terms and conditions for copying, distribution and modification follow. Pay close attention to the difference between a "work based on the library" and a "work that uses the library". The former contains code derived from the library, while the latter only works together with the library.
+
+Note that it is possible for a library to be covered by the ordinary General Public License rather than by this special one.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+   &lt;&lt;var;name="bullet";original="0.";match=".{0,20}"&gt;&gt; This License Agreement applies to any software library which contains a notice placed by the copyright holder or other authorized party saying it may be distributed under the terms of this Library General Public License (also called "this License"). Each licensee is addressed as "you".
+
+   A "library" means a collection of software functions and/or data prepared so as to be conveniently linked with application programs (which use some of those functions and data) to form executables.
+
+   The "Library", below, refers to any such software library or work which has been distributed under these terms. A "work based on the Library" means either the Library or any derivative work under copyright law: that is to say, a work containing the Library or a portion of it, either verbatim or with modifications and/or translated straightforwardly into another language. (Hereinafter, translation is included without limitation in the term "modification".)
+
+   "Source code" for a work means the preferred form of the work for making modifications to it. For a library, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the library.
+
+   Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running a program using the Library is not restricted, and output from such a program is covered only if its contents constitute a work based on the Library (independent of the use of the Library in a tool for writing it). Whether that is true depends on what the Library does and what the program that uses the Library does.
+
+   &lt;&lt;var;name="bullet";original="1.";match=".{0,20}"&gt;&gt; You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and distribute a copy of this License along with the Library.
+
+   You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+   &lt;&lt;var;name="bullet";original="2.";match=".{0,20}"&gt;&gt; You may modify your copy or copies of the Library or any portion of it, thus forming a work based on the Library, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+      &lt;&lt;var;name="bullet";original="a)";match=".{0,20}"&gt;&gt; The modified work must itself be a software library.
+
+      &lt;&lt;var;name="bullet";original="b)";match=".{0,20}"&gt;&gt; You must cause the files modified to carry prominent notices stating that you changed the files and the date of any change.
+
+      &lt;&lt;var;name="bullet";original="c)";match=".{0,20}"&gt;&gt; You must cause the whole of the work to be licensed at no charge to all third parties under the terms of this License.
+
+      &lt;&lt;var;name="bullet";original="d)";match=".{0,20}"&gt;&gt; If a facility in the modified Library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful.
+
+      (For example, a function in a library to compute square roots has a purpose that is entirely well-defined independent of the application. Therefore, Subsection 2d requires that any application-supplied function or table used by this function must be optional: if the application does not supply it, the square root function must still compute square roots.)
+
+   These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Library, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Library, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+   Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Library.
+
+   In addition, mere aggregation of another work not based on the Library with the Library (or with a work based on the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+   &lt;&lt;var;name="bullet";original="3.";match=".{0,20}"&gt;&gt; You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if you wish.) Do not make any other change in these notices.
+
+   Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU General Public License applies to all subsequent copies and derivative works made from that copy.
+
+   This option is useful when you wish to copy part of the code of the Library into a program that is not a library.
+
+   &lt;&lt;var;name="bullet";original="4.";match=".{0,20}"&gt;&gt; You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange.
+
+   If distribution of object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place satisfies the requirement to distribute the source code, even though third parties are not compelled to copy the source along with the object code.
+
+   &lt;&lt;var;name="bullet";original="5.";match=".{0,20}"&gt;&gt; A program that contains no derivative of any portion of the Library, but is designed to work with the Library by being compiled or linked with it, is called a "work that uses the Library". Such a work, in isolation, is not a derivative work of the Library, and therefore falls outside the scope of this License.
+
+   However, linking a "work that uses the Library" with the Library creates an executable that is a derivative of the Library (because it contains portions of the Library), rather than a "work that uses the library". The executable is therefore covered by this License. Section 6 states terms for distribution of such executables.
+
+   When a "work that uses the Library" uses material from a header file that is part of the Library, the object code for the work may be a derivative work of the Library even though the source code is not. Whether this is true is especially significant if the work can be linked without the Library, or if the work is itself a library. The threshold for this to be true is not precisely defined by law.
+
+   If such an object file uses only numerical parameters, data structure layouts and accessors, and small macros and small inline functions (ten lines or less in length), then the use of the object file is unrestricted, regardless of whether it is legally a derivative work. (Executables containing this object code plus portions of the Library will still fall under Section 6.)
+
+   Otherwise, if the work is a derivative of the Library, you may distribute the object code for the work under the terms of Section 6. Any executables containing that work also fall under Section 6, whether or not they are linked directly with the Library itself.
+
+   &lt;&lt;var;name="bullet";original="6.";match=".{0,20}"&gt;&gt; As an exception to the Sections above, you may also compile or link a "work that uses the Library" with the Library to produce a work containing portions of the Library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's own use and reverse engineering for debugging such modifications.
+
+   You must give prominent notice with each copy of the work that the Library is used in it and that the Library and its use are covered by this License. You must supply a copy of this License. If the work during execution displays copyright notices, you must include the copyright notice for the Library among them, as well as a reference directing the user to the copy of this License. Also, you must do one of these things:
+
+      &lt;&lt;var;name="bullet";original="a)";match=".{0,20}"&gt;&gt; Accompany the work with the complete corresponding machine-readable source code for the Library including whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the work is an executable linked with the Library, with the complete machine-readable "work that uses the Library", as object code and/or source code, so that the user can modify the Library and then relink to produce a modified executable containing the modified Library. (It is understood that the user who changes the contents of definitions files in the Library will not necessarily be able to recompile the application to use the modified definitions.)
+
+      &lt;&lt;var;name="bullet";original="b)";match=".{0,20}"&gt;&gt; Accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of performing this distribution.
+
+      &lt;&lt;var;name="bullet";original="c)";match=".{0,20}"&gt;&gt; If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place.
+
+      &lt;&lt;var;name="bullet";original="d)";match=".{0,20}"&gt;&gt; Verify that the user has already received a copy of these materials or that you have already sent this user a copy.
+
+   For an executable, the required form of the "work that uses the Library" must include any data and utility programs needed for reproducing the executable from it. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+   It may happen that this requirement contradicts the license restrictions of other proprietary libraries that do not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library together in an executable that you distribute.
+
+   &lt;&lt;var;name="bullet";original="7.";match=".{0,20}"&gt;&gt; You may place library facilities that are a work based on the Library side-by-side in a single library together with other library facilities not covered by this License, and distribute such a combined library, provided that the separate distribution of the work based on the Library and of the other library facilities is otherwise permitted, and provided that you do these two things:
+
+      &lt;&lt;var;name="bullet";original="a)";match=".{0,20}"&gt;&gt; Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities. This must be distributed under the terms of the Sections above.
+
+      &lt;&lt;var;name="bullet";original="b)";match=".{0,20}"&gt;&gt; Give prominent notice with the combined library of the fact that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+   &lt;&lt;var;name="bullet";original="8.";match=".{0,20}"&gt;&gt; You may not copy, modify, sublicense, link with, or distribute the Library except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or distribute the Library is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+   &lt;&lt;var;name="bullet";original="9.";match=".{0,20}"&gt;&gt; You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Library or works based on it.
+
+   &lt;&lt;var;name="bullet";original="10.";match=".{0,20}"&gt;&gt; Each time you redistribute the Library (or any work based on the Library), the recipient automatically receives a license from the original licensor to copy, distribute, link with or modify the Library subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties to this License.
+
+   &lt;&lt;var;name="bullet";original="11.";match=".{0,20}"&gt;&gt; If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license would not permit royalty-free redistribution of the Library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Library.
+
+   If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply, and the section as a whole is intended to apply in other circumstances.
+
+   It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+   This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+   &lt;&lt;var;name="bullet";original="12.";match=".{0,20}"&gt;&gt; If the distribution and/or use of the Library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Library under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+   &lt;&lt;var;name="bullet";original="13.";match=".{0,20}"&gt;&gt; The Free Software Foundation may publish revised and/or new versions of the Library General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+   Each version is given a distinguishing version number. If the Library specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Library does not specify a license version number, you may choose any version ever published by the Free Software Foundation.
+
+   &lt;&lt;var;name="bullet";original="14.";match=".{0,20}"&gt;&gt; If you wish to incorporate parts of the Library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+   NO WARRANTY
+
+   &lt;&lt;var;name="bullet";original="15.";match=".{0,20}"&gt;&gt; BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+   &lt;&lt;var;name="bullet";original="16.";match=".{0,20}"&gt;&gt; IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.&lt;&lt;beginOptional&gt;&gt; END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Libraries
+
+If you develop a new library, and you want it to be of the greatest possible use to the public, we recommend making it free software that everyone can redistribute and change. You can do so by permitting redistribution under these terms (or, alternatively, under the terms of the ordinary General Public License).
+
+To apply these terms, attach the following notices to the library. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+one line to give the library's name and an idea of what it does.
+
+Copyright (C) year name of author
+
+This library is free software; you can redistribute it and/or modify it under the terms of the GNU Library General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the library, if necessary. Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in
+
+the library `Frob' (a library for tweaking knobs) written
+
+by James Random Hacker.
+
+signature of Ty Coon, 1 April 1990
+
+Ty Coon, President of Vice
+
+That's all there is to it!&lt;&lt;endOptional&gt;&gt;</spdx:standardLicenseTemplate>
+                    <spdx:isDeprecatedLicenseId rdf:datatype=
+                    "http://www.w3.org/2001/XMLSchema#boolean"
+                    >false</spdx:isDeprecatedLicenseId>
+                    <spdx:standardLicenseHeaderTemplate>Copyright (C) &lt;&lt;var;name="copyright";original="year name of author";match=".+"&gt;&gt;
+
+This library is free software; you can redistribute it and/or modify it under the terms of the GNU Library General Public License as published by the Free Software Foundation; version 2.
+
+This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.</spdx:standardLicenseHeaderTemplate>
+                    <spdx:standardLicenseHeader>Copyright (C) year name of author
+
+This library is free software; you can redistribute it and/or modify it under the terms of the GNU Library General Public License as published by the Free Software Foundation; version 2.
+
+This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.</spdx:standardLicenseHeader>
+                    <spdx:isOsiApproved rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                    >true</spdx:isOsiApproved>
+                    <rdfs:comment>This license was released: June 1991. This license has been superseded by LGPL-2.1. This license identifier refers to the choice to use the code under LGPL-2.0-only, as distinguished from use of code under LGPL-2.0-or-later (i.e., LGPL-2.0 or some later version). The license notice (as seen in the Standard License Header field below) states which of these applies to the code in the file. The example in the exhibit to the license shows the license notice for the "or later" approach.</rdfs:comment>
+                    <spdx:crossRef>
+                      <spdx:CrossRef>
+                        <spdx:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+                        >0</spdx:order>
+                        <spdx:timestamp>2020-11-25 - 21:55:42</spdx:timestamp>
+                        <spdx:url>https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</spdx:url>
+                        <spdx:match>true</spdx:match>
+                        <spdx:isWayBackLink rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                        >false</spdx:isWayBackLink>
+                        <spdx:isValid rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                        >true</spdx:isValid>
+                        <spdx:isLive rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                        >true</spdx:isLive>
+                      </spdx:CrossRef>
+                    </spdx:crossRef>
+                    <spdx:name>GNU Library General Public License v2 only</spdx:name>
+                  </spdx:ListedLicense>
+                </spdx:member>
+              </spdx:DisjunctiveLicenseSet>
+            </spdx:licenseConcluded>
+            <spdx:downloadLocation>http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz</spdx:downloadLocation>
+            <spdx:relationship>
+              <spdx:Relationship>
+                <spdx:relatedSpdxElement>
+                  <spdx:File rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-JenaLib">
+                    <spdx:licenseConcluded>
+                      <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-1">
+                        <spdx:licenseId>LicenseRef-1</spdx:licenseId>
+                        <spdx:extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/</spdx:extractedText>
+                      </spdx:ExtractedLicensingInfo>
+                    </spdx:licenseConcluded>
+                    <spdx:licenseComments>This license is used by Jena</spdx:licenseComments>
+                    <spdx:checksum>
+                      <spdx:Checksum>
+                        <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+                        <spdx:checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</spdx:checksumValue>
+                      </spdx:Checksum>
+                    </spdx:checksum>
+                    <spdx:fileContributor>Hewlett Packard Inc.</spdx:fileContributor>
+                    <spdx:fileType rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
+                    <spdx:copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</spdx:copyrightText>
+                    <spdx:fileContributor>Apache Software Foundation</spdx:fileContributor>
+                    <spdx:licenseInfoInFile rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-1"/>
+                    <spdx:relationship>
+                      <spdx:Relationship>
+                        <spdx:relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package"/>
+                        <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_contains"/>
+                      </spdx:Relationship>
+                    </spdx:relationship>
+                    <rdfs:comment>This file belongs to Jena</rdfs:comment>
+                    <spdx:fileName>./lib-source/jena-2.6.3-sources.jar</spdx:fileName>
+                  </spdx:File>
+                </spdx:relatedSpdxElement>
+                <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_contains"/>
+              </spdx:Relationship>
+            </spdx:relationship>
+            <spdx:externalRef>
+              <spdx:ExternalRef>
+                <spdx:referenceCategory rdf:resource="http://spdx.org/rdf/terms#referenceCategory_other"/>
+                <rdfs:comment>This is the external ref for Acme</rdfs:comment>
+                <spdx:referenceType rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge"/>
+                <spdx:referenceLocator>acmecorp/acmenator/4.1.3-alpha</spdx:referenceLocator>
+              </spdx:ExternalRef>
+            </spdx:externalRef>
+            <spdx:versionInfo>2.11.1</spdx:versionInfo>
+            <spdx:licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/GPL-2.0-only"/>
+            <spdx:filesAnalyzed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >true</spdx:filesAnalyzed>
+            <spdx:licenseComments>The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change.</spdx:licenseComments>
+            <spdx:packageVerificationCode>
+              <spdx:PackageVerificationCode>
+                <spdx:packageVerificationCodeValue>d6a770ba38583ed4bb4525bd96e50461655d2758</spdx:packageVerificationCodeValue>
+                <spdx:packageVerificationCodeExcludedFile>./package.spdx</spdx:packageVerificationCodeExcludedFile>
+              </spdx:PackageVerificationCode>
+            </spdx:packageVerificationCode>
+            <doap:homepage>http://ftp.gnu.org/gnu/glibc</doap:homepage>
+            <spdx:externalRef>
+              <spdx:ExternalRef>
+                <spdx:referenceCategory rdf:resource="http://spdx.org/rdf/terms#referenceCategory_security"/>
+                <spdx:referenceType rdf:resource="http://spdx.org/rdf/references/cpe23Type"/>
+                <spdx:referenceLocator>cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*</spdx:referenceLocator>
+              </spdx:ExternalRef>
+            </spdx:externalRef>
+            <spdx:licenseInfoFromFiles rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-1"/>
+            <spdx:name>glibc</spdx:name>
+            <spdx:supplier>Person: Jane Doe (jane.doe@example.com)</spdx:supplier>
+            <spdx:annotation>
+              <spdx:Annotation>
+                <spdx:annotator>Person: Package Commenter</spdx:annotator>
+                <rdfs:comment>Package level annotation</rdfs:comment>
+                <spdx:annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_other"/>
+                <spdx:annotationDate>2011-01-29T18:30:22Z</spdx:annotationDate>
+              </spdx:Annotation>
+            </spdx:annotation>
+            <spdx:licenseDeclared>
+              <spdx:ConjunctiveLicenseSet>
+                <spdx:member rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-3"/>
+                <spdx:member rdf:resource="http://spdx.org/licenses/LGPL-2.0-only"/>
+              </spdx:ConjunctiveLicenseSet>
+            </spdx:licenseDeclared>
+            <spdx:attributionText>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</spdx:attributionText>
+            <spdx:originator>Organization: ExampleCodeInspect (contact@example.com)</spdx:originator>
+            <spdx:hasFile rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+            <spdx:licenseInfoFromFiles>
+              <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-2">
+                <spdx:licenseId>LicenseRef-2</spdx:licenseId>
+                <spdx:extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+� Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</spdx:extractedText>
+              </spdx:ExtractedLicensingInfo>
+            </spdx:licenseInfoFromFiles>
+            <spdx:hasFile rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-JenaLib"/>
+            <spdx:hasFile>
+              <spdx:File rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-CommonsLangSrc">
+                <spdx:checksum>
+                  <spdx:Checksum>
+                    <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+                    <spdx:checksumValue>c2b4e1c67a2d28fced849ee1bb76e7391b93f125</spdx:checksumValue>
+                  </spdx:Checksum>
+                </spdx:checksum>
+                <spdx:noticeText>Apache Commons Lang
+Copyright 2001-2011 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software from the Spring Framework,
+under the Apache License 2.0 (see: StringUtils.containsWhitespace())</spdx:noticeText>
+                <spdx:licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+                <spdx:licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+                <spdx:fileContributor>Apache Software Foundation</spdx:fileContributor>
+                <spdx:relationship>
+                  <spdx:Relationship>
+                    <spdx:relatedSpdxElement rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
+                    <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_generatedFrom"/>
+                  </spdx:Relationship>
+                </spdx:relationship>
+                <spdx:fileName>./lib-source/commons-lang3-3.1-sources.jar</spdx:fileName>
+                <spdx:copyrightText>Copyright 2001-2011 The Apache Software Foundation</spdx:copyrightText>
+                <rdfs:comment>This file is used by Jena</rdfs:comment>
+                <spdx:fileType rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
+              </spdx:File>
+            </spdx:hasFile>
+            <spdx:checksum>
+              <spdx:Checksum>
+                <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_md5"/>
+                <spdx:checksumValue>624c1abb3664f4b35547e7c73864ad24</spdx:checksumValue>
+              </spdx:Checksum>
+            </spdx:checksum>
+            <spdx:relationship>
+              <spdx:Relationship>
+                <spdx:relatedSpdxElement>
+                  <spdx:Package rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Saxon">
+                    <spdx:name>Saxon</spdx:name>
+                    <spdx:description>The Saxon package is a collection of tools for processing XML documents.</spdx:description>
+                    <doap:homepage>http://saxon.sourceforge.net/</doap:homepage>
+                    <spdx:versionInfo>8.8</spdx:versionInfo>
+                    <spdx:licenseComments>Other versions available for a commercial license</spdx:licenseComments>
+                    <spdx:downloadLocation>https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download</spdx:downloadLocation>
+                    <spdx:packageFileName>saxonB-8.8.zip</spdx:packageFileName>
+                    <spdx:licenseConcluded>
+                      <spdx:ListedLicense rdf:about="http://spdx.org/licenses/MPL-1.0">
+                        <rdfs:seeAlso>https://opensource.org/licenses/MPL-1.0</rdfs:seeAlso>
+                        <spdx:licenseText>MOZILLA PUBLIC LICENSE
+Version 1.0
+
+1. Definitions.
+
+     1.1. ``Contributor'' means each entity that creates or contributes to the creation of Modifications.
+
+     1.2. ``Contributor Version'' means the combination of the Original Code, prior Modifications used by a Contributor, and the Modifications made by that particular Contributor.
+
+     1.3. ``Covered Code'' means the Original Code or Modifications or the combination of the Original Code and Modifications, in each case including portions thereof.
+
+     1.4. ``Electronic Distribution Mechanism'' means a mechanism generally accepted in the software development community for the electronic transfer of data.
+
+     1.5. ``Executable'' means Covered Code in any form other than Source Code.
+
+     1.6. ``Initial Developer'' means the individual or entity identified as the Initial Developer in the Source Code notice required by Exhibit A.
+
+     1.7. ``Larger Work'' means a work which combines Covered Code or portions thereof with code not governed by the terms of this License.
+
+     1.8. ``License'' means this document.
+
+     1.9. ``Modifications'' means any addition to or deletion from the substance or structure of either the Original Code or any previous Modifications. When Covered Code is released as a series of files, a Modification is:
+
+          A. Any addition to or deletion from the contents of a file containing Original Code or previous Modifications.
+
+          B. Any new file that contains any part of the Original Code or previous Modifications.
+
+     1.10. ``Original Code'' means Source Code of computer software code which is described in the Source Code notice required by Exhibit A as Original Code, and which, at the time of its release under this License is not already Covered Code governed by this License.
+
+     1.11. ``Source Code'' means the preferred form of the Covered Code for making modifications to it, including all modules it contains, plus any associated interface definition files, scripts used to control compilation and installation of an Executable, or a list of source code differential comparisons against either the Original Code or another well known, available Covered Code of the Contributor's choice. The Source Code can be in a compressed or archival form, provided the appropriate decompression or de-archiving software is widely available for no charge.
+
+     1.12. ``You'' means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License or a future version of this License issued under Section 6.1. For legal entities, ``You'' includes any entity which controls, is controlled by, or is under common control with You. For purposes of this definition, ``control'' means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of fifty percent (50%) or more of the outstanding shares or beneficial ownership of such entity.
+
+2. Source Code License.
+
+     2.1. The Initial Developer Grant.
+The Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive license, subject to third party intellectual property claims:
+
+          (a) to use, reproduce, modify, display, perform, sublicense and distribute the Original Code (or portions thereof) with or without Modifications, or as part of a Larger Work; and
+
+          (b) under patents now or hereafter owned or controlled by Initial Developer, to make, have made, use and sell (``Utilize'') the Original Code (or portions thereof), but solely to the extent that any such patent is reasonably necessary to enable You to Utilize 	the Original Code (or portions thereof) and not to any greater extent that may be necessary to Utilize further Modifications or combinations.
+
+     2.2. Contributor Grant.
+Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license, subject to third party intellectual property claims:
+
+          (a) to use, reproduce, modify, display, perform, sublicense and distribute the Modifications created by such Contributor (or portions thereof) either on an unmodified basis, with other Modifications, as Covered Code or as part of a Larger Work; and
+
+          (b) under patents now or hereafter owned or controlled by Contributor, to Utilize the Contributor Version (or portions thereof), but solely to the extent that any such patent is reasonably necessary to enable You to Utilize the Contributor Version (or portions 	thereof), and not to any greater extent that may be necessary to Utilize further Modifications or combinations.
+
+3. Distribution Obligations.
+
+     3.1. Application of License.
+     The Modifications which You create or to which You contribute are governed by the terms of this License, including without limitation Section 2.2. The Source Code version of Covered Code may be distributed only under the terms of this License or a future version of this License released under Section 6.1, and You must include a copy of this License with every copy of the Source Code You distribute. You may not offer or impose any terms on any Source Code version that alters or restricts the applicable version of this License or the recipients' rights hereunder. However, You may include an additional document offering the additional rights described in Section 3.5.
+
+     3.2. Availability of Source Code.
+     Any Modification which You create or to which You contribute must be made available in Source Code form under the terms of this License either on the same media as an Executable version or via an accepted Electronic Distribution Mechanism to anyone to whom you made an Executable version available; and if made available via Electronic Distribution Mechanism, must remain available for at least twelve (12) months after the date it initially became available, or at least six (6) months after a subsequent version of that particular Modification has been made available to such recipients. You are responsible for ensuring that the Source Code version remains available even if the Electronic Distribution Mechanism is maintained by a third party.
+
+     3.3. Description of Modifications.
+     You must cause all Covered Code to which you contribute to contain a file documenting the changes You made to create that Covered Code and the date of any change. You must include a prominent statement that the Modification is derived, directly or indirectly, from Original Code provided by the Initial Developer and including the name of the Initial Developer in (a) the Source Code, and (b) in any notice in an Executable version or related documentation in which You describe the origin or ownership of the Covered Code.
+
+     3.4. Intellectual Property Matters
+
+          (a) Third Party Claims.
+          If You have knowledge that a party claims an intellectual property right in particular functionality or code (or its utilization under this License), you must include a text file with the source code distribution titled ``LEGAL'' which describes the claim and the party making the claim in sufficient detail that a recipient will know whom to contact. If you obtain such knowledge after You make Your Modification available as described in Section 3.2, You shall promptly modify the LEGAL file in all copies You make available thereafter and shall take other steps (such as notifying appropriate mailing lists or newsgroups) reasonably calculated to inform those who received the Covered Code that new knowledge has been obtained.
+
+          (b) Contributor APIs.
+          If Your Modification is an application programming interface and You own or control patents which are reasonably necessary to implement that API, you must also include this information in the LEGAL file.
+
+     3.5. Required Notices.
+     You must duplicate the notice in Exhibit A in each file of the Source Code, and this License in any documentation for the Source Code, where You describe recipients' rights relating to Covered Code. If You created one or more Modification(s), You may add your name as a Contributor to the notice described in Exhibit A. If it is not possible to put such notice in a particular Source Code file due to its structure, then you must include such notice in a location (such as a relevant directory file) where a user would be likely to look for such a notice. You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Code. However, You may do so only on Your own behalf, and not on behalf of the Initial Developer or any Contributor. You must make it absolutely clear than any such warranty, support, indemnity or liability obligation is offered by You alone, and You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of warranty, support, indemnity or liability terms You offer.
+
+     3.6. Distribution of Executable Versions.
+     You may distribute Covered Code in Executable form only if the requirements of Section 3.1-3.5 have been met for that Covered Code, and if You include a notice stating that the Source Code version of the Covered Code is available under the terms of this License, including a description of how and where You have fulfilled the obligations of Section 3.2. The notice must be conspicuously included in any notice in an Executable version, related documentation or collateral in which You describe recipients' rights relating to the Covered Code. You may distribute the Executable version of Covered Code under a license of Your choice, which may contain terms different from this License, provided that You are in compliance with the terms of this License and that the license for the Executable version does not attempt to limit or alter the recipient's rights in the Source Code version from the rights set forth in this License. If You distribute the Executable version under a different license You must make it absolutely clear that any terms which differ from this License are offered by You alone, not by the Initial Developer or any Contributor. You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of any such terms You offer.
+
+     3.7. Larger Works.
+     You may create a Larger Work by combining Covered Code with other code not governed by the terms of this License and distribute the Larger Work as a single product. In such a case, You must make sure the requirements of this License are fulfilled for the Covered Code.
+
+4. Inability to Comply Due to Statute or Regulation.
+If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Covered Code due to statute or regulation then You must: (a) comply with the terms of this License to the maximum extent possible; and (b) describe the limitations and the code they affect. Such description must be included in the LEGAL file described in Section 3.4 and must be included with all distributions of the Source Code. Except to the extent prohibited by statute or regulation, such description must be sufficiently detailed for a recipient of ordinary skill to be able to understand it.
+
+5. Application of this License.
+This License applies to code to which the Initial Developer has attached the notice in Exhibit A, and to related Covered Code.
+
+6. Versions of the License.
+
+     6.1. New Versions.
+     Netscape Communications Corporation (``Netscape'') may publish revised and/or new versions of the License from time to time. Each version will be given a distinguishing version number.
+
+     6.2. Effect of New Versions.
+     Once Covered Code has been published under a particular version of the License, You may always continue to use it under the terms of that version. You may also choose to use such Covered Code under the terms of any subsequent version of the License published by Netscape. No one other than Netscape has the right to modify the terms applicable to Covered Code created under this License.
+
+     6.3. Derivative Works.
+     If you create or use a modified version of this License (which you may only do in order to apply it to code which is not already Covered Code governed by this License), you must (a) rename Your license so that the phrases ``Mozilla'', ``MOZILLAPL'', ``MOZPL'', ``Netscape'', ``NPL'' or any confusingly similar phrase do not appear anywhere in your license and (b) otherwise make it clear that your version of the license contains terms which differ from the Mozilla Public License and Netscape Public License. (Filling in the name of the Initial Developer, Original Code or Contributor in the notice described in Exhibit A shall not of themselves be deemed to be modifications of this License.)
+
+7. DISCLAIMER OF WARRANTY.
+COVERED CODE IS PROVIDED UNDER THIS LICENSE ON AN ``AS IS'' BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED CODE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED CODE IS WITH YOU. SHOULD ANY COVERED CODE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY COVERED CODE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
+
+8. TERMINATION.
+This License and the rights granted hereunder will terminate automatically if You fail to comply with terms herein and fail to cure such breach within 30 days of becoming aware of the breach. All sublicenses to the Covered Code which are properly granted shall survive any termination of this License. Provisions which, by their nature, must remain in effect beyond the termination of this License shall survive.
+
+9. LIMITATION OF LIABILITY.
+UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL THE INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED CODE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO YOU OR ANY OTHER PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THAT EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
+
+10. U.S. GOVERNMENT END USERS.
+The Covered Code is a ``commercial item,'' as that term is defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of ``commercial computer software'' and ``commercial computer software documentation,'' as such terms are used in 48 C.F.R. 12.212 (Sept. 1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1 through 227.7202-4 (June 1995), all U.S. Government End Users acquire Covered Code with only those rights set forth herein.
+
+11. MISCELLANEOUS.
+This License represents the complete agreement concerning subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. This License shall be governed by California law provisions (except to the extent applicable law, if any, provides otherwise), excluding its conflict-of-law provisions. With respect to disputes in which at least one party is a citizen of, or an entity chartered or registered to do business in, the United States of America: (a) unless otherwise agreed in writing, all disputes relating to this License (excepting any dispute relating to intellectual property rights) shall be subject to final and binding arbitration, with the losing party paying all costs of arbitration; (b) any arbitration relating to this Agreement shall be held in Santa Clara County, California, under the auspices of JAMS/EndDispute; and (c) any litigation relating to this Agreement shall be subject to the jurisdiction of the Federal Courts of the Northern District of California, with venue lying in Santa Clara County, California, with the losing party responsible for costs, including without limitation, court costs and reasonable attorneys fees and expenses. The application of the United Nations Convention on Contracts for the International Sale of Goods is expressly excluded. Any law or regulation which provides that the language of a contract shall be construed against the drafter shall not apply to this License.
+
+12. RESPONSIBILITY FOR CLAIMS.
+Except in cases where another Contributor has failed to comply with Section 3.4, You are responsible for damages arising, directly or indirectly, out of Your utilization of rights under this License, based on the number of copies of Covered Code you made available, the revenues you received from utilizing such rights, and other relevant factors. You agree to work with affected parties to distribute responsibility on an equitable basis.
+
+EXHIBIT A.
+
+``The contents of this file are subject to the Mozilla Public License Version 1.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.mozilla.org/MPL/
+
+Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the specific language governing rights and limitations under the License.
+
+The Original Code is ______________________________________.
+
+The Initial Developer of the Original Code is ________________________. Portions created by ______________________ are Copyright (C) ______ _______________________. All Rights Reserved.
+
+Contributor(s): ______________________________________.''
+</spdx:licenseText>     <spdx:crossRef>
+                          <spdx:CrossRef>
+                            <spdx:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+                            >0</spdx:order>
+                            <spdx:timestamp>2020-11-25 - 21:52:42</spdx:timestamp>
+                            <spdx:url>http://www.mozilla.org/MPL/MPL-1.0.html</spdx:url>
+                            <spdx:match>true</spdx:match>
+                            <spdx:isWayBackLink rdf:datatype=
+                            "http://www.w3.org/2001/XMLSchema#boolean"
+                            >false</spdx:isWayBackLink>
+                            <spdx:isValid rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                            >true</spdx:isValid>
+                            <spdx:isLive rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                            >false</spdx:isLive>
+                          </spdx:CrossRef>
+                        </spdx:crossRef>
+                        <rdfs:seeAlso>http://www.mozilla.org/MPL/MPL-1.0.html</rdfs:seeAlso>
+                        <rdfs:comment>This license has been superseded by v1.1</rdfs:comment>
+                        <spdx:crossRef>
+                          <spdx:CrossRef>
+                            <spdx:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+                            >1</spdx:order>
+                            <spdx:timestamp>2020-11-25 - 21:52:43</spdx:timestamp>
+                            <spdx:url>https://opensource.org/licenses/MPL-1.0</spdx:url>
+                            <spdx:match>true</spdx:match>
+                            <spdx:isWayBackLink rdf:datatype=
+                            "http://www.w3.org/2001/XMLSchema#boolean"
+                            >false</spdx:isWayBackLink>
+                            <spdx:isValid rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                            >true</spdx:isValid>
+                            <spdx:isLive rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                            >true</spdx:isLive>
+                          </spdx:CrossRef>
+                        </spdx:crossRef>
+                        <spdx:name>Mozilla Public License 1.0</spdx:name>
+                        <spdx:isOsiApproved rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                        >true</spdx:isOsiApproved>
+                        <spdx:standardLicenseHeaderTemplate>&lt;&lt;beginOptional&gt;&gt;"&lt;&lt;endOptional&gt;&gt;The contents of this file are subject to the Mozilla Public License Version 1.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.mozilla.org/MPL/
+
+Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the specific language governing rights and limitations under the License.
+
+The Original Code is &lt;&lt;var;name="code";original="_____";match=".+"&gt;&gt; . The Initial Developer of the Original Code is &lt;&lt;var;name="InitialDeveloper";original="_____";match=".+"&gt;&gt; . Portions created by &lt;&lt;var;name="createdby";original="_____";match=".+"&gt;&gt; are Copyright (C) &lt;&lt;var;name="copyright";original="_____";match=".+"&gt;&gt; . All Rights Reserved. Contributor(s): &lt;&lt;var;name="contributor";original="_____";match=".+"&gt;&gt; .&lt;&lt;beginOptional&gt;&gt;"&lt;&lt;endOptional&gt;&gt;</spdx:standardLicenseHeaderTemplate>
+                        <spdx:standardLicenseTemplate>&lt;&lt;beginOptional&gt;&gt; MOZILLA PUBLIC LICENSE
+
+Version 1.0&lt;&lt;endOptional&gt;&gt;
+
+   &lt;&lt;var;name="bullet";original="1.";match=".{0,20}"&gt;&gt; Definitions.
+
+      &lt;&lt;var;name="bullet";original="1.1.";match=".{0,20}"&gt;&gt; "Contributor" means each entity that creates or contributes to the creation of Modifications.
+
+      &lt;&lt;var;name="bullet";original="1.2.";match=".{0,20}"&gt;&gt; "Contributor Version" means the combination of the Original Code, prior Modifications used by a Contributor, and the Modifications made by that particular Contributor.
+
+      &lt;&lt;var;name="bullet";original="1.3.";match=".{0,20}"&gt;&gt; "Covered Code" means the Original Code or Modifications or the combination of the Original Code and Modifications, in each case including portions thereof.
+
+      &lt;&lt;var;name="bullet";original="1.4.";match=".{0,20}"&gt;&gt; "Electronic Distribution Mechanism" means a mechanism generally accepted in the software development community for the electronic transfer of data.
+
+      &lt;&lt;var;name="bullet";original="1.5.";match=".{0,20}"&gt;&gt; "Executable" means Covered Code in any form other than Source Code.
+
+      &lt;&lt;var;name="bullet";original="1.6.";match=".{0,20}"&gt;&gt; "Initial Developer" means the individual or entity identified as the Initial Developer in the Source Code notice required by Exhibit A.
+
+      &lt;&lt;var;name="bullet";original="1.7.";match=".{0,20}"&gt;&gt; "Larger Work" means a work which combines Covered Code or portions thereof with code not governed by the terms of this License.
+
+      &lt;&lt;var;name="bullet";original="1.8.";match=".{0,20}"&gt;&gt; "License" means this document.
+
+      &lt;&lt;var;name="bullet";original="1.9.";match=".{0,20}"&gt;&gt; "Modifications" means any addition to or deletion from the substance or structure of either the Original Code or any previous Modifications. When Covered Code is released as a series of files, a Modification is:
+
+         &lt;&lt;var;name="bullet";original="A.";match=".{0,20}"&gt;&gt; Any addition to or deletion from the contents of a file containing Original Code or previous Modifications.
+
+         &lt;&lt;var;name="bullet";original="B.";match=".{0,20}"&gt;&gt; Any new file that contains any part of the Original Code or previous Modifications.
+
+      &lt;&lt;var;name="bullet";original="1.10.";match=".{0,20}"&gt;&gt; "Original Code" means Source Code of computer software code which is described in the Source Code notice required by Exhibit A as Original Code, and which, at the time of its release under this License is not already Covered Code governed by this License.
+
+      &lt;&lt;var;name="bullet";original="1.11.";match=".{0,20}"&gt;&gt; "Source Code" means the preferred form of the Covered Code for making modifications to it, including all modules it contains, plus any associated interface definition files, scripts used to control compilation and installation of an Executable, or a list of source code differential comparisons against either the Original Code or another well known, available Covered Code of the Contributor's choice. The Source Code can be in a compressed or archival form, provided the appropriate decompression or de-archiving software is widely available for no charge.
+
+      &lt;&lt;var;name="bullet";original="1.12.";match=".{0,20}"&gt;&gt; "You" means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License or a future version of this License issued under Section 6.1. For legal entities, "You" includes any entity which controls, is controlled by, or is under common control with You. For purposes of this definition, "control" means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of fifty percent (50%) or more of the outstanding shares or beneficial ownership of such entity.
+
+   &lt;&lt;var;name="bullet";original="2.";match=".{0,20}"&gt;&gt; Source Code License.
+
+      &lt;&lt;var;name="bullet";original="2.1.";match=".{0,20}"&gt;&gt; The Initial Developer Grant.
+
+      The Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive license, subject to third party intellectual property claims:
+
+         &lt;&lt;var;name="bullet";original="(a)";match=".{0,20}"&gt;&gt; to use, reproduce, modify, display, perform, sublicense and distribute the Original Code (or portions thereof) with or without Modifications, or as part of a Larger Work; and
+
+         &lt;&lt;var;name="bullet";original="(b)";match=".{0,20}"&gt;&gt; under patents now or hereafter owned or controlled by Initial Developer, to make, have made, use and sell ("Utilize") the Original Code (or portions thereof), but solely to the extent that any such patent is reasonably necessary to enable You to Utilize the Original Code (or portions thereof) and not to any greater extent that may be necessary to Utilize further Modifications or combinations.
+
+      &lt;&lt;var;name="bullet";original="2.2.";match=".{0,20}"&gt;&gt; Contributor Grant.
+
+      Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license, subject to third party intellectual property claims:
+
+         &lt;&lt;var;name="bullet";original="(a)";match=".{0,20}"&gt;&gt; to use, reproduce, modify, display, perform, sublicense and distribute the Modifications created by such Contributor (or portions thereof) either on an unmodified basis, with other Modifications, as Covered Code or as part of a Larger Work; and
+
+         &lt;&lt;var;name="bullet";original="(b)";match=".{0,20}"&gt;&gt; under patents now or hereafter owned or controlled by Contributor, to Utilize the Contributor Version (or portions thereof), but solely to the extent that any such patent is reasonably necessary to enable You to Utilize the Contributor Version (or portions thereof), and not to any greater extent that may be necessary to Utilize further Modifications or combinations.
+
+   &lt;&lt;var;name="bullet";original="3.";match=".{0,20}"&gt;&gt; Distribution Obligations.
+
+      &lt;&lt;var;name="bullet";original="3.1.";match=".{0,20}"&gt;&gt; Application of License.
+
+      The Modifications which You create or to which You contribute are governed by the terms of this License, including without limitation Section 2.2. The Source Code version of Covered Code may be distributed only under the terms of this License or a future version of this License released under Section 6.1, and You must include a copy of this License with every copy of the Source Code You distribute. You may not offer or impose any terms on any Source Code version that alters or restricts the applicable version of this License or the recipients' rights hereunder. However, You may include an additional document offering the additional rights described in Section 3.5.
+
+      &lt;&lt;var;name="bullet";original="3.2.";match=".{0,20}"&gt;&gt; Availability of Source Code.
+
+      Any Modification which You create or to which You contribute must be made available in Source Code form under the terms of this License either on the same media as an Executable version or via an accepted Electronic Distribution Mechanism to anyone to whom you made an Executable version available; and if made available via Electronic Distribution Mechanism, must remain available for at least twelve (12) months after the date it initially became available, or at least six (6) months after a subsequent version of that particular Modification has been made available to such recipients. You are responsible for ensuring that the Source Code version remains available even if the Electronic Distribution Mechanism is maintained by a third party.
+
+      &lt;&lt;var;name="bullet";original="3.3.";match=".{0,20}"&gt;&gt; Description of Modifications.
+
+      You must cause all Covered Code to which you contribute to contain a file documenting the changes You made to create that Covered Code and the date of any change. You must include a prominent statement that the Modification is derived, directly or indirectly, from Original Code provided by the Initial Developer and including the name of the Initial Developer in (a) the Source Code, and (b) in any notice in an Executable version or related documentation in which You describe the origin or ownership of the Covered Code.
+
+      &lt;&lt;var;name="bullet";original="3.4.";match=".{0,20}"&gt;&gt; Intellectual Property Matters
+
+         &lt;&lt;var;name="bullet";original="(a)";match=".{0,20}"&gt;&gt; Third Party Claims.
+
+         If You have knowledge that a party claims an intellectual property right in particular functionality or code (or its utilization under this License), you must include a text file with the source code distribution titled "LEGAL" which describes the claim and the party making the claim in sufficient detail that a recipient will know whom to contact. If you obtain such knowledge after You make Your Modification available as described in Section 3.2, You shall promptly modify the LEGAL file in all copies You make available thereafter and shall take other steps (such as notifying appropriate mailing lists or newsgroups) reasonably calculated to inform those who received the Covered Code that new knowledge has been obtained.
+
+         &lt;&lt;var;name="bullet";original="(b)";match=".{0,20}"&gt;&gt; Contributor APIs.
+
+         If Your Modification is an application programming interface and You own or control patents which are reasonably necessary to implement that API, you must also include this information in the LEGAL file.
+
+      &lt;&lt;var;name="bullet";original="3.5.";match=".{0,20}"&gt;&gt; Required Notices.
+
+      You must duplicate the notice in Exhibit A in each file of the Source Code, and this License in any documentation for the Source Code, where You describe recipients' rights relating to Covered Code. If You created one or more Modification(s), You may add your name as a Contributor to the notice described in Exhibit A. If it is not possible to put such notice in a particular Source Code file due to its structure, then you must include such notice in a location (such as a relevant directory file) where a user would be likely to look for such a notice. You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Code. However, You may do so only on Your own behalf, and not on behalf of the Initial Developer or any Contributor. You must make it absolutely clear than any such warranty, support, indemnity or liability obligation is offered by You alone, and You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of warranty, support, indemnity or liability terms You offer.
+
+      &lt;&lt;var;name="bullet";original="3.6.";match=".{0,20}"&gt;&gt; Distribution of Executable Versions.
+
+      You may distribute Covered Code in Executable form only if the requirements of Section 3.1-3.5 have been met for that Covered Code, and if You include a notice stating that the Source Code version of the Covered Code is available under the terms of this License, including a description of how and where You have fulfilled the obligations of Section 3.2. The notice must be conspicuously included in any notice in an Executable version, related documentation or collateral in which You describe recipients' rights relating to the Covered Code. You may distribute the Executable version of Covered Code under a license of Your choice, which may contain terms different from this License, provided that You are in compliance with the terms of this License and that the license for the Executable version does not attempt to limit or alter the recipient's rights in the Source Code version from the rights set forth in this License. If You distribute the Executable version under a different license You must make it absolutely clear that any terms which differ from this License are offered by You alone, not by the Initial Developer or any Contributor. You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of any such terms You offer.
+
+      &lt;&lt;var;name="bullet";original="3.7.";match=".{0,20}"&gt;&gt; Larger Works.
+
+      You may create a Larger Work by combining Covered Code with other code not governed by the terms of this License and distribute the Larger Work as a single product. In such a case, You must make sure the requirements of this License are fulfilled for the Covered Code.
+
+   &lt;&lt;var;name="bullet";original="4.";match=".{0,20}"&gt;&gt; Inability to Comply Due to Statute or Regulation.
+
+   If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Covered Code due to statute or regulation then You must: (a) comply with the terms of this License to the maximum extent possible; and (b) describe the limitations and the code they affect. Such description must be included in the LEGAL file described in Section 3.4 and must be included with all distributions of the Source Code. Except to the extent prohibited by statute or regulation, such description must be sufficiently detailed for a recipient of ordinary skill to be able to understand it.
+
+   &lt;&lt;var;name="bullet";original="5.";match=".{0,20}"&gt;&gt; Application of this License.
+
+   This License applies to code to which the Initial Developer has attached the notice in Exhibit A, and to related Covered Code.
+
+   &lt;&lt;var;name="bullet";original="6.";match=".{0,20}"&gt;&gt; Versions of the License.
+
+      &lt;&lt;var;name="bullet";original="6.1.";match=".{0,20}"&gt;&gt; New Versions.
+
+      Netscape Communications Corporation ("Netscape") may publish revised and/or new versions of the License from time to time. Each version will be given a distinguishing version number.
+
+      &lt;&lt;var;name="bullet";original="6.2.";match=".{0,20}"&gt;&gt; Effect of New Versions.
+
+      Once Covered Code has been published under a particular version of the License, You may always continue to use it under the terms of that version. You may also choose to use such Covered Code under the terms of any subsequent version of the License published by Netscape. No one other than Netscape has the right to modify the terms applicable to Covered Code created under this License.
+
+      &lt;&lt;var;name="bullet";original="6.3.";match=".{0,20}"&gt;&gt; Derivative Works.
+
+      If you create or use a modified version of this License (which you may only do in order to apply it to code which is not already Covered Code governed by this License), you must (a) rename Your license so that the phrases "Mozilla", "MOZILLAPL", "MOZPL", "Netscape", "NPL" or any confusingly similar phrase do not appear anywhere in your license and (b) otherwise make it clear that your version of the license contains terms which differ from the Mozilla Public License and Netscape Public License. (Filling in the name of the Initial Developer, Original Code or Contributor in the notice described in Exhibit A shall not of themselves be deemed to be modifications of this License.)
+
+   &lt;&lt;var;name="bullet";original="7.";match=".{0,20}"&gt;&gt; DISCLAIMER OF WARRANTY.
+
+   COVERED CODE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS" BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED CODE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED CODE IS WITH YOU. SHOULD ANY COVERED CODE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY COVERED CODE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
+
+   &lt;&lt;var;name="bullet";original="8.";match=".{0,20}"&gt;&gt; TERMINATION.
+
+   This License and the rights granted hereunder will terminate automatically if You fail to comply with terms herein and fail to cure such breach within 30 days of becoming aware of the breach. All sublicenses to the Covered Code which are properly granted shall survive any termination of this License. Provisions which, by their nature, must remain in effect beyond the termination of this License shall survive.
+
+   &lt;&lt;var;name="bullet";original="9.";match=".{0,20}"&gt;&gt; LIMITATION OF LIABILITY.
+
+   UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL THE INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED CODE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO YOU OR ANY OTHER PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THAT EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
+
+   &lt;&lt;var;name="bullet";original="10.";match=".{0,20}"&gt;&gt; U.S. GOVERNMENT END USERS.
+
+   The Covered Code is a "commercial item," as that term is defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of "commercial computer software" and "commercial computer software documentation," as such terms are used in 48 C.F.R. 12.212 (Sept. 1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1 through 227.7202-4 (June 1995), all U.S. Government End Users acquire Covered Code with only those rights set forth herein.
+
+   &lt;&lt;var;name="bullet";original="11.";match=".{0,20}"&gt;&gt; MISCELLANEOUS.
+
+   This License represents the complete agreement concerning subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. This License shall be governed by California law provisions (except to the extent applicable law, if any, provides otherwise), excluding its conflict-of-law provisions. With respect to disputes in which at least one party is a citizen of, or an entity chartered or registered to do business in, the United States of America: (a) unless otherwise agreed in writing, all disputes relating to this License (excepting any dispute relating to intellectual property rights) shall be subject to final and binding arbitration, with the losing party paying all costs of arbitration; (b) any arbitration relating to this Agreement shall be held in Santa Clara County, California, under the auspices of JAMS/EndDispute; and (c) any litigation relating to this Agreement shall be subject to the jurisdiction of the Federal Courts of the Northern District of California, with venue lying in Santa Clara County, California, with the losing party responsible for costs, including without limitation, court costs and reasonable attorneys fees and expenses. The application of the United Nations Convention on Contracts for the International Sale of Goods is expressly excluded. Any law or regulation which provides that the language of a contract shall be construed against the drafter shall not apply to this License.
+
+   &lt;&lt;var;name="bullet";original="12.";match=".{0,20}"&gt;&gt; RESPONSIBILITY FOR CLAIMS.
+
+   Except in cases where another Contributor has failed to comply with Section 3.4, You are responsible for damages arising, directly or indirectly, out of Your utilization of rights under this License, based on the number of copies of Covered Code you made available, the revenues you received from utilizing such rights, and other relevant factors. You agree to work with affected parties to distribute responsibility on an equitable basis.&lt;&lt;beginOptional&gt;&gt; EXHIBIT A.
+
+&lt;&lt;beginOptional&gt;&gt;"&lt;&lt;endOptional&gt;&gt;The contents of this file are subject to the Mozilla Public License Version 1.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.mozilla.org/MPL/
+
+Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the specific language governing rights and limitations under the License.
+
+The Original Code is &lt;&lt;var;name="code";original="_____";match=".+"&gt;&gt; . The Initial Developer of the Original Code is &lt;&lt;var;name="InitialDeveloper";original="_____";match=".+"&gt;&gt; . Portions created by &lt;&lt;var;name="createdby";original="_____";match=".+"&gt;&gt; are Copyright (C) &lt;&lt;var;name="copyright";original="_____";match=".+"&gt;&gt; . All Rights Reserved. Contributor(s): &lt;&lt;var;name="contributor";original="_____";match=".+"&gt;&gt; .&lt;&lt;beginOptional&gt;&gt;"&lt;&lt;endOptional&gt;&gt;&lt;&lt;endOptional&gt;&gt;</spdx:standardLicenseTemplate>
+                        <spdx:isDeprecatedLicenseId rdf:datatype=
+                        "http://www.w3.org/2001/XMLSchema#boolean"
+                        >false</spdx:isDeprecatedLicenseId>
+                        <spdx:licenseId>MPL-1.0</spdx:licenseId>
+                        <spdx:standardLicenseHeader>"The contents of this file are subject to the Mozilla Public License Version 1.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.mozilla.org/MPL/
+
+Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the specific language governing rights and limitations under the License.
+
+The Original Code is _____ . The Initial Developer of the Original Code is _____ . Portions created by _____ are Copyright (C) _____ . All Rights Reserved. Contributor(s): _____ ."</spdx:standardLicenseHeader>
+                      </spdx:ListedLicense>
+                    </spdx:licenseConcluded>
+                    <spdx:filesAnalyzed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                    >false</spdx:filesAnalyzed>
+                    <spdx:copyrightText>Copyright Saxonica Ltd</spdx:copyrightText>
+                    <spdx:licenseDeclared rdf:resource="http://spdx.org/licenses/MPL-1.0"/>
+                    <spdx:checksum>
+                      <spdx:Checksum>
+                        <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+                        <spdx:checksumValue>85ed0817af83a24ad8da68c2b5094de69833983c</spdx:checksumValue>
+                      </spdx:Checksum>
+                    </spdx:checksum>
+                  </spdx:Package>
+                </spdx:relatedSpdxElement>
+                <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_dynamicLink"/>
+              </spdx:Relationship>
+            </spdx:relationship>
+            <spdx:sourceInfo>uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.</spdx:sourceInfo>
+            <spdx:packageFileName>glibc-2.11.1.tar.gz</spdx:packageFileName>
+            <spdx:checksum>
+              <spdx:Checksum>
+                <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha256"/>
+                <spdx:checksumValue>11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd</spdx:checksumValue>
+              </spdx:Checksum>
+            </spdx:checksum>
+            <spdx:checksum>
+              <spdx:Checksum>
+                <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+                <spdx:checksumValue>85ed0817af83a24ad8da68c2b5094de69833983c</spdx:checksumValue>
+              </spdx:Checksum>
+            </spdx:checksum>
+            <spdx:summary>GNU C library.</spdx:summary>
+            <spdx:copyrightText>Copyright 2008-2010 John Smith</spdx:copyrightText>
+            <spdx:description>The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.</spdx:description>
+          </spdx:Package>
+        </spdx:relatedSpdxElement>
+        <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+      </spdx:Relationship>
+    </spdx:relationship>
+    <spdx:relationship>
+      <spdx:Relationship>
+        <spdx:relatedSpdxElement>
+          <spdx:File rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File">
+            <spdx:fileName>./package/foo.c</spdx:fileName>
+            <spdx:licenseComments>The concluded license was taken from the package level that the file was included in.</spdx:licenseComments>
+            <spdx:checksum>
+              <spdx:Checksum>
+                <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+                <spdx:checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2758</spdx:checksumValue>
+              </spdx:Checksum>
+            </spdx:checksum>
+            <spdx:relationship>
+              <spdx:Relationship>
+                <spdx:relatedSpdxElement>
+                  <spdx:Package rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-fromDoap-0">
+                    <doap:homepage>http://www.openjena.org/</doap:homepage>
+                    <spdx:copyrightText>NOASSERTION</spdx:copyrightText>
+                    <spdx:licenseDeclared rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
+                    <spdx:downloadLocation>NOASSERTION</spdx:downloadLocation>
+                    <rdfs:comment>This package was converted from a DOAP Project by the same name</rdfs:comment>
+                    <spdx:name>Jena</spdx:name>
+                    <spdx:licenseConcluded rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
+                    <spdx:filesAnalyzed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                    >false</spdx:filesAnalyzed>
+                  </spdx:Package>
+                </spdx:relatedSpdxElement>
+                <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_generatedFrom"/>
+              </spdx:Relationship>
+            </spdx:relationship>
+            <spdx:licenseInfoInFile rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-2"/>
+            <spdx:licenseInfoInFile rdf:resource="http://spdx.org/licenses/GPL-2.0-only"/>
+            <spdx:licenseConcluded>
+              <spdx:DisjunctiveLicenseSet>
+                <spdx:member rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-2"/>
+                <spdx:member rdf:resource="http://spdx.org/licenses/LGPL-2.0-only"/>
+              </spdx:DisjunctiveLicenseSet>
+            </spdx:licenseConcluded>
+            <spdx:copyrightText>Copyright 2008-2010 John Smith</spdx:copyrightText>
+            <spdx:annotation>
+              <spdx:Annotation>
+                <spdx:annotator>Person: File Commenter</spdx:annotator>
+                <rdfs:comment>File level annotation</rdfs:comment>
+                <spdx:annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_other"/>
+                <spdx:annotationDate>2011-01-29T18:30:22Z</spdx:annotationDate>
+              </spdx:Annotation>
+            </spdx:annotation>
+            <spdx:fileContributor>The Regents of the University of California</spdx:fileContributor>
+            <spdx:noticeText>Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the �Software�), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED �AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</spdx:noticeText>
+            <spdx:checksum>
+              <spdx:Checksum>
+                <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_md5"/>
+                <spdx:checksumValue>624c1abb3664f4b35547e7c73864ad24</spdx:checksumValue>
+              </spdx:Checksum>
+            </spdx:checksum>
+            <spdx:fileContributor>Modified by Paul Mundt lethal@linux-sh.org</spdx:fileContributor>
+            <spdx:fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+            <spdx:fileContributor>IBM Corporation</spdx:fileContributor>
+            <rdfs:comment>The concluded license was taken from the package level that the file was included in.
+This information was found in the COPYING.txt file in the xyz directory.</rdfs:comment>
+          </spdx:File>
+        </spdx:relatedSpdxElement>
+        <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+      </spdx:Relationship>
+    </spdx:relationship>
+    <spdx:relationship>
+      <spdx:Relationship>
+        <spdx:relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-ToolsElement"/>
+        <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_copyOf"/>
+      </spdx:Relationship>
+    </spdx:relationship>
+    <spdx:relationship>
+      <spdx:Relationship>
+        <spdx:relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package"/>
+        <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_contains"/>
+      </spdx:Relationship>
+    </spdx:relationship>
+    <spdx:specVersion>SPDX-2.2</spdx:specVersion>
+    <spdx:dataLicense>
+      <spdx:ListedLicense rdf:about="http://spdx.org/licenses/CC0-1.0">
+        <spdx:isOsiApproved rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+        >false</spdx:isOsiApproved>
+        <spdx:standardLicenseTemplate>&lt;&lt;beginOptional&gt;&gt; &lt;&lt;beginOptional&gt;&gt; Creative Commons&lt;&lt;beginOptional&gt;&gt; Legal Code&lt;&lt;endOptional&gt;&gt;&lt;&lt;endOptional&gt;&gt;
+
+CC0 1.0 Universal&lt;&lt;endOptional&gt;&gt;&lt;&lt;beginOptional&gt;&gt; CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER.&lt;&lt;endOptional&gt;&gt;
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer exclusive Copyright and Related Rights (defined below) upon the creator and subsequent owner(s) (each and all, an "owner") of an original work of authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the purpose of contributing to a commons of creative, cultural and scientific works ("Commons") that the public can reliably and without fear of later claims of infringement build upon, modify, incorporate in other works, reuse and redistribute as freely as possible in any form whatsoever and for any purposes, including without limitation commercial purposes. These owners may contribute to the Commons to promote the ideal of a free culture and the further production of creative, cultural and scientific works, or to gain reputation or greater distribution for their Work in part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation of additional consideration or compensation, the person associating CC0 with a Work (the "Affirmer"), to the extent that he or she is an owner of Copyright and Related Rights in the Work, voluntarily elects to apply CC0 to the Work and publicly distribute the Work under its terms, with knowledge of his or her Copyright and Related Rights in the Work and the meaning and intended legal effect of CC0 on those rights.
+
+   &lt;&lt;var;name="bullet";original="1.";match=".{0,20}"&gt;&gt; Copyright and Related Rights. A Work made available under CC0 may be protected by copyright and related or neighboring rights ("Copyright and Related Rights"). Copyright and Related Rights include, but are not limited to, the following:
+
+      &lt;&lt;var;name="bullet";original="i.";match=".{0,20}"&gt;&gt; the right to reproduce, adapt, distribute, perform, display, communicate, and translate a Work;
+
+      &lt;&lt;var;name="bullet";original="ii.";match=".{0,20}"&gt;&gt; moral rights retained by the original author(s) and/or performer(s);
+
+      &lt;&lt;var;name="bullet";original="iii.";match=".{0,20}"&gt;&gt; publicity and privacy rights pertaining to a person's image or likeness depicted in a Work;
+
+      &lt;&lt;var;name="bullet";original="iv.";match=".{0,20}"&gt;&gt; rights protecting against unfair competition in regards to a Work, subject to the limitations in paragraph 4(a), below;
+
+      &lt;&lt;var;name="bullet";original="v.";match=".{0,20}"&gt;&gt; rights protecting the extraction, dissemination, use and reuse of data in a Work;
+
+      &lt;&lt;var;name="bullet";original="vi.";match=".{0,20}"&gt;&gt; database rights (such as those arising under Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, and under any national implementation thereof, including any amended or successor version of such directive); and
+
+      &lt;&lt;var;name="bullet";original="vii.";match=".{0,20}"&gt;&gt; other similar, equivalent or corresponding rights throughout the world based on applicable law or treaty, and any national implementations thereof.
+
+   &lt;&lt;var;name="bullet";original="2.";match=".{0,20}"&gt;&gt; Waiver. To the greatest extent permitted by, but not in contravention of, applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and unconditionally waives, abandons, and surrenders all of Affirmer's Copyright and Related Rights and associated claims and causes of action, whether now known or unknown (including existing as well as future claims and causes of action), in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each member of the public at large and to the detriment of Affirmer's heirs and successors, fully intending that such Waiver shall not be subject to revocation, rescission, cancellation, termination, or any other legal or equitable action to disrupt the quiet enjoyment of the Work by the public as contemplated by Affirmer's express Statement of Purpose.
+
+   &lt;&lt;var;name="bullet";original="3.";match=".{0,20}"&gt;&gt; Public License Fallback. Should any part of the Waiver for any reason be judged legally invalid or ineffective under applicable law, then the Waiver shall be preserved to the maximum extent permitted taking into account Affirmer's express Statement of Purpose. In addition, to the extent the Waiver is so judged Affirmer hereby grants to each affected person a royalty-free, non transferable, non sublicensable, non exclusive, irrevocable and unconditional license to exercise Affirmer's Copyright and Related Rights in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "License"). The License shall be deemed effective as of the date CC0 was applied by Affirmer to the Work. Should any part of the License for any reason be judged legally invalid or ineffective under applicable law, such partial invalidity or ineffectiveness shall not invalidate the remainder of the License, and in such case Affirmer hereby affirms that he or she will not (i) exercise any of his or her remaining Copyright and Related Rights in the Work or (ii) assert any associated claims and causes of action with respect to the Work, in either case contrary to Affirmer's express Statement of Purpose.
+
+   &lt;&lt;var;name="bullet";original="4.";match=".{0,20}"&gt;&gt; Limitations and Disclaimers.
+
+      &lt;&lt;var;name="bullet";original="a.";match=".{0,20}"&gt;&gt; No trademark or patent rights held by Affirmer are waived, abandoned, surrendered, licensed or otherwise affected by this document.
+
+      &lt;&lt;var;name="bullet";original="b.";match=".{0,20}"&gt;&gt; Affirmer offers the Work as-is and makes no representations or warranties of any kind concerning the Work, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non infringement, or the absence of latent or other defects, accuracy, or the present or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.
+
+      &lt;&lt;var;name="bullet";original="c.";match=".{0,20}"&gt;&gt; Affirmer disclaims responsibility for clearing rights of other persons that may apply to the Work or any use thereof, including without limitation any person's Copyright and Related Rights in the Work. Further, Affirmer disclaims responsibility for obtaining any necessary consents, permissions or other rights required for any use of the Work.
+
+      &lt;&lt;var;name="bullet";original="d.";match=".{0,20}"&gt;&gt; Affirmer understands and acknowledges that Creative Commons is not a party to this document and has no duty or obligation with respect to this CC0 or use of the Work.&lt;&lt;beginOptional&gt;&gt; &lt;&lt;var;name="upstreamLink";original="";match="For more information, please see &lt;http://creativecommons.org/publicdomain/zero/1.0/&gt;"&gt;&gt;&lt;&lt;endOptional&gt;&gt;</spdx:standardLicenseTemplate>
+        <spdx:isFsfLibre rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+        >true</spdx:isFsfLibre>
+        <spdx:isDeprecatedLicenseId rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+        >false</spdx:isDeprecatedLicenseId>
+        <spdx:crossRef>
+          <spdx:CrossRef>
+            <spdx:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+            >0</spdx:order>
+            <spdx:timestamp>2020-11-25 - 21:49:19</spdx:timestamp>
+            <spdx:url>https://creativecommons.org/publicdomain/zero/1.0/legalcode</spdx:url>
+            <spdx:match>false</spdx:match>
+            <spdx:isWayBackLink rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >false</spdx:isWayBackLink>
+            <spdx:isValid rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >true</spdx:isValid>
+            <spdx:isLive rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >true</spdx:isLive>
+          </spdx:CrossRef>
+        </spdx:crossRef>
+        <spdx:name>Creative Commons Zero v1.0 Universal</spdx:name>
+        <spdx:licenseId>CC0-1.0</spdx:licenseId>
+        <spdx:licenseText>Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.
+</spdx:licenseText>
+        <rdfs:seeAlso>https://creativecommons.org/publicdomain/zero/1.0/legalcode</rdfs:seeAlso>
+      </spdx:ListedLicense>
+    </spdx:dataLicense>
+    <spdx:hasExtractedLicensingInfo rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-3"/>
+    <spdx:hasExtractedLicensingInfo>
+      <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-Beerware-4.2">
+        <spdx:licenseId>LicenseRef-Beerware-4.2</spdx:licenseId>
+        <spdx:extractedText>"THE BEER-WARE LICENSE" (Revision 42):
+phk@FreeBSD.ORG wrote this file. As long as you retain this notice you
+can do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a beer in return Poul-Henning Kamp  &lt;/
+LicenseName: Beer-Ware License (Version 42)
+LicenseCrossReference:  http://people.freebsd.org/~phk/
+LicenseComment: 
+The beerware license has a couple of other standard variants.</spdx:extractedText>
+      </spdx:ExtractedLicensingInfo>
+    </spdx:hasExtractedLicensingInfo>
+    <spdx:externalDocumentRef>
+      <spdx:ExternalDocumentRef rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#DocumentRef-spdx-tool-1.2">
+        <spdx:spdxDocument rdf:resource="http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301"/>
+        <spdx:checksum>
+          <spdx:Checksum>
+            <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+            <spdx:checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</spdx:checksumValue>
+          </spdx:Checksum>
+        </spdx:checksum>
+        <spdx:externalDocumentId>DocumentRef-spdx-tool-1.2</spdx:externalDocumentId>
+      </spdx:ExternalDocumentRef>
+    </spdx:externalDocumentRef>
+    <spdx:hasExtractedLicensingInfo>
+      <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-4">
+        <spdx:licenseId>LicenseRef-4</spdx:licenseId>
+        <spdx:extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/</spdx:extractedText>
+      </spdx:ExtractedLicensingInfo>
+    </spdx:hasExtractedLicensingInfo>
+    <spdx:creationInfo>
+      <spdx:CreationInfo>
+        <rdfs:comment>This package has been shipped in source and binary form.
+The binaries were created with gcc 4.5.1 and expect to link to
+compatible system run time libraries.</rdfs:comment>
+        <spdx:created>2010-01-29T18:30:22Z</spdx:created>
+        <spdx:creator>Person: Jane Doe ()</spdx:creator>
+        <spdx:creator>Organization: ExampleCodeInspect ()</spdx:creator>
+        <spdx:creator>Tool: LicenseFind-1.0</spdx:creator>
+        <spdx:licenseListVersion>3.9</spdx:licenseListVersion>
+      </spdx:CreationInfo>
+    </spdx:creationInfo>
+    <spdx:hasExtractedLicensingInfo rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-2"/>
+    <rdfs:comment>This document was created using SPDX 2.0 using licenses from the web site.</rdfs:comment>
+    <spdx:annotation>
+      <spdx:Annotation>
+        <spdx:annotator>Person: Suzanne Reviewer</spdx:annotator>
+        <rdfs:comment>Another example reviewer.</rdfs:comment>
+        <spdx:annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_review"/>
+        <spdx:annotationDate>2011-03-13T00:00:00Z</spdx:annotationDate>
+      </spdx:Annotation>
+    </spdx:annotation>
+    <spdx:annotation>
+      <spdx:Annotation>
+        <spdx:annotator>Person: Joe Reviewer</spdx:annotator>
+        <rdfs:comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <spdx:annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_review"/>
+        <spdx:annotationDate>2010-02-10T00:00:00Z</spdx:annotationDate>
+      </spdx:Annotation>
+    </spdx:annotation>
+    <spdx:name>SPDX-Tools-v2.0</spdx:name>
+    <spdx:annotation>
+      <spdx:Annotation>
+        <spdx:annotator>Person: Jane Doe ()</spdx:annotator>
+        <rdfs:comment>Document level annotation</rdfs:comment>
+        <spdx:annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_other"/>
+        <spdx:annotationDate>2010-01-29T18:30:22Z</spdx:annotationDate>
+      </spdx:Annotation>
+    </spdx:annotation>
+    <spdx:hasExtractedLicensingInfo rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-1"/>
+  </spdx:SpdxDocument>
+  <spdx:Package rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-2-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-fromDoap-1">
+    <doap:homepage>http://commons.apache.org/proper/commons-lang/</doap:homepage>
+    <spdx:copyrightText>NOASSERTION</spdx:copyrightText>
+    <spdx:licenseDeclared rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
+    <spdx:downloadLocation>NOASSERTION</spdx:downloadLocation>
+    <rdfs:comment>This package was converted from a DOAP Project by the same name</rdfs:comment>
+    <spdx:name>Apache Commons Lang</spdx:name>
+    <spdx:licenseConcluded rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
+    <spdx:filesAnalyzed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >false</spdx:filesAnalyzed>
+  </spdx:Package>
+</rdf:RDF>

--- a/src/examples/SPDXRdfExample-v2.3.spdx.rdf
+++ b/src/examples/SPDXRdfExample-v2.3.spdx.rdf
@@ -1,0 +1,4342 @@
+<rdf:RDF
+    xmlns:spdx="http://spdx.org/rdf/terms#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:doap="http://usefulinc.com/ns/doap#"
+    xmlns:ptr="http://www.w3.org/2009/pointers#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+  <spdx:ExternalSpdxElement rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#DocumentRef-spdx-tool-1.2%3ASPDXRef-ToolsElement"/>
+  <spdx:Snippet rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Snippet">
+    <spdx:name>from linux kernel</spdx:name>
+    <spdx:copyrightText>Copyright 2008-2010 John Smith</spdx:copyrightText>
+    <spdx:licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</spdx:licenseComments>
+    <spdx:snippetFromFile>
+      <spdx:File rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource">
+        <spdx:copyrightText>Copyright 2010, 2011 Source Auditor Inc.</spdx:copyrightText>
+        <spdx:fileContributor>Open Logic Inc.</spdx:fileContributor>
+        <spdx:fileName>./src/org/spdx/parser/DOAPProject.java</spdx:fileName>
+        <spdx:fileContributor>Black Duck Software In.c</spdx:fileContributor>
+        <spdx:fileContributor>Source Auditor Inc.</spdx:fileContributor>
+        <spdx:fileContributor>SPDX Technical Team Members</spdx:fileContributor>
+        <spdx:licenseConcluded>
+          <spdx:ListedLicense rdf:about="http://spdx.org/licenses/Apache-2.0">
+            <spdx:standardLicenseTemplate>&lt;&lt;beginOptional&gt;&gt;Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+&lt;&lt;endOptional&gt;&gt;&lt;&lt;beginOptional&gt;&gt; TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+&lt;&lt;endOptional&gt;&gt;
+
+   &lt;&lt;var;name="bullet";original="1.";match=".{0,20}"&gt;&gt; Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+   &lt;&lt;var;name="bullet";original="2.";match=".{0,20}"&gt;&gt; Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+   &lt;&lt;var;name="bullet";original="3.";match=".{0,20}"&gt;&gt; Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+   &lt;&lt;var;name="bullet";original="4.";match=".{0,20}"&gt;&gt; Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+      &lt;&lt;var;name="bullet";original="(a)";match=".{0,20}"&gt;&gt; You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+      &lt;&lt;var;name="bullet";original="(b)";match=".{0,20}"&gt;&gt; You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+      &lt;&lt;var;name="bullet";original="(c)";match=".{0,20}"&gt;&gt; You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+      &lt;&lt;var;name="bullet";original="(d)";match=".{0,20}"&gt;&gt; If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+   &lt;&lt;var;name="bullet";original="5.";match=".{0,20}"&gt;&gt; Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+   &lt;&lt;var;name="bullet";original="6.";match=".{0,20}"&gt;&gt; Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+   &lt;&lt;var;name="bullet";original="7.";match=".{0,20}"&gt;&gt; Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+   &lt;&lt;var;name="bullet";original="8.";match=".{0,20}"&gt;&gt; Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+   &lt;&lt;var;name="bullet";original="9.";match=".{0,20}"&gt;&gt; Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.&lt;&lt;beginOptional&gt;&gt; END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!) The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright &lt;&lt;var;name="copyright";original="[yyyy] [name of copyright owner]";match=".+"&gt;&gt;
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+
+distributed under the License is distributed on an "AS IS" BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+
+limitations under the License.
+
+&lt;&lt;endOptional&gt;&gt;</spdx:standardLicenseTemplate>
+            <rdfs:comment>This license was released January 2004</rdfs:comment>
+            <spdx:name>Apache License 2.0</spdx:name>
+            <spdx:crossRef>
+              <spdx:CrossRef>
+                <spdx:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+                >0</spdx:order>
+                <spdx:timestamp>2022-05-09T00:09:00Z</spdx:timestamp>
+                <spdx:url>https://www.apache.org/licenses/LICENSE-2.0</spdx:url>
+                <spdx:match>true</spdx:match>
+                <spdx:isWayBackLink rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                >false</spdx:isWayBackLink>
+                <spdx:isValid rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                >true</spdx:isValid>
+                <spdx:isLive rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                >true</spdx:isLive>
+              </spdx:CrossRef>
+            </spdx:crossRef>
+            <spdx:standardLicenseHeaderHtml>
+         &lt;p&gt;Copyright &lt;var class="replacable-license-text"&gt; [yyyy] [name of copyright owner]&lt;/var&gt;&lt;/p&gt;
+
+         &lt;p&gt;Licensed under the Apache License, Version 2.0 (the &amp;quot;License&amp;quot;);
+        &lt;br /&gt;
+
+you may not use this file except in compliance with the License.
+        &lt;br /&gt;
+
+You may obtain a copy of the License at
+      &lt;/p&gt;
+
+         &lt;p&gt;http://www.apache.org/licenses/LICENSE-2.0&lt;/p&gt;
+
+         &lt;p&gt;Unless required by applicable law or agreed to in writing, software
+        &lt;br /&gt;
+
+distributed under the License is distributed on an &amp;quot;AS IS&amp;quot; BASIS,
+        &lt;br /&gt;
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        &lt;br /&gt;
+
+See the License for the specific language governing permissions and
+        &lt;br /&gt;
+
+limitations under the License.
+      &lt;/p&gt;
+
+        </spdx:standardLicenseHeaderHtml>
+            <rdfs:seeAlso>https://www.apache.org/licenses/LICENSE-2.0</rdfs:seeAlso>
+            <spdx:standardLicenseHeader>Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+
+distributed under the License is distributed on an "AS IS" BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+
+limitations under the License.
+
+</spdx:standardLicenseHeader>
+            <spdx:standardLicenseHeaderTemplate>Copyright &lt;&lt;var;name="copyright";original="[yyyy] [name of copyright owner]";match=".+"&gt;&gt;
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+
+distributed under the License is distributed on an "AS IS" BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+
+limitations under the License.
+
+</spdx:standardLicenseHeaderTemplate>
+            <spdx:licenseTextHtml>
+      &lt;div class="optional-license-text"&gt; 
+         &lt;p&gt;Apache License
+        &lt;br /&gt;
+
+Version 2.0, January 2004
+        &lt;br /&gt;
+
+http://www.apache.org/licenses/
+      &lt;/p&gt;
+
+      &lt;/div&gt;
+      &lt;div class="optional-license-text"&gt; 
+         &lt;p&gt;TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION&lt;/p&gt;
+
+      &lt;/div&gt;
+
+&lt;ul style="list-style:none"&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 1.&lt;/var&gt;
+          Definitions.
+          
+&lt;ul style="list-style:none"&gt;
+               
+&lt;li&gt;
+                  &lt;p&gt;&amp;quot;License&amp;quot; shall mean the terms and conditions for use, reproduction, and distribution
+              as defined by Sections 1 through 9 of this document.&lt;/p&gt;
+
+               &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;p&gt;&amp;quot;Licensor&amp;quot; shall mean the copyright owner or entity authorized by the copyright owner
+                 that is granting the License.&lt;/p&gt;
+
+               &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;p&gt;&amp;quot;Legal Entity&amp;quot; shall mean the union of the acting entity and all other entities that
+                 control, are controlled by, or are under common control with that entity. For the purposes of
+                 this definition, &amp;quot;control&amp;quot; means (i) the power, direct or indirect, to cause the
+                 direction or management of such entity, whether by contract or otherwise, or (ii) ownership of
+                 fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such
+                 entity.&lt;/p&gt;
+
+               &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;p&gt;&amp;quot;You&amp;quot; (or &amp;quot;Your&amp;quot;) shall mean an individual or Legal Entity exercising
+                permissions granted by this License.&lt;/p&gt;
+
+               &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;p&gt;&amp;quot;Source&amp;quot; form shall mean the preferred form for making modifications, including but not
+                limited to software source code, documentation source, and configuration files.&lt;/p&gt;
+
+               &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;p&gt;&amp;quot;Object&amp;quot; form shall mean any form resulting from mechanical transformation or
+                 translation of a Source form, including but not limited to compiled object code, generated
+                 documentation, and conversions to other media types.&lt;/p&gt;
+
+               &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;p&gt;&amp;quot;Work&amp;quot; shall mean the work of authorship, whether in Source or Object form, made
+                 available under the License, as indicated by a copyright notice that is included in or
+                 attached to the work (an example is provided in the Appendix below).&lt;/p&gt;
+
+               &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;p&gt;&amp;quot;Derivative Works&amp;quot; shall mean any work, whether in Source or Object form, that is based
+                 on (or derived from) the Work and for which the editorial revisions, annotations,
+                 elaborations, or other modifications represent, as a whole, an original work of authorship.
+                 For the purposes of this License, Derivative Works shall not include works that remain
+                 separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative
+                 Works thereof.&lt;/p&gt;
+
+               &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;p&gt;&amp;quot;Contribution&amp;quot; shall mean any work of authorship, including the original version of the
+                 Work and any modifications or additions to that Work or Derivative Works thereof, that is
+                 intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an
+                 individual or Legal Entity authorized to submit on behalf of the copyright owner. For the
+                 purposes of this definition, &amp;quot;submitted&amp;quot; means any form of electronic, verbal, or
+                 written communication sent to the Licensor or its representatives, including but not limited
+                 to communication on electronic mailing lists, source code control systems, and issue tracking
+                 systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and
+                 improving the Work, but excluding communication that is conspicuously marked or otherwise
+                 designated in writing by the copyright owner as &amp;quot;Not a Contribution.&amp;quot;&lt;/p&gt;
+
+               &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;p&gt;&amp;quot;Contributor&amp;quot; shall mean Licensor and any individual or Legal Entity on behalf of whom
+                 a Contribution has been received by Licensor and subsequently incorporated within the
+                 Work.&lt;/p&gt;
+
+               &lt;/li&gt;
+            
+&lt;/ul&gt;
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 2.&lt;/var&gt;
+          Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor
+             hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+             irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display,
+             publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or
+             Object form.
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 3.&lt;/var&gt;
+          Grant of Patent License. Subject to the terms and conditions of this License, each Contributor
+             hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+             irrevocable (except as stated in this section) patent license to make, have made, use, offer
+             to sell, sell, import, and otherwise transfer the Work, where such license applies only to
+             those patent claims licensable by such Contributor that are necessarily infringed by their
+             Contribution(s) alone or by combination of their Contribution(s) with the Work to which such
+             Contribution(s) was submitted. If You institute patent litigation against any entity
+             (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+             Contribution incorporated within the Work constitutes direct or contributory patent
+             infringement, then any patent licenses granted to You under this License for that Work shall
+             terminate as of the date such litigation is filed.
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 4.&lt;/var&gt;
+          Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof
+             in any medium, with or without modifications, and in Source or Object form, provided that You
+             meet the following conditions:
+          
+&lt;ul style="list-style:none"&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; (a)&lt;/var&gt;
+              You must give any other recipients of the Work or Derivative Works a copy of this License; and
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; (b)&lt;/var&gt;
+              You must cause any modified files to carry prominent notices stating that You changed the files; and
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; (c)&lt;/var&gt;
+              You must retain, in the Source form of any Derivative Works that You distribute, all
+                 copyright, patent, trademark, and attribution notices from the Source form of the Work,
+                 excluding those notices that do not pertain to any part of the Derivative Works; and
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; (d)&lt;/var&gt;
+              If the Work includes a &amp;quot;NOTICE&amp;quot; text file as part of its distribution, then any
+                 Derivative Works that You distribute must include a readable copy of the attribution
+                 notices contained within such NOTICE file, excluding those notices that do not pertain to
+                 any part of the Derivative Works, in at least one of the following places: within a NOTICE
+                 text file distributed as part of the Derivative Works; within the Source form or
+                 documentation, if provided along with the Derivative Works; or, within a display generated
+                 by the Derivative Works, if and wherever such third-party notices normally appear. The
+                 contents of the NOTICE file are for informational purposes only and do not modify the
+                 License. You may add Your own attribution notices within Derivative Works that You
+                 distribute, alongside or as an addendum to the NOTICE text from the Work, provided that
+                 such additional attribution notices cannot be construed as modifying the License.
+              &lt;p&gt;You may add Your own copyright statement to Your modifications and may provide additional or
+                 different license terms and conditions for use, reproduction, or distribution of Your
+                 modifications, or for any such Derivative Works as a whole, provided Your use,
+                 reproduction, and distribution of the Work otherwise complies with the conditions stated
+                 in this License.&lt;/p&gt;
+
+               &lt;/li&gt;
+            
+&lt;/ul&gt;
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 5.&lt;/var&gt;
+          Submission of Contributions. Unless You explicitly state otherwise, any Contribution
+             intentionally submitted for inclusion in the Work by You to the Licensor shall be under the
+             terms and conditions of this License, without any additional terms or conditions.
+             Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate
+             license agreement you may have executed with Licensor regarding such Contributions.
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 6.&lt;/var&gt;
+          Trademarks. This License does not grant permission to use the trade names, trademarks, service
+             marks, or product names of the Licensor, except as required for reasonable and customary use
+             in describing the origin of the Work and reproducing the content of the NOTICE file.
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 7.&lt;/var&gt;
+          Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor
+             provides the Work (and each Contributor provides its Contributions) on an &amp;quot;AS IS&amp;quot;
+             BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including,
+             without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY,
+             or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the
+             appropriateness of using or redistributing the Work and assume any risks associated with Your
+             exercise of permissions under this License.
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 8.&lt;/var&gt;
+          Limitation of Liability. In no event and under no legal theory, whether in tort (including
+             negligence), contract, or otherwise, unless required by applicable law (such as deliberate and
+             grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for
+             damages, including any direct, indirect, special, incidental, or consequential damages of any
+             character arising as a result of this License or out of the use or inability to use the Work
+             (including but not limited to damages for loss of goodwill, work stoppage, computer failure or
+             malfunction, or any and all other commercial damages or losses), even if such Contributor has
+             been advised of the possibility of such damages.
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 9.&lt;/var&gt;
+          Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works
+             thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty,
+             indemnity, or other liability obligations and/or rights consistent with this License. However,
+             in accepting such obligations, You may act only on Your own behalf and on Your sole
+             responsibility, not on behalf of any other Contributor, and only if You agree to indemnify,
+             defend, and hold each Contributor harmless for any liability incurred by, or claims asserted
+             against, such Contributor by reason of your accepting any such warranty or additional
+             liability.
+        &lt;/li&gt;
+      
+&lt;/ul&gt;
+
+      &lt;div class="optional-license-text"&gt; 
+         &lt;p&gt;END OF TERMS AND CONDITIONS&lt;/p&gt;
+
+         &lt;p&gt;APPENDIX: How to apply the Apache License to your work.&lt;/p&gt;
+
+         &lt;p&gt;To apply the Apache License to your work, attach the following boilerplate notice, with the fields
+         enclosed by brackets &amp;quot;[]&amp;quot; replaced with your own identifying information. (Don&amp;apos;t
+         include the brackets!) The text should be enclosed in the appropriate comment syntax for the file
+         format. We also recommend that a file or class name and description of purpose be included on the same
+         &amp;quot;printed page&amp;quot; as the copyright notice for easier identification within third-party
+         archives.&lt;/p&gt;
+
+         &lt;p&gt;Copyright &lt;var class="replacable-license-text"&gt; [yyyy] [name of copyright owner]&lt;/var&gt;&lt;/p&gt;
+
+         &lt;p&gt;Licensed under the Apache License, Version 2.0 (the &amp;quot;License&amp;quot;);
+        &lt;br /&gt;
+
+you may not use this file except in compliance with the License.
+        &lt;br /&gt;
+
+You may obtain a copy of the License at
+      &lt;/p&gt;
+
+         &lt;p&gt;http://www.apache.org/licenses/LICENSE-2.0&lt;/p&gt;
+
+         &lt;p&gt;Unless required by applicable law or agreed to in writing, software
+        &lt;br /&gt;
+
+distributed under the License is distributed on an &amp;quot;AS IS&amp;quot; BASIS,
+        &lt;br /&gt;
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        &lt;br /&gt;
+
+See the License for the specific language governing permissions and
+        &lt;br /&gt;
+
+limitations under the License.
+      &lt;/p&gt;
+
+      &lt;/div&gt;
+    </spdx:licenseTextHtml>
+            <spdx:isOsiApproved rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >true</spdx:isOsiApproved>
+            <spdx:isFsfLibre rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >true</spdx:isFsfLibre>
+            <rdfs:seeAlso>https://opensource.org/licenses/Apache-2.0</rdfs:seeAlso>
+            <spdx:isDeprecatedLicenseId rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >false</spdx:isDeprecatedLicenseId>
+            <spdx:licenseId>Apache-2.0</spdx:licenseId>
+            <spdx:crossRef>
+              <spdx:CrossRef>
+                <spdx:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+                >1</spdx:order>
+                <spdx:timestamp>2022-05-09T00:09:01Z</spdx:timestamp>
+                <spdx:url>https://opensource.org/licenses/Apache-2.0</spdx:url>
+                <spdx:match>true</spdx:match>
+                <spdx:isWayBackLink rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                >false</spdx:isWayBackLink>
+                <spdx:isValid rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                >true</spdx:isValid>
+                <spdx:isLive rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                >true</spdx:isLive>
+              </spdx:CrossRef>
+            </spdx:crossRef>
+            <spdx:licenseText>Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+</spdx:licenseText>
+          </spdx:ListedLicense>
+        </spdx:licenseConcluded>
+        <spdx:fileContributor>Protecode Inc.</spdx:fileContributor>
+        <spdx:fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+        <spdx:licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <spdx:checksum>
+          <spdx:Checksum>
+            <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+            <spdx:checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</spdx:checksumValue>
+          </spdx:Checksum>
+        </spdx:checksum>
+      </spdx:File>
+    </spdx:snippetFromFile>
+    <spdx:licenseInfoInSnippet>
+      <spdx:ListedLicense rdf:about="http://spdx.org/licenses/GPL-2.0-only">
+        <spdx:standardLicenseTemplate>&lt;&lt;beginOptional&gt;&gt;GNU GENERAL PUBLIC LICENSE
+
+Version 2, June 1991
+
+&lt;&lt;endOptional&gt;&gt;
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc. &lt;&lt;var;name="incComma";original="";match=",|"&gt;&gt;
+
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301&lt;&lt;beginOptional&gt;&gt;, &lt;&lt;endOptional&gt;&gt; USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users. This General Public License applies to most of the Free Software Foundation's software and to any other program whose authors commit to using it. (Some other Free Software Foundation software is covered by the GNU Lesser General Public License instead.) You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or for a fee, you must give the recipients all the rights that you have. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2) offer you this license which gives you legal permission to copy, distribute and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain that everyone understands that there is no warranty for this free software. If the software is modified by someone else and passed on, we want its recipients to know that what they have is not the original, so that any problems introduced by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that redistributors of a free program will individually obtain patent licenses, in effect making the program proprietary. To prevent this, we have made it clear that any patent must be licensed for everyone's free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+&lt;&lt;var;name="termsTitle";original="";match="GNU GENERAL PUBLIC LICENSE|"&gt;&gt; TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+   &lt;&lt;var;name="bullet";original="0.";match=".{0,20}"&gt;&gt; This License applies to any program or other work which contains a notice placed by the copyright holder saying it may be distributed under the terms of this General Public License. The "Program", below, refers to any such program or work, and a "work based on the Program" means either the Program or any derivative work under copyright law: that is to say, a work containing the Program or a portion of it, either verbatim or with modifications and/or translated into another language. (Hereinafter, translation is included without limitation in the term "modification".) Each licensee is addressed as "you".
+
+   Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running the Program is not restricted, and the output from the Program is covered only if its contents constitute a work based on the Program (independent of having been made by running the Program). Whether that is true depends on what the Program does.
+
+   &lt;&lt;var;name="bullet";original="1.";match=".{0,20}"&gt;&gt; You may copy and distribute verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and give any other recipients of the Program a copy of this License along with the Program.
+
+   You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+   &lt;&lt;var;name="bullet";original="2.";match=".{0,20}"&gt;&gt; You may modify your copy or copies of the Program or any portion of it, thus forming a work based on the Program, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+      &lt;&lt;var;name="bullet";original="a)";match=".{0,20}"&gt;&gt; You must cause the modified files to carry prominent notices stating that you changed the files and the date of any change.
+
+      &lt;&lt;var;name="bullet";original="b)";match=".{0,20}"&gt;&gt; You must cause any work that you distribute or publish, that in whole or in part contains or is derived from the Program or any part thereof, to be licensed as a whole at no charge to all third parties under the terms of this License.
+
+      &lt;&lt;var;name="bullet";original="c)";match=".{0,20}"&gt;&gt; If the modified program normally reads commands interactively when run, you must cause it, when started running for such interactive use in the most ordinary way, to print or display an announcement including an appropriate copyright notice and a notice that there is no warranty (or else, saying that you provide a warranty) and that users may redistribute the program under these conditions, and telling the user how to view a copy of this License. (Exception: if the Program itself is interactive but does not normally print such an announcement, your work based on the Program is not required to print an announcement.)
+
+   These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Program, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Program, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+   Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Program.
+
+   In addition, mere aggregation of another work not based on the Program with the Program (or with a work based on the Program) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+   &lt;&lt;var;name="bullet";original="3.";match=".{0,20}"&gt;&gt; You may copy and distribute the Program (or a work based on it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you also do one of the following:
+
+      &lt;&lt;var;name="bullet";original="a)";match=".{0,20}"&gt;&gt; Accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+
+      &lt;&lt;var;name="bullet";original="b)";match=".{0,20}"&gt;&gt; Accompany it with a written offer, valid for at least three years, to give any third party, for a charge no more than your cost of physically performing source distribution, a complete machine-readable copy of the corresponding source code, to be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+
+      &lt;&lt;var;name="bullet";original="c)";match=".{0,20}"&gt;&gt; Accompany it with the information you received as to the offer to distribute corresponding source code. (This alternative is allowed only for noncommercial distribution and only if you received the program in object code or executable form with such an offer, in accord with Subsection b above.)
+
+   The source code for a work means the preferred form of the work for making modifications to it. For an executable work, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the executable. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+   If distribution of executable or object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place counts as distribution of the source code, even though third parties are not compelled to copy the source along with the object code.
+
+   &lt;&lt;var;name="bullet";original="4.";match=".{0,20}"&gt;&gt; You may not copy, modify, sublicense, or distribute the Program except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense or distribute the Program is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+   &lt;&lt;var;name="bullet";original="5.";match=".{0,20}"&gt;&gt; You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Program or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Program (or any work based on the Program), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Program or works based on it.
+
+   &lt;&lt;var;name="bullet";original="6.";match=".{0,20}"&gt;&gt; Each time you redistribute the Program (or any work based on the Program), the recipient automatically receives a license from the original licensor to copy, distribute or modify the Program subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties to this License.
+
+   &lt;&lt;var;name="bullet";original="7.";match=".{0,20}"&gt;&gt; If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Program at all. For example, if a patent license would not permit royalty-free redistribution of the Program by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Program.
+
+   If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply and the section as a whole is intended to apply in other circumstances.
+
+   It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system, which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+   This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+   &lt;&lt;var;name="bullet";original="8.";match=".{0,20}"&gt;&gt; If the distribution and/or use of the Program is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Program under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+   &lt;&lt;var;name="bullet";original="9.";match=".{0,20}"&gt;&gt; The Free Software Foundation may publish revised and/or new versions of the General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+   Each version is given a distinguishing version number. If the Program specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of this License, you may choose any version ever published by the Free Software Foundation.
+
+   &lt;&lt;var;name="bullet";original="10.";match=".{0,20}"&gt;&gt; If you wish to incorporate parts of the Program into other free programs whose distribution conditions are different, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+   NO WARRANTY
+
+   &lt;&lt;var;name="bullet";original="11.";match=".{0,20}"&gt;&gt; BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+   &lt;&lt;var;name="bullet";original="12.";match=".{0,20}"&gt;&gt; IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.&lt;&lt;beginOptional&gt;&gt; END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+&lt;&lt;beginOptional&gt;&gt;&lt;&lt;&lt;endOptional&gt;&gt;one line to give the program's name and &lt;&lt;var;name="ideaArticle";original="an";match="a brief|an"&gt;&gt; idea of what it does.&lt;&lt;beginOptional&gt;&gt;&gt;&lt;&lt;endOptional&gt;&gt;
+
+Copyright (C)&lt;&lt;beginOptional&gt;&gt;&lt;&lt;&lt;endOptional&gt;&gt; &lt;&lt;var;name="templateYear";original="yyyy";match="yyyy|year"&gt;&gt;&lt;&lt;beginOptional&gt;&gt;&gt; &lt;&lt;endOptional&gt;&gt;&lt;&lt;beginOptional&gt;&gt; &lt;&lt;&lt;endOptional&gt;&gt;name of author&lt;&lt;beginOptional&gt;&gt;&gt;&lt;&lt;endOptional&gt;&gt;
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301&lt;&lt;beginOptional&gt;&gt;, &lt;&lt;endOptional&gt;&gt; USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this when it starts in an interactive mode:
+
+Gnomovision version 69, Copyright (C) year name of author Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'. This is free software, and you are welcome to redistribute it under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate parts of the General Public License. Of course, the commands you use may be called something other than `show w' and `show c'; they could even be mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the program, if necessary. Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in the program `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+&lt;&lt;beginOptional&gt;&gt;&lt;&lt;&lt;endOptional&gt;&gt;signature of Ty Coon&lt;&lt;beginOptional&gt;&gt; &gt;&lt;&lt;endOptional&gt;&gt;, 1 April 1989 Ty Coon, President of Vice
+
+&lt;&lt;endOptional&gt;&gt;&lt;&lt;beginOptional&gt;&gt; This General Public License does not permit incorporating your program into proprietary programs. If your program is a subroutine library, you may consider it more useful to permit linking proprietary applications with the library. If this is what you want to do, use the GNU Lesser General Public License instead of this License.
+
+&lt;&lt;endOptional&gt;&gt;</spdx:standardLicenseTemplate>
+        <rdfs:seeAlso>https://opensource.org/licenses/GPL-2.0</rdfs:seeAlso>
+        <rdfs:comment>This license was released: June 1991. This license identifier refers to the choice to use the code under GPL-2.0-only, as distinguished from use of code under GPL-2.0-or-later (i.e., GPL-2.0 or some later version). The license notice (as seen in the Standard License Header field below) states which of these applies to the code in the file. The example in the exhibit to the license shows the license notice for the "or later" approach.</rdfs:comment>
+        <spdx:licenseId>GPL-2.0-only</spdx:licenseId>
+        <rdfs:seeAlso>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</rdfs:seeAlso>
+        <spdx:crossRef>
+          <spdx:CrossRef>
+            <spdx:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+            >0</spdx:order>
+            <spdx:timestamp>2022-05-09T00:00:00Z</spdx:timestamp>
+            <spdx:url>https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</spdx:url>
+            <spdx:match>true</spdx:match>
+            <spdx:isWayBackLink rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >false</spdx:isWayBackLink>
+            <spdx:isValid rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >true</spdx:isValid>
+            <spdx:isLive rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >true</spdx:isLive>
+          </spdx:CrossRef>
+        </spdx:crossRef>
+        <spdx:isFsfLibre rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+        >true</spdx:isFsfLibre>
+        <spdx:crossRef>
+          <spdx:CrossRef>
+            <spdx:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+            >1</spdx:order>
+            <spdx:timestamp>2022-05-09T00:00:00Z</spdx:timestamp>
+            <spdx:url>https://opensource.org/licenses/GPL-2.0</spdx:url>
+            <spdx:match>false</spdx:match>
+            <spdx:isWayBackLink rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >false</spdx:isWayBackLink>
+            <spdx:isValid rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >true</spdx:isValid>
+            <spdx:isLive rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >true</spdx:isLive>
+          </spdx:CrossRef>
+        </spdx:crossRef>
+        <spdx:standardLicenseHeaderTemplate>Copyright (C) &lt;&lt;var;name="copyright";original="yyyy name of author";match=".+"&gt;&gt;
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; version 2.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301&lt;&lt;beginOptional&gt;&gt;, &lt;&lt;endOptional&gt;&gt; USA.
+
+</spdx:standardLicenseHeaderTemplate>
+        <spdx:isDeprecatedLicenseId rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+        >false</spdx:isDeprecatedLicenseId>
+        <spdx:name>GNU General Public License v2.0 only</spdx:name>
+        <spdx:licenseTextHtml>
+    &lt;div class="optional-license-text"&gt; 
+      &lt;p&gt;
+        GNU GENERAL PUBLIC LICENSE&lt;br /&gt;
+
+        Version 2, June 1991
+      &lt;/p&gt;
+
+    &lt;/div&gt;
+    &lt;p&gt;
+      Copyright (C) 1989, 1991 Free Software Foundation, Inc.&lt;var class="replacable-license-text"&gt; &lt;/var&gt;&lt;br /&gt;
+
+      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301&lt;var class="optional-license-text"&gt;, &lt;/var&gt;
+      USA
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      Preamble
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      The licenses for most software are designed to take away your freedom
+      to share and change it. By contrast, the GNU General Public License is
+      intended to guarantee your freedom to share and change free software--to
+      make sure the software is free for all its users. This General Public
+      License applies to most of the Free Software Foundation&amp;apos;s software
+      and to any other program whose authors commit to using it. (Some other
+      Free Software Foundation software is covered by the GNU Lesser General
+      Public License instead.) You can apply it to your programs, too.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      When we speak of free software, we are referring to freedom, not price.
+      Our General Public Licenses are designed to make sure that you have
+      the freedom to distribute copies of free software (and charge for
+      this service if you wish), that you receive source code or can get
+      it if you want it, that you can change the software or use pieces of
+      it in new free programs; and that you know you can do these things.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      To protect your rights, we need to make restrictions that forbid
+      anyone to deny you these rights or to ask you to surrender the
+      rights. These restrictions translate to certain responsibilities for
+      you if you distribute copies of the software, or if you modify it.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      For example, if you distribute copies of such a program, whether gratis
+      or for a fee, you must give the recipients all the rights that you
+      have. You must make sure that they, too, receive or can get the source
+      code. And you must show them these terms so they know their rights.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      We protect your rights with two steps: (1) copyright the
+      software, and (2) offer you this license which gives you legal
+      permission to copy, distribute and/or modify the software.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      Also, for each author&amp;apos;s protection and ours, we want to make
+      certain that everyone understands that there is no warranty for
+      this free software. If the software is modified by someone else
+      and passed on, we want its recipients to know that what they
+      have is not the original, so that any problems introduced by
+      others will not reflect on the original authors&amp;apos; reputations.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      Finally, any free program is threatened constantly by software patents.
+      We wish to avoid the danger that redistributors of a free program
+      will individually obtain patent licenses, in effect making the program
+      proprietary. To prevent this, we have made it clear that any patent
+      must be licensed for everyone&amp;apos;s free use or not licensed at all.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      The precise terms and conditions for copying,
+      distribution and modification follow.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      &lt;var class="replacable-license-text"&gt; &lt;/var&gt;
+      TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+    &lt;/p&gt;
+
+&lt;ul style="list-style:none"&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 0.&lt;/var&gt;
+        This License applies to any program or other work which contains a
+        notice placed by the copyright holder saying it may be distributed
+        under the terms of this General Public License. The &amp;quot;Program&amp;quot;, below,
+        refers to any such program or work, and a &amp;quot;work based on the Program&amp;quot;
+        means either the Program or any derivative work under copyright law:
+        that is to say, a work containing the Program or a portion of it,
+        either verbatim or with modifications and/or translated into another
+        language. (Hereinafter, translation is included without limitation
+        in the term &amp;quot;modification&amp;quot;.) Each licensee is addressed as &amp;quot;you&amp;quot;.
+        &lt;p&gt;
+          Activities other than copying, distribution and modification are
+          not covered by this License; they are outside its scope. The act
+          of running the Program is not restricted, and the output from the
+          Program is covered only if its contents constitute a work based
+          on the Program (independent of having been made by running the
+          Program). Whether that is true depends on what the Program does.
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 1.&lt;/var&gt;
+        You may copy and distribute verbatim copies of the Program&amp;apos;s source
+        code as you receive it, in any medium, provided that you conspicuously
+        and appropriately publish on each copy an appropriate copyright notice
+        and disclaimer of warranty; keep intact all the notices that refer to
+        this License and to the absence of any warranty; and give any other
+        recipients of the Program a copy of this License along with the Program.
+        &lt;p&gt;
+          You may charge a fee for the physical act of
+          transferring a copy, and you may at your option
+          offer warranty protection in exchange for a fee.
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 2.&lt;/var&gt;
+        You may modify your copy or copies of the Program or any portion
+        of it, thus forming a work based on the Program, and copy and
+        distribute such modifications or work under the terms of Section
+        1 above, provided that you also meet all of these conditions:
+        
+&lt;ul style="list-style:none"&gt;
+          
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; a)&lt;/var&gt;
+            You must cause the modified files to carry prominent notices
+            stating that you changed the files and the date of any change.
+          &lt;/li&gt;
+          
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; b)&lt;/var&gt;
+            You must cause any work that you distribute or publish,
+            that in whole or in part contains or is derived from the
+            Program or any part thereof, to be licensed as a whole at no
+            charge to all third parties under the terms of this License.
+          &lt;/li&gt;
+          
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; c)&lt;/var&gt;
+            If the modified program normally reads commands interactively
+            when run, you must cause it, when started running for such
+            interactive use in the most ordinary way, to print or display
+            an announcement including an appropriate copyright notice and
+            a notice that there is no warranty (or else, saying that you
+            provide a warranty) and that users may redistribute the program
+            under these conditions, and telling the user how to view a copy
+            of this License. (Exception: if the Program itself is interactive
+            but does not normally print such an announcement, your work
+            based on the Program is not required to print an announcement.)
+          &lt;/li&gt;
+        
+&lt;/ul&gt;
+        &lt;p&gt;
+          These requirements apply to the modified work as a whole. If
+          identifiable sections of that work are not derived from the
+          Program, and can be reasonably considered independent and separate
+          works in themselves, then this License, and its terms, do not
+          apply to those sections when you distribute them as separate
+          works. But when you distribute the same sections as part of a
+          whole which is a work based on the Program, the distribution
+          of the whole must be on the terms of this License, whose
+          permissions for other licensees extend to the entire whole,
+          and thus to each and every part regardless of who wrote it.
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          Thus, it is not the intent of this section to claim rights or
+          contest your rights to work written entirely by you; rather,
+          the intent is to exercise the right to control the distribution
+          of derivative or collective works based on the Program.
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          In addition, mere aggregation of another work not based on
+          the Program with the Program (or with a work based on the
+          Program) on a volume of a storage or distribution medium does
+          not bring the other work under the scope of this License.
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 3.&lt;/var&gt;
+        You may copy and distribute the Program (or a work based on it,
+        under Section 2) in object code or executable form under the terms of
+        Sections 1 and 2 above provided that you also do one of the following:
+        
+&lt;ul style="list-style:none"&gt;
+          
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; a)&lt;/var&gt;
+            Accompany it with the complete corresponding machine-readable source
+            code, which must be distributed under the terms of Sections 1 and
+            2 above on a medium customarily used for software interchange; or,
+          &lt;/li&gt;
+          
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; b)&lt;/var&gt;
+            Accompany it with a written offer, valid for at least three
+            years, to give any third party, for a charge no more than your
+            cost of physically performing source distribution, a complete
+            machine-readable copy of the corresponding source code, to
+            be distributed under the terms of Sections 1 and 2 above
+            on a medium customarily used for software interchange; or,
+          &lt;/li&gt;
+          
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; c)&lt;/var&gt;
+            Accompany it with the information you received as to the offer
+            to distribute corresponding source code. (This alternative
+            is allowed only for noncommercial distribution and only if
+            you received the program in object code or executable form
+            with such an offer, in accord with Subsection b above.)
+          &lt;/li&gt;
+        
+&lt;/ul&gt;
+        &lt;p&gt;
+          The source code for a work means the preferred form of the work
+          for making modifications to it. For an executable work, complete
+          source code means all the source code for all modules it contains,
+          plus any associated interface definition files, plus the scripts
+          used to control compilation and installation of the executable.
+          However, as a special exception, the source code distributed
+          need not include anything that is normally distributed (in either
+          source or binary form) with the major components (compiler,
+          kernel, and so on) of the operating system on which the executable
+          runs, unless that component itself accompanies the executable.
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          If distribution of executable or object code is made by offering
+          access to copy from a designated place, then offering equivalent
+          access to copy the source code from the same place counts as
+          distribution of the source code, even though third parties are
+          not compelled to copy the source along with the object code.
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 4.&lt;/var&gt;
+        You may not copy, modify, sublicense, or distribute the Program
+        except as expressly provided under this License. Any attempt
+        otherwise to copy, modify, sublicense or distribute the Program
+        is void, and will automatically terminate your rights under
+        this License. However, parties who have received copies, or
+        rights, from you under this License will not have their licenses
+        terminated so long as such parties remain in full compliance.
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 5.&lt;/var&gt;
+        You are not required to accept this License, since you have
+        not signed it. However, nothing else grants you permission to
+        modify or distribute the Program or its derivative works. These
+        actions are prohibited by law if you do not accept this License.
+        Therefore, by modifying or distributing the Program (or any
+        work based on the Program), you indicate your acceptance of this
+        License to do so, and all its terms and conditions for copying,
+        distributing or modifying the Program or works based on it.
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 6.&lt;/var&gt;
+        Each time you redistribute the Program (or any work based on the
+        Program), the recipient automatically receives a license from the
+        original licensor to copy, distribute or modify the Program subject to
+        these terms and conditions. You may not impose any further restrictions
+        on the recipients&amp;apos; exercise of the rights granted herein. You are not
+        responsible for enforcing compliance by third parties to this License.
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 7.&lt;/var&gt;
+        If, as a consequence of a court judgment or allegation of patent
+        infringement or for any other reason (not limited to patent issues),
+        conditions are imposed on you (whether by court order, agreement
+        or otherwise) that contradict the conditions of this License,
+        they do not excuse you from the conditions of this License. If you
+        cannot distribute so as to satisfy simultaneously your obligations
+        under this License and any other pertinent obligations, then as a
+        consequence you may not distribute the Program at all. For example,
+        if a patent license would not permit royalty-free redistribution of
+        the Program by all those who receive copies directly or indirectly
+        through you, then the only way you could satisfy both it and this
+        License would be to refrain entirely from distribution of the Program.
+        &lt;p&gt;
+          If any portion of this section is held invalid or
+          unenforceable under any particular circumstance, the
+          balance of the section is intended to apply and the section
+          as a whole is intended to apply in other circumstances.
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          It is not the purpose of this section to induce you to infringe
+          any patents or other property right claims or to contest
+          validity of any such claims; this section has the sole purpose
+          of protecting the integrity of the free software distribution
+          system, which is implemented by public license practices. Many
+          people have made generous contributions to the wide range of
+          software distributed through that system in reliance on consistent
+          application of that system; it is up to the author/donor to
+          decide if he or she is willing to distribute software through
+          any other system and a licensee cannot impose that choice.
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          This section is intended to make thoroughly clear what is
+          believed to be a consequence of the rest of this License.
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 8.&lt;/var&gt;
+        If the distribution and/or use of the Program is restricted in
+        certain countries either by patents or by copyrighted interfaces,
+        the original copyright holder who places the Program under this
+        License may add an explicit geographical distribution limitation
+        excluding those countries, so that distribution is permitted only
+        in or among countries not thus excluded. In such case, this License
+        incorporates the limitation as if written in the body of this License.
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 9.&lt;/var&gt;
+        The Free Software Foundation may publish revised and/or new
+        versions of the General Public License from time to time. Such
+        new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        &lt;p&gt;
+          Each version is given a distinguishing version number. If the
+          Program specifies a version number of this License which applies
+          to it and &amp;quot;any later version&amp;quot;, you have the option of following
+          the terms and conditions either of that version or of any later
+          version published by the Free Software Foundation. If the Program
+          does not specify a version number of this License, you may choose
+          any version ever published by the Free Software Foundation.
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 10.&lt;/var&gt;
+        If you wish to incorporate parts of the Program into other free
+        programs whose distribution conditions are different, write to the
+        author to ask for permission. For software which is copyrighted by the
+        Free Software Foundation, write to the Free Software Foundation; we
+        sometimes make exceptions for this. Our decision will be guided by the
+        two goals of preserving the free status of all derivatives of our free
+        software and of promoting the sharing and reuse of software generally.
+        &lt;p&gt;
+          NO WARRANTY
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 11.&lt;/var&gt;
+        BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+        FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT
+        WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
+        PARTIES PROVIDE THE PROGRAM &amp;quot;AS IS&amp;quot; WITHOUT WARRANTY OF ANY KIND,
+        EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+        PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF
+        THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU
+        ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 12.&lt;/var&gt;
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+        REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+        DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+        DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM
+        (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+        INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+        THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      &lt;/li&gt;
+    
+&lt;/ul&gt;
+    &lt;div class="optional-license-text"&gt; 
+      &lt;p&gt;
+        END OF TERMS AND CONDITIONS
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        How to Apply These Terms to Your New Programs
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        If you develop a new program, and you want it to be
+        of the greatest possible use to the public, the best
+        way to achieve this is to make it free software which
+        everyone can redistribute and change under these terms.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        To do so, attach the following notices to the program. It is safest
+        to attach them to the start of each source file to most effectively
+        convey the exclusion of warranty; and each file should have at least
+        the &amp;quot;copyright&amp;quot; line and a pointer to where the full notice is found.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        &lt;var class="optional-license-text"&gt;&amp;lt;&lt;/var&gt;one line to give the program&amp;apos;s name and &lt;var class="replacable-license-text"&gt; an&lt;/var&gt; idea of what it does.&lt;var class="optional-license-text"&gt;&amp;gt;&lt;/var&gt;
+        &lt;br /&gt;
+
+        Copyright (C)
+        &lt;var class="optional-license-text"&gt;&amp;lt;&lt;/var&gt;&lt;var class="replacable-license-text"&gt; yyyy&lt;/var&gt;&lt;var class="optional-license-text"&gt;&amp;gt; &lt;/var&gt;
+        &lt;var class="optional-license-text"&gt; &amp;lt;&lt;/var&gt;name of author&lt;var class="optional-license-text"&gt;&amp;gt;&lt;/var&gt;
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        This program is free software; you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation; either version
+        2 of the License, or (at your option) any later version.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        You should have received a copy of the GNU General Public License
+        along with this program; if not, write to the Free Software Foundation,
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301&lt;var class="optional-license-text"&gt;, &lt;/var&gt;
+        USA.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        Also add information on how to
+        contact you by electronic and paper mail.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        If the program is interactive, make it output a short
+        notice like this when it starts in an interactive mode:
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        Gnomovision version 69, Copyright (C) year name of author
+        Gnomovision comes with ABSOLUTELY NO WARRANTY; for details
+        type `show w&amp;apos;. This is free software, and you are welcome to
+        redistribute it under certain conditions; type `show c&amp;apos; for details.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        The hypothetical commands `show w&amp;apos; and `show c&amp;apos; should show the
+        appropriate parts of the General Public License. Of course, the commands
+        you use may be called something other than `show w&amp;apos; and `show c&amp;apos;; they
+        could even be mouse-clicks or menu items--whatever suits your program.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        You should also get your employer (if you work as a programmer)
+        or your school, if any, to sign a &amp;quot;copyright disclaimer&amp;quot; for
+        the program, if necessary. Here is a sample; alter the names:
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+        `Gnomovision&amp;apos; (which makes passes at compilers) written by James Hacker.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+	&lt;var class="optional-license-text"&gt;&amp;lt;&lt;/var&gt;signature of Ty Coon&lt;var class="optional-license-text"&gt; &amp;gt;&lt;/var&gt;,
+	1 April 1989 Ty Coon, President of Vice
+      &lt;/p&gt;
+
+    &lt;/div&gt;
+    &lt;div class="optional-license-text"&gt; 
+      &lt;p&gt;
+        This General Public License does not permit incorporating your program into
+        proprietary programs.  If your program is a subroutine library, you may
+        consider it more useful to permit linking proprietary applications with the
+        library.  If this is what you want to do, use the GNU Lesser General
+        Public License instead of this License.
+      &lt;/p&gt;
+
+    &lt;/div&gt;
+    </spdx:licenseTextHtml>
+        <spdx:isOsiApproved rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+        >true</spdx:isOsiApproved>
+        <spdx:licenseText>GNU GENERAL PUBLIC LICENSE
+Version 2, June 1991
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users. This General Public License applies to most of the Free Software Foundation's software and to any other program whose authors commit to using it. (Some other Free Software Foundation software is covered by the GNU Lesser General Public License instead.) You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or for a fee, you must give the recipients all the rights that you have. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2) offer you this license which gives you legal permission to copy, distribute and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain that everyone understands that there is no warranty for this free software. If the software is modified by someone else and passed on, we want its recipients to know that what they have is not the original, so that any problems introduced by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that redistributors of a free program will individually obtain patent licenses, in effect making the program proprietary. To prevent this, we have made it clear that any patent must be licensed for everyone's free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains a notice placed by the copyright holder saying it may be distributed under the terms of this General Public License. The "Program", below, refers to any such program or work, and a "work based on the Program" means either the Program or any derivative work under copyright law: that is to say, a work containing the Program or a portion of it, either verbatim or with modifications and/or translated into another language. (Hereinafter, translation is included without limitation in the term "modification".) Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running the Program is not restricted, and the output from the Program is covered only if its contents constitute a work based on the Program (independent of having been made by running the Program). Whether that is true depends on what the Program does.
+
+1. You may copy and distribute verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and give any other recipients of the Program a copy of this License along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion of it, thus forming a work based on the Program, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+     a) You must cause the modified files to carry prominent notices stating that you changed the files and the date of any change.
+
+     b) You must cause any work that you distribute or publish, that in whole or in part contains or is derived from the Program or any part thereof, to be licensed as a whole at no charge to all third parties under the terms of this License.
+
+     c) If the modified program normally reads commands interactively when run, you must cause it, when started running for such interactive use in the most ordinary way, to print or display an announcement including an appropriate copyright notice and a notice that there is no warranty (or else, saying that you provide a warranty) and that users may redistribute the program under these conditions, and telling the user how to view a copy of this License. (Exception: if the Program itself is interactive but does not normally print such an announcement, your work based on the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Program, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Program, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program with the Program (or with a work based on the Program) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+3. You may copy and distribute the Program (or a work based on it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you also do one of the following:
+
+     a) Accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+
+     b) Accompany it with a written offer, valid for at least three years, to give any third party, for a charge no more than your cost of physically performing source distribution, a complete machine-readable copy of the corresponding source code, to be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
+
+     c) Accompany it with the information you received as to the offer to distribute corresponding source code. (This alternative is allowed only for noncommercial distribution and only if you received the program in object code or executable form with such an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for making modifications to it. For an executable work, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the executable. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+If distribution of executable or object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place counts as distribution of the source code, even though third parties are not compelled to copy the source along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense or distribute the Program is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Program or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Program (or any work based on the Program), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the Program), the recipient automatically receives a license from the original licensor to copy, distribute or modify the Program subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Program at all. For example, if a patent license would not permit royalty-free redistribution of the Program by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system, which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Program under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+9. The Free Software Foundation may publish revised and/or new versions of the General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of this License, you may choose any version ever published by the Free Software Foundation.
+
+10. If you wish to incorporate parts of the Program into other free programs whose distribution conditions are different, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     one line to give the program's name and an idea of what it does. Copyright (C) yyyy name of author
+
+     This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+     You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA. Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this when it starts in an interactive mode:
+
+     Gnomovision version 69, Copyright (C) year name of author Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'. This is free software, and you are welcome to redistribute it under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate parts of the General Public License. Of course, the commands you use may be called something other than `show w' and `show c'; they could even be mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the program, if necessary. Here is a sample; alter the names:
+
+     Yoyodyne, Inc., hereby disclaims all copyright interest in the program `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+signature of Ty Coon, 1 April 1989 Ty Coon, President of Vice
+</spdx:licenseText>
+        <spdx:standardLicenseHeader>Copyright (C) yyyy name of author
+
+This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; version 2.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+</spdx:standardLicenseHeader>
+        <spdx:standardLicenseHeaderHtml>
+      Copyright (C) &lt;var class="replacable-license-text"&gt; yyyy name of author&lt;/var&gt;
+      &lt;p&gt;
+        This program is free software; you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation; version 2.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        This program is distributed in the hope that it will be
+        useful, but WITHOUT ANY WARRANTY; without even the implied
+        warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU General Public License for more details.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        You should have received a copy of the GNU General Public License
+        along with this program; if not, write to the Free Software Foundation,
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301&lt;var class="optional-license-text"&gt;, &lt;/var&gt;
+        USA.
+      &lt;/p&gt;
+
+    </spdx:standardLicenseHeaderHtml>
+      </spdx:ListedLicense>
+    </spdx:licenseInfoInSnippet>
+    <spdx:licenseConcluded rdf:resource="http://spdx.org/licenses/GPL-2.0-only"/>
+    <spdx:range>
+      <ptr:StartEndPointer>
+        <ptr:endPointer>
+          <ptr:LineCharPointer>
+            <ptr:lineNumber rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+            >23</ptr:lineNumber>
+            <ptr:reference rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+          </ptr:LineCharPointer>
+        </ptr:endPointer>
+        <ptr:startPointer>
+          <ptr:LineCharPointer>
+            <ptr:lineNumber rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+            >5</ptr:lineNumber>
+            <ptr:reference rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+          </ptr:LineCharPointer>
+        </ptr:startPointer>
+      </ptr:StartEndPointer>
+    </spdx:range>
+    <rdfs:comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0.</rdfs:comment>
+    <spdx:range>
+      <ptr:StartEndPointer>
+        <ptr:endPointer>
+          <ptr:ByteOffsetPointer>
+            <ptr:offset rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+            >420</ptr:offset>
+            <ptr:reference rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+          </ptr:ByteOffsetPointer>
+        </ptr:endPointer>
+        <ptr:startPointer>
+          <ptr:ByteOffsetPointer>
+            <ptr:offset rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+            >310</ptr:offset>
+            <ptr:reference rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+          </ptr:ByteOffsetPointer>
+        </ptr:startPointer>
+      </ptr:StartEndPointer>
+    </spdx:range>
+  </spdx:Snippet>
+  <spdx:SpdxNoAssertionLicense rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#NOASSERTION_LICENSE_ID"/>
+  <spdx:SpdxDocument rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DOCUMENT">
+    <spdx:creationInfo>
+      <spdx:CreationInfo>
+        <rdfs:comment>This package has been shipped in source and binary form.
+The binaries were created with gcc 4.5.1 and expect to link to
+compatible system run time libraries.</rdfs:comment>
+        <spdx:created>2010-01-29T18:30:22Z</spdx:created>
+        <spdx:creator>Person: Jane Doe ()</spdx:creator>
+        <spdx:creator>Organization: ExampleCodeInspect ()</spdx:creator>
+        <spdx:creator>Tool: LicenseFind-1.0</spdx:creator>
+        <spdx:licenseListVersion>3.17</spdx:licenseListVersion>
+      </spdx:CreationInfo>
+    </spdx:creationInfo>
+    <spdx:relationship>
+      <spdx:Relationship>
+        <spdx:relatedSpdxElement>
+          <spdx:Package rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package">
+            <spdx:downloadLocation>http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz</spdx:downloadLocation>
+            <spdx:relationship>
+              <spdx:Relationship>
+                <spdx:relatedSpdxElement>
+                  <spdx:File rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-CommonsLangSrc">
+                    <spdx:noticeText>Apache Commons Lang
+Copyright 2001-2011 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software from the Spring Framework,
+under the Apache License 2.0 (see: StringUtils.containsWhitespace())</spdx:noticeText>
+                    <spdx:licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+                    <spdx:checksum>
+                      <spdx:Checksum>
+                        <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+                        <spdx:checksumValue>c2b4e1c67a2d28fced849ee1bb76e7391b93f125</spdx:checksumValue>
+                      </spdx:Checksum>
+                    </spdx:checksum>
+                    <spdx:licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+                    <spdx:fileContributor>Apache Software Foundation</spdx:fileContributor>
+                    <spdx:relationship>
+                      <spdx:Relationship>
+                        <spdx:relatedSpdxElement rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
+                        <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_generatedFrom"/>
+                      </spdx:Relationship>
+                    </spdx:relationship>
+                    <spdx:fileName>./lib-source/commons-lang3-3.1-sources.jar</spdx:fileName>
+                    <spdx:copyrightText>Copyright 2001-2011 The Apache Software Foundation</spdx:copyrightText>
+                    <rdfs:comment>This file is used by Jena</rdfs:comment>
+                    <spdx:fileType rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
+                  </spdx:File>
+                </spdx:relatedSpdxElement>
+                <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_contains"/>
+              </spdx:Relationship>
+            </spdx:relationship>
+            <spdx:relationship>
+              <spdx:Relationship>
+                <spdx:relatedSpdxElement>
+                  <spdx:File rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Specification">
+                    <spdx:fileType rdf:resource="http://spdx.org/rdf/terms#fileType_documentation"/>
+                    <spdx:relationship>
+                      <spdx:Relationship>
+                        <spdx:relatedSpdxElement>
+                          <spdx:Package rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-fromDoap-0">
+                            <doap:homepage>http://www.openjena.org/</doap:homepage>
+                            <spdx:externalRef>
+                              <spdx:ExternalRef>
+                                <spdx:referenceCategory rdf:resource="http://spdx.org/rdf/terms#referenceCategory_packageManager"/>
+                                <spdx:referenceType rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#purl"/>
+                                <spdx:referenceLocator>pkg:maven/org.apache.jena/apache-jena@3.12.0</spdx:referenceLocator>
+                              </spdx:ExternalRef>
+                            </spdx:externalRef>
+                            <spdx:versionInfo>3.12.0</spdx:versionInfo>
+                            <spdx:downloadLocation>https://search.maven.org/remotecontent?filepath=org/apache/jena/apache-jena/3.12.0/apache-jena-3.12.0.tar.gz</spdx:downloadLocation>
+                            <spdx:name>Jena</spdx:name>
+                            <spdx:filesAnalyzed rdf:datatype=
+                            "http://www.w3.org/2001/XMLSchema#boolean"
+                            >false</spdx:filesAnalyzed>
+                          </spdx:Package>
+                        </spdx:relatedSpdxElement>
+                        <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_specificationFor"/>
+                      </spdx:Relationship>
+                    </spdx:relationship>
+                    <rdfs:comment>Specification Documentation</rdfs:comment>
+                    <spdx:checksum>
+                      <spdx:Checksum>
+                        <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+                        <spdx:checksumValue>fff4e1c67a2d28fced849ee1bb76e7391b93f125</spdx:checksumValue>
+                      </spdx:Checksum>
+                    </spdx:checksum>
+                    <spdx:fileName>./docs/myspec.pdf</spdx:fileName>
+                  </spdx:File>
+                </spdx:relatedSpdxElement>
+                <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_contains"/>
+              </spdx:Relationship>
+            </spdx:relationship>
+            <spdx:primaryPackagePurpose rdf:resource="http://spdx.org/rdf/terms#purpose_source"/>
+            <spdx:checksum>
+              <spdx:Checksum>
+                <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_blake2b384"/>
+                <spdx:checksumValue>aaabd89c926ab525c242e6621f2f5fa73aa4afe3d9e24aed727faaadd6af38b620bdb623dd2b4788b1c8086984af8706</spdx:checksumValue>
+              </spdx:Checksum>
+            </spdx:checksum>
+            <spdx:licenseComments>The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change.</spdx:licenseComments>
+            <spdx:filesAnalyzed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >true</spdx:filesAnalyzed>
+            <spdx:licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/GPL-2.0-only"/>
+            <spdx:versionInfo>2.11.1</spdx:versionInfo>
+            <spdx:checksum>
+              <spdx:Checksum>
+                <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_md5"/>
+                <spdx:checksumValue>624c1abb3664f4b35547e7c73864ad24</spdx:checksumValue>
+              </spdx:Checksum>
+            </spdx:checksum>
+            <spdx:builtDate>2011-01-29T18:30:22Z</spdx:builtDate>
+            <spdx:licenseInfoFromFiles>
+              <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-1">
+                <spdx:licenseId>LicenseRef-1</spdx:licenseId>
+                <spdx:extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/</spdx:extractedText>
+              </spdx:ExtractedLicensingInfo>
+            </spdx:licenseInfoFromFiles>
+            <doap:homepage>http://ftp.gnu.org/gnu/glibc</doap:homepage>
+            <spdx:name>glibc</spdx:name>
+            <spdx:supplier>Person: Jane Doe (jane.doe@example.com)</spdx:supplier>
+            <spdx:externalRef>
+              <spdx:ExternalRef>
+                <spdx:referenceCategory rdf:resource="http://spdx.org/rdf/terms#referenceCategory_other"/>
+                <rdfs:comment>This is the external ref for Acme</rdfs:comment>
+                <spdx:referenceType rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge"/>
+                <spdx:referenceLocator>acmecorp/acmenator/4.1.3-alpha</spdx:referenceLocator>
+              </spdx:ExternalRef>
+            </spdx:externalRef>
+            <spdx:externalRef>
+              <spdx:ExternalRef>
+                <spdx:referenceCategory rdf:resource="http://spdx.org/rdf/terms#referenceCategory_security"/>
+                <spdx:referenceType rdf:resource="http://spdx.org/rdf/references/cpe23Type"/>
+                <spdx:referenceLocator>cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*</spdx:referenceLocator>
+              </spdx:ExternalRef>
+            </spdx:externalRef>
+            <spdx:licenseConcluded>
+              <spdx:DisjunctiveLicenseSet>
+                <spdx:member>
+                  <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-3">
+                    <rdfs:seeAlso>http://justasample.url.com</rdfs:seeAlso>
+                    <rdfs:seeAlso>http://people.apache.org/~andyc/neko/LICENSE</rdfs:seeAlso>
+                    <spdx:licenseId>LicenseRef-3</spdx:licenseId>
+                    <rdfs:comment>This is tye CyperNeko License</rdfs:comment>
+                    <spdx:extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</spdx:extractedText>
+                    <spdx:name>CyberNeko License</spdx:name>
+                  </spdx:ExtractedLicensingInfo>
+                </spdx:member>
+                <spdx:member>
+                  <spdx:ListedLicense rdf:about="http://spdx.org/licenses/LGPL-2.0-only">
+                    <spdx:licenseText>GNU LIBRARY GENERAL PUBLIC LICENSE
+
+Version 2, June 1991
+
+Copyright (C) 1991 Free Software Foundation, Inc.
+51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+[This is the first released version of the library GPL.  It is numbered 2 because it goes with version 2 of the ordinary GPL.]
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public Licenses are intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users.
+
+This license, the Library General Public License, applies to some specially designated Free Software Foundation software, and to any other libraries whose authors decide to use it. You can use it for your libraries, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library, or if you modify it.
+
+For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you link a program with the library, you must provide complete object files to the recipients so that they can relink them with the library, after making changes to the library and recompiling it. And you must show them these terms so they know their rights.
+
+Our method of protecting your rights has two steps: (1) copyright the library, and (2) offer you this license which gives you legal permission to copy, distribute and/or modify the library.
+
+Also, for each distributor's protection, we want to make certain that everyone understands that there is no warranty for this free library. If the library is modified by someone else and passed on, we want its recipients to know that what they have is not the original version, so that any problems introduced by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that companies distributing free software will individually obtain patent licenses, thus in effect transforming the program into proprietary software. To prevent this, we have made it clear that any patent must be licensed for everyone's free use or not licensed at all.
+
+Most GNU software, including some libraries, is covered by the ordinary GNU General Public License, which was designed for utility programs. This license, the GNU Library General Public License, applies to certain designated libraries. This license is quite different from the ordinary one; be sure to read it in full, and don't assume that anything in it is the same as in the ordinary license.
+
+The reason we have a separate public license for some libraries is that they blur the distinction we usually make between modifying or adding to a program and simply using it. Linking a program with a library, without changing the library, is in some sense simply using the library, and is analogous to running a utility program or application program. However, in a textual and legal sense, the linked executable is a combined work, a derivative of the original library, and the ordinary General Public License treats it as such.
+
+Because of this blurred distinction, using the ordinary General Public License for libraries did not effectively promote software sharing, because most developers did not use the libraries. We concluded that weaker conditions might promote sharing better.
+
+However, unrestricted linking of non-free programs would deprive the users of those programs of all benefit from the free status of the libraries themselves. This Library General Public License is intended to permit developers of non-free programs to use free libraries, while preserving your freedom as a user of such programs to change the free libraries that are incorporated in them. (We have not seen how to achieve this as regards changes in header files, but we have achieved it as regards changes in the actual functions of the Library.) The hope is that this will lead to faster development of free libraries.
+
+The precise terms and conditions for copying, distribution and modification follow. Pay close attention to the difference between a "work based on the library" and a "work that uses the library". The former contains code derived from the library, while the latter only works together with the library.
+
+Note that it is possible for a library to be covered by the ordinary General Public License rather than by this special one.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License Agreement applies to any software library which contains a notice placed by the copyright holder or other authorized party saying it may be distributed under the terms of this Library General Public License (also called "this License"). Each licensee is addressed as "you".
+
+A "library" means a collection of software functions and/or data prepared so as to be conveniently linked with application programs (which use some of those functions and data) to form executables.
+
+The "Library", below, refers to any such software library or work which has been distributed under these terms. A "work based on the Library" means either the Library or any derivative work under copyright law: that is to say, a work containing the Library or a portion of it, either verbatim or with modifications and/or translated straightforwardly into another language. (Hereinafter, translation is included without limitation in the term "modification".)
+
+"Source code" for a work means the preferred form of the work for making modifications to it. For a library, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the library.
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running a program using the Library is not restricted, and output from such a program is covered only if its contents constitute a work based on the Library (independent of the use of the Library in a tool for writing it). Whether that is true depends on what the Library does and what the program that uses the Library does.
+
+1. You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and distribute a copy of this License along with the Library.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Library or any portion of it, thus forming a work based on the Library, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+     a) The modified work must itself be a software library.
+
+     b) You must cause the files modified to carry prominent notices stating that you changed the files and the date of any change.
+
+     c) You must cause the whole of the work to be licensed at no charge to all third parties under the terms of this License.
+
+     d) If a facility in the modified Library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful.
+
+(For example, a function in a library to compute square roots has a purpose that is entirely well-defined independent of the application. Therefore, Subsection 2d requires that any application-supplied function or table used by this function must be optional: if the application does not supply it, the square root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Library, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Library, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library with the Library (or with a work based on the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+3. You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if you wish.) Do not make any other change in these notices.
+
+Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU General Public License applies to all subsequent copies and derivative works made from that copy.
+
+This option is useful when you wish to copy part of the code of the Library into a program that is not a library.
+
+4. You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange.
+
+If distribution of object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place satisfies the requirement to distribute the source code, even though third parties are not compelled to copy the source along with the object code.
+
+5. A program that contains no derivative of any portion of the Library, but is designed to work with the Library by being compiled or linked with it, is called a "work that uses the Library". Such a work, in isolation, is not a derivative work of the Library, and therefore falls outside the scope of this License.
+
+However, linking a "work that uses the Library" with the Library creates an executable that is a derivative of the Library (because it contains portions of the Library), rather than a "work that uses the library". The executable is therefore covered by this License. Section 6 states terms for distribution of such executables.
+
+When a "work that uses the Library" uses material from a header file that is part of the Library, the object code for the work may be a derivative work of the Library even though the source code is not. Whether this is true is especially significant if the work can be linked without the Library, or if the work is itself a library. The threshold for this to be true is not precisely defined by law.
+
+If such an object file uses only numerical parameters, data structure layouts and accessors, and small macros and small inline functions (ten lines or less in length), then the use of the object file is unrestricted, regardless of whether it is legally a derivative work. (Executables containing this object code plus portions of the Library will still fall under Section 6.)
+
+Otherwise, if the work is a derivative of the Library, you may distribute the object code for the work under the terms of Section 6. Any executables containing that work also fall under Section 6, whether or not they are linked directly with the Library itself.
+
+6. As an exception to the Sections above, you may also compile or link a "work that uses the Library" with the Library to produce a work containing portions of the Library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's own use and reverse engineering for debugging such modifications.
+
+You must give prominent notice with each copy of the work that the Library is used in it and that the Library and its use are covered by this License. You must supply a copy of this License. If the work during execution displays copyright notices, you must include the copyright notice for the Library among them, as well as a reference directing the user to the copy of this License. Also, you must do one of these things:
+
+     a) Accompany the work with the complete corresponding machine-readable source code for the Library including whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the work is an executable linked with the Library, with the complete machine-readable "work that uses the Library", as object code and/or source code, so that the user can modify the Library and then relink to produce a modified executable containing the modified Library. (It is understood that the user who changes the contents of definitions files in the Library will not necessarily be able to recompile the application to use the modified definitions.)
+
+     b) Accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of performing this distribution.
+
+     c) If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place.
+
+     d) Verify that the user has already received a copy of these materials or that you have already sent this user a copy.
+
+For an executable, the required form of the "work that uses the Library" must include any data and utility programs needed for reproducing the executable from it. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+It may happen that this requirement contradicts the license restrictions of other proprietary libraries that do not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library together in an executable that you distribute.
+
+7. You may place library facilities that are a work based on the Library side-by-side in a single library together with other library facilities not covered by this License, and distribute such a combined library, provided that the separate distribution of the work based on the Library and of the other library facilities is otherwise permitted, and provided that you do these two things:
+
+     a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities. This must be distributed under the terms of the Sections above.
+
+     b) Give prominent notice with the combined library of the fact that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+8. You may not copy, modify, sublicense, link with, or distribute the Library except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or distribute the Library is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+9. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Library or works based on it.
+
+10. Each time you redistribute the Library (or any work based on the Library), the recipient automatically receives a license from the original licensor to copy, distribute, link with or modify the Library subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties to this License.
+
+11. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license would not permit royalty-free redistribution of the Library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply, and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+12. If the distribution and/or use of the Library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Library under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+13. The Free Software Foundation may publish revised and/or new versions of the Library General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Library does not specify a license version number, you may choose any version ever published by the Free Software Foundation.
+
+14. If you wish to incorporate parts of the Library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Libraries
+
+If you develop a new library, and you want it to be of the greatest possible use to the public, we recommend making it free software that everyone can redistribute and change. You can do so by permitting redistribution under these terms (or, alternatively, under the terms of the ordinary General Public License).
+
+To apply these terms, attach the following notices to the library. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     one line to give the library's name and an idea of what it does.
+     Copyright (C) year  name of author
+
+     This library is free software; you can redistribute it and/or modify it under the terms of the GNU Library General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+     This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public License for more details.
+
+     You should have received a copy of the GNU Library General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the library, if necessary. Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in
+the library `Frob' (a library for tweaking knobs) written
+by James Random Hacker.
+
+signature of Ty Coon, 1 April 1990
+Ty Coon, President of Vice
+
+That's all there is to it!
+</spdx:licenseText> <spdx:licenseId>LGPL-2.0-only</spdx:licenseId>
+                    <rdfs:seeAlso>https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</rdfs:seeAlso>
+                    <spdx:isDeprecatedLicenseId rdf:datatype=
+                    "http://www.w3.org/2001/XMLSchema#boolean"
+                    >false</spdx:isDeprecatedLicenseId>
+                    <spdx:licenseTextHtml>
+    &lt;div class="optional-license-text"&gt; 
+      &lt;p&gt;
+        GNU LIBRARY GENERAL PUBLIC LICENSE
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        Version 2, June 1991
+      &lt;/p&gt;
+
+    &lt;/div&gt;
+    &lt;div class="replacable-license-text"&gt; 
+      &lt;p&gt;
+        Copyright (C) 1991 Free Software Foundation, Inc.&lt;br /&gt;
+
+        51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+      &lt;/p&gt;
+
+    &lt;/div&gt;
+    &lt;p&gt;
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      [This is the first released version of the library GPL. It is
+      numbered 2 because it goes with version 2 of the ordinary GPL.]
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      Preamble
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      The licenses for most software are designed to take away your
+      freedom to share and change it. By contrast, the GNU General Public
+      Licenses are intended to guarantee your freedom to share and change
+      free software--to make sure the software is free for all its users.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      This license, the Library General Public License, applies
+      to some specially designated Free Software Foundation
+      software, and to any other libraries whose authors
+      decide to use it. You can use it for your libraries, too.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      When we speak of free software, we are referring to freedom, not price.
+      Our General Public Licenses are designed to make sure that you have
+      the freedom to distribute copies of free software (and charge for
+      this service if you wish), that you receive source code or can get
+      it if you want it, that you can change the software or use pieces of
+      it in new free programs; and that you know you can do these things.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      To protect your rights, we need to make restrictions that forbid
+      anyone to deny you these rights or to ask you to surrender the
+      rights. These restrictions translate to certain responsibilities for
+      you if you distribute copies of the library, or if you modify it.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      For example, if you distribute copies of the library, whether gratis
+      or for a fee, you must give the recipients all the rights that we
+      gave you. You must make sure that they, too, receive or can get the
+      source code. If you link a program with the library, you must provide
+      complete object files to the recipients so that they can relink them
+      with the library, after making changes to the library and recompiling
+      it. And you must show them these terms so they know their rights.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      Our method of protecting your rights has two steps: (1) copyright
+      the library, and (2) offer you this license which gives you
+      legal permission to copy, distribute and/or modify the library.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      Also, for each distributor&amp;apos;s protection, we want to make certain
+      that everyone understands that there is no warranty for this
+      free library. If the library is modified by someone else and
+      passed on, we want its recipients to know that what they have
+      is not the original version, so that any problems introduced by
+      others will not reflect on the original authors&amp;apos; reputations.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      Finally, any free program is threatened constantly by software
+      patents. We wish to avoid the danger that companies distributing
+      free software will individually obtain patent licenses, thus
+      in effect transforming the program into proprietary software.
+      To prevent this, we have made it clear that any patent must
+      be licensed for everyone&amp;apos;s free use or not licensed at all.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      Most GNU software, including some libraries, is covered by the
+      ordinary GNU General Public License, which was designed for utility
+      programs. This license, the GNU Library General Public License,
+      applies to certain designated libraries. This license is quite
+      different from the ordinary one; be sure to read it in full, and don&amp;apos;t
+      assume that anything in it is the same as in the ordinary license.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      The reason we have a separate public license for some libraries is
+      that they blur the distinction we usually make between modifying
+      or adding to a program and simply using it. Linking a program with
+      a library, without changing the library, is in some sense simply
+      using the library, and is analogous to running a utility program
+      or application program. However, in a textual and legal sense, the
+      linked executable is a combined work, a derivative of the original
+      library, and the ordinary General Public License treats it as such.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      Because of this blurred distinction, using the ordinary General
+      Public License for libraries did not effectively promote software
+      sharing, because most developers did not use the libraries. We
+      concluded that weaker conditions might promote sharing better.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      However, unrestricted linking of non-free programs would deprive the
+      users of those programs of all benefit from the free status of the
+      libraries themselves. This Library General Public License is intended
+      to permit developers of non-free programs to use free libraries, while
+      preserving your freedom as a user of such programs to change the free
+      libraries that are incorporated in them. (We have not seen how to
+      achieve this as regards changes in header files, but we have achieved
+      it as regards changes in the actual functions of the Library.) The
+      hope is that this will lead to faster development of free libraries.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      The precise terms and conditions for copying, distribution
+      and modification follow. Pay close attention to the difference
+      between a &amp;quot;work based on the library&amp;quot; and a &amp;quot;work that uses
+      the library&amp;quot;. The former contains code derived from the
+      library, while the latter only works together with the library.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      Note that it is possible for a library to be covered by the
+      ordinary General Public License rather than by this special one.
+    &lt;/p&gt;
+
+    &lt;p&gt;
+      TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+    &lt;/p&gt;
+
+&lt;ul style="list-style:none"&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 0.&lt;/var&gt;
+        This License Agreement applies to any software library
+        which contains a notice placed by the copyright holder or
+        other authorized party saying it may be distributed under
+        the terms of this Library General Public License (also
+        called &amp;quot;this License&amp;quot;). Each licensee is addressed as &amp;quot;you&amp;quot;.
+        &lt;p&gt;
+          A &amp;quot;library&amp;quot; means a collection of software functions and/or data
+          prepared so as to be conveniently linked with application programs
+          (which use some of those functions and data) to form executables.
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          The &amp;quot;Library&amp;quot;, below, refers to any such software library or work
+          which has been distributed under these terms. A &amp;quot;work based on
+          the Library&amp;quot; means either the Library or any derivative work under
+          copyright law: that is to say, a work containing the Library or a
+          portion of it, either verbatim or with modifications and/or translated
+          straightforwardly into another language. (Hereinafter, translation
+          is included without limitation in the term &amp;quot;modification&amp;quot;.)
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          &amp;quot;Source code&amp;quot; for a work means the preferred form of the work
+          for making modifications to it. For a library, complete source
+          code means all the source code for all modules it contains,
+          plus any associated interface definition files, plus the scripts
+          used to control compilation and installation of the library.
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          Activities other than copying, distribution and modification are
+          not covered by this License; they are outside its scope. The act of
+          running a program using the Library is not restricted, and output
+          from such a program is covered only if its contents constitute a
+          work based on the Library (independent of the use of the Library
+          in a tool for writing it). Whether that is true depends on what
+          the Library does and what the program that uses the Library does.
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 1.&lt;/var&gt;
+        You may copy and distribute verbatim copies of the Library&amp;apos;s complete
+        source code as you receive it, in any medium, provided that you
+        conspicuously and appropriately publish on each copy an appropriate
+        copyright notice and disclaimer of warranty; keep intact all the
+        notices that refer to this License and to the absence of any warranty;
+        and distribute a copy of this License along with the Library.
+        &lt;p&gt;
+          You may charge a fee for the physical act of
+          transferring a copy, and you may at your option
+          offer warranty protection in exchange for a fee.
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 2.&lt;/var&gt;
+        You may modify your copy or copies of the Library or any portion
+        of it, thus forming a work based on the Library, and copy and
+        distribute such modifications or work under the terms of Section
+        1 above, provided that you also meet all of these conditions:
+        
+&lt;ul style="list-style:none"&gt;
+          
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; a)&lt;/var&gt;
+            The modified work must itself be a software library.
+          &lt;/li&gt;
+          
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; b)&lt;/var&gt;
+            You must cause the files modified to carry prominent notices
+            stating that you changed the files and the date of any change.
+          &lt;/li&gt;
+          
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; c)&lt;/var&gt;
+            You must cause the whole of the work to be licensed at no
+            charge to all third parties under the terms of this License.
+          &lt;/li&gt;
+          
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; d)&lt;/var&gt;
+            If a facility in the modified Library refers to a function
+            or a table of data to be supplied by an application program
+            that uses the facility, other than as an argument passed
+            when the facility is invoked, then you must make a good faith
+            effort to ensure that, in the event an application does not
+            supply such function or table, the facility still operates,
+            and performs whatever part of its purpose remains meaningful.
+            &lt;p&gt;
+              (For example, a function in a library to compute square roots
+              has a purpose that is entirely well-defined independent of
+              the application. Therefore, Subsection 2d requires that any
+              application-supplied function or table used by this function
+              must be optional: if the application does not supply it,
+              the square root function must still compute square roots.)
+            &lt;/p&gt;
+
+          &lt;/li&gt;
+        
+&lt;/ul&gt;
+        &lt;p&gt;
+          These requirements apply to the modified work as a whole. If
+          identifiable sections of that work are not derived from the
+          Library, and can be reasonably considered independent and separate
+          works in themselves, then this License, and its terms, do not
+          apply to those sections when you distribute them as separate
+          works. But when you distribute the same sections as part of a
+          whole which is a work based on the Library, the distribution
+          of the whole must be on the terms of this License, whose
+          permissions for other licensees extend to the entire whole,
+          and thus to each and every part regardless of who wrote it.
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          Thus, it is not the intent of this section to claim rights or
+          contest your rights to work written entirely by you; rather,
+          the intent is to exercise the right to control the distribution
+          of derivative or collective works based on the Library.
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          In addition, mere aggregation of another work not based on
+          the Library with the Library (or with a work based on the
+          Library) on a volume of a storage or distribution medium does
+          not bring the other work under the scope of this License.
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 3.&lt;/var&gt;
+        You may opt to apply the terms of the ordinary GNU General
+        Public License instead of this License to a given copy of the
+        Library. To do this, you must alter all the notices that refer
+        to this License, so that they refer to the ordinary GNU General
+        Public License, version 2, instead of to this License. (If a
+        newer version than version 2 of the ordinary GNU General Public
+        License has appeared, then you can specify that version instead
+        if you wish.) Do not make any other change in these notices.
+        &lt;p&gt;
+          Once this change is made in a given copy, it is irreversible for
+          that copy, so the ordinary GNU General Public License applies to
+          all subsequent copies and derivative works made from that copy.
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          This option is useful when you wish to copy part of the
+          code of the Library into a program that is not a library.
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 4.&lt;/var&gt;
+        You may copy and distribute the Library (or a portion or derivative
+        of it, under Section 2) in object code or executable form under
+        the terms of Sections 1 and 2 above provided that you accompany
+        it with the complete corresponding machine-readable source code,
+        which must be distributed under the terms of Sections 1 and 2
+        above on a medium customarily used for software interchange.
+        &lt;p&gt;
+          If distribution of object code is made by offering access to copy
+          from a designated place, then offering equivalent access to copy
+          the source code from the same place satisfies the requirement
+          to distribute the source code, even though third parties are
+          not compelled to copy the source along with the object code.
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 5.&lt;/var&gt;
+        A program that contains no derivative of any portion of the
+        Library, but is designed to work with the Library by being compiled
+        or linked with it, is called a &amp;quot;work that uses the Library&amp;quot;.
+        Such a work, in isolation, is not a derivative work of the
+        Library, and therefore falls outside the scope of this License.
+        &lt;p&gt;
+          However, linking a &amp;quot;work that uses the Library&amp;quot; with the Library
+          creates an executable that is a derivative of the Library (because
+          it contains portions of the Library), rather than a &amp;quot;work that uses
+          the library&amp;quot;. The executable is therefore covered by this License.
+          Section 6 states terms for distribution of such executables.
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          When a &amp;quot;work that uses the Library&amp;quot; uses material from a header
+          file that is part of the Library, the object code for the work may
+          be a derivative work of the Library even though the source code is
+          not. Whether this is true is especially significant if the work can
+          be linked without the Library, or if the work is itself a library.
+          The threshold for this to be true is not precisely defined by law.
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          If such an object file uses only numerical parameters, data
+          structure layouts and accessors, and small macros and small inline
+          functions (ten lines or less in length), then the use of the
+          object file is unrestricted, regardless of whether it is legally
+          a derivative work. (Executables containing this object code
+          plus portions of the Library will still fall under Section 6.)
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          Otherwise, if the work is a derivative of the Library, you may
+          distribute the object code for the work under the terms of Section
+          6. Any executables containing that work also fall under Section 6,
+          whether or not they are linked directly with the Library itself.
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 6.&lt;/var&gt;
+        As an exception to the Sections above, you may also compile or
+        link a &amp;quot;work that uses the Library&amp;quot; with the Library to produce
+        a work containing portions of the Library, and distribute
+        that work under terms of your choice, provided that the terms
+        permit modification of the work for the customer&amp;apos;s own use
+        and reverse engineering for debugging such modifications.
+        &lt;p&gt;
+          You must give prominent notice with each copy of the work
+          that the Library is used in it and that the Library and its
+          use are covered by this License. You must supply a copy of
+          this License. If the work during execution displays copyright
+          notices, you must include the copyright notice for the Library
+          among them, as well as a reference directing the user to the
+          copy of this License. Also, you must do one of these things:
+        &lt;/p&gt;
+
+&lt;ul style="list-style:none"&gt;
+          
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; a)&lt;/var&gt;
+            Accompany the work with the complete corresponding machine-readable
+            source code for the Library including whatever changes were used in
+            the work (which must be distributed under Sections 1 and 2 above);
+            and, if the work is an executable linked with the Library, with the
+            complete machine-readable &amp;quot;work that uses the Library&amp;quot;, as object
+            code and/or source code, so that the user can modify the Library
+            and then relink to produce a modified executable containing the
+            modified Library. (It is understood that the user who changes the
+            contents of definitions files in the Library will not necessarily be
+            able to recompile the application to use the modified definitions.)
+          &lt;/li&gt;
+          
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; b)&lt;/var&gt;
+            Accompany the work with a written offer, valid for at
+            least three years, to give the same user the materials
+            specified in Subsection 6a, above, for a charge no
+            more than the cost of performing this distribution.
+          &lt;/li&gt;
+          
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; c)&lt;/var&gt;
+            If distribution of the work is made by offering access to
+            copy from a designated place, offer equivalent access to
+            copy the above specified materials from the same place.
+          &lt;/li&gt;
+          
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; d)&lt;/var&gt;
+            Verify that the user has already received a copy of these
+            materials or that you have already sent this user a copy.
+          &lt;/li&gt;
+        
+&lt;/ul&gt;
+        &lt;p&gt;
+          For an executable, the required form of the &amp;quot;work that uses
+          the Library&amp;quot; must include any data and utility programs needed
+          for reproducing the executable from it. However, as a special
+          exception, the source code distributed need not include
+          anything that is normally distributed (in either source or
+          binary form) with the major components (compiler, kernel,
+          and so on) of the operating system on which the executable
+          runs, unless that component itself accompanies the executable.
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          It may happen that this requirement contradicts the
+          license restrictions of other proprietary libraries that
+          do not normally accompany the operating system. Such
+          a contradiction means you cannot use both them and the
+          Library together in an executable that you distribute.
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 7.&lt;/var&gt;
+        You may place library facilities that are a work based on the
+        Library side-by-side in a single library together with other library
+        facilities not covered by this License, and distribute such a
+        combined library, provided that the separate distribution of the
+        work based on the Library and of the other library facilities is
+        otherwise permitted, and provided that you do these two things:
+      &lt;/li&gt;
+      
+&lt;ul style="list-style:none"&gt;
+        
+&lt;li&gt;
+          &lt;var class="replacable-license-text"&gt; a)&lt;/var&gt;
+          Accompany the combined library with a copy of the same work based
+          on the Library, uncombined with any other library facilities.
+          This must be distributed under the terms of the Sections above.
+        &lt;/li&gt;
+        
+&lt;li&gt;
+          &lt;var class="replacable-license-text"&gt; b)&lt;/var&gt;
+          Give prominent notice with the combined library of the fact
+          that part of it is a work based on the Library, and explaining
+          where to find the accompanying uncombined form of the same work.
+        &lt;/li&gt;
+      
+&lt;/ul&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 8.&lt;/var&gt;
+        You may not copy, modify, sublicense, link with, or distribute the
+        Library except as expressly provided under this License. Any attempt
+        otherwise to copy, modify, sublicense, link with, or distribute
+        the Library is void, and will automatically terminate your rights
+        under this License. However, parties who have received copies, or
+        rights, from you under this License will not have their licenses
+        terminated so long as such parties remain in full compliance.
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 9.&lt;/var&gt;
+        You are not required to accept this License, since you have
+        not signed it. However, nothing else grants you permission to
+        modify or distribute the Library or its derivative works. These
+        actions are prohibited by law if you do not accept this License.
+        Therefore, by modifying or distributing the Library (or any
+        work based on the Library), you indicate your acceptance of this
+        License to do so, and all its terms and conditions for copying,
+        distributing or modifying the Library or works based on it.
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 10.&lt;/var&gt;
+        Each time you redistribute the Library (or any work based on
+        the Library), the recipient automatically receives a license
+        from the original licensor to copy, distribute, link with or
+        modify the Library subject to these terms and conditions. You
+        may not impose any further restrictions on the recipients&amp;apos;
+        exercise of the rights granted herein. You are not responsible
+        for enforcing compliance by third parties to this License.
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 11.&lt;/var&gt;
+        If, as a consequence of a court judgment or allegation of patent
+        infringement or for any other reason (not limited to patent issues),
+        conditions are imposed on you (whether by court order, agreement
+        or otherwise) that contradict the conditions of this License,
+        they do not excuse you from the conditions of this License. If you
+        cannot distribute so as to satisfy simultaneously your obligations
+        under this License and any other pertinent obligations, then as a
+        consequence you may not distribute the Library at all. For example,
+        if a patent license would not permit royalty-free redistribution of
+        the Library by all those who receive copies directly or indirectly
+        through you, then the only way you could satisfy both it and this
+        License would be to refrain entirely from distribution of the Library.
+        &lt;p&gt;
+          If any portion of this section is held invalid or
+          unenforceable under any particular circumstance, the
+          balance of the section is intended to apply, and the section
+          as a whole is intended to apply in other circumstances.
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          It is not the purpose of this section to induce you to infringe
+          any patents or other property right claims or to contest
+          validity of any such claims; this section has the sole purpose
+          of protecting the integrity of the free software distribution
+          system which is implemented by public license practices. Many
+          people have made generous contributions to the wide range of
+          software distributed through that system in reliance on consistent
+          application of that system; it is up to the author/donor to
+          decide if he or she is willing to distribute software through
+          any other system and a licensee cannot impose that choice.
+        &lt;/p&gt;
+
+        &lt;p&gt;
+          This section is intended to make thoroughly clear what is
+          believed to be a consequence of the rest of this License.
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 12.&lt;/var&gt;
+        If the distribution and/or use of the Library is restricted in
+        certain countries either by patents or by copyrighted interfaces,
+        the original copyright holder who places the Library under this
+        License may add an explicit geographical distribution limitation
+        excluding those countries, so that distribution is permitted only
+        in or among countries not thus excluded. In such case, this License
+        incorporates the limitation as if written in the body of this License.
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 13.&lt;/var&gt;
+        The Free Software Foundation may publish revised and/or new versions
+        of the Library General Public License from time to time. Such
+        new versions will be similar in spirit to the present version,
+        but may differ in detail to address new problems or concerns.
+        &lt;p&gt;
+          Each version is given a distinguishing version number. If
+          the Library specifies a version number of this License which
+          applies to it and &amp;quot;any later version&amp;quot;, you have the option of
+          following the terms and conditions either of that version or of
+          any later version published by the Free Software Foundation. If
+          the Library does not specify a license version number, you may
+          choose any version ever published by the Free Software Foundation.
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 14.&lt;/var&gt;
+        If you wish to incorporate parts of the Library into other free programs
+        whose distribution conditions are incompatible with these, write to
+        the author to ask for permission. For software which is copyrighted by
+        the Free Software Foundation, write to the Free Software Foundation; we
+        sometimes make exceptions for this. Our decision will be guided by the
+        two goals of preserving the free status of all derivatives of our free
+        software and of promoting the sharing and reuse of software generally.
+        &lt;p&gt;
+          NO WARRANTY
+        &lt;/p&gt;
+
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 15.&lt;/var&gt;
+        BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+        FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT
+        WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
+        PARTIES PROVIDE THE LIBRARY &amp;quot;AS IS&amp;quot; WITHOUT WARRANTY OF ANY KIND,
+        EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+        PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF
+        THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU
+        ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+      &lt;/li&gt;
+      
+&lt;li&gt;
+        &lt;var class="replacable-license-text"&gt; 16.&lt;/var&gt;
+        IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+        WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+        REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+        DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+        DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY
+        (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+        INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF
+        THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER
+        OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+      &lt;/li&gt;
+    
+&lt;/ul&gt;
+    &lt;div class="optional-license-text"&gt; 
+      &lt;p&gt;
+        END OF TERMS AND CONDITIONS
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        How to Apply These Terms to Your New Libraries
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        If you develop a new library, and you want it to be of the greatest
+        possible use to the public, we recommend making it free software
+        that everyone can redistribute and change. You can do so by
+        permitting redistribution under these terms (or, alternatively,
+        under the terms of the ordinary General Public License).
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        To apply these terms, attach the following notices to the
+        library. It is safest to attach them to the start of each
+        source file to most effectively convey the exclusion of
+        warranty; and each file should have at least the &amp;quot;copyright&amp;quot;
+        line and a pointer to where the full notice is found.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        one line to give the library&amp;apos;s name
+        and an idea of what it does.&lt;br /&gt;
+
+        Copyright (C) year name of author
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        This library is free software; you can redistribute it and/or
+        modify it under the terms of the GNU Library General Public
+        License as published by the Free Software Foundation; either
+        version 2 of the License, or (at your option) any later version.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        This library is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty
+        of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+        the GNU Library General Public License for more details.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        You should have received a copy of the GNU Library
+        General Public License along with this library; if
+        not, write to the Free Software Foundation, Inc., 51
+        Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        Also add information on how to contact you by electronic and paper mail.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        You should also get your employer (if you work as a programmer)
+        or your school, if any, to sign a &amp;quot;copyright disclaimer&amp;quot; for
+        the library, if necessary. Here is a sample; alter the names:
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        Yoyodyne, Inc., hereby disclaims all copyright interest in&lt;br /&gt;
+
+        the library `Frob&amp;apos; (a library for tweaking knobs) written&lt;br /&gt;
+
+        by James Random Hacker.
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        signature of Ty Coon, 1 April 1990&lt;br /&gt;
+
+        Ty Coon, President of Vice
+      &lt;/p&gt;
+
+      &lt;p&gt;
+        That&amp;apos;s all there is to it!
+      &lt;/p&gt;
+
+    &lt;/div&gt;
+    </spdx:licenseTextHtml>
+                    <spdx:crossRef>
+                      <spdx:CrossRef>
+                        <spdx:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+                        >0</spdx:order>
+                        <spdx:timestamp>2022-05-09T00:07:17Z</spdx:timestamp>
+                        <spdx:url>https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html</spdx:url>
+                        <spdx:match>true</spdx:match>
+                        <spdx:isWayBackLink rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                        >false</spdx:isWayBackLink>
+                        <spdx:isValid rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                        >true</spdx:isValid>
+                        <spdx:isLive rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                        >true</spdx:isLive>
+                      </spdx:CrossRef>
+                    </spdx:crossRef>
+                    <spdx:isOsiApproved rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                    >true</spdx:isOsiApproved>
+                    <spdx:standardLicenseHeader>Copyright (C) year name of author
+
+This library is free software; you can redistribute it and/or modify it under the terms of the GNU Library General Public License as published by the Free Software Foundation; version 2.
+
+This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+
+</spdx:standardLicenseHeader>
+                    <spdx:standardLicenseTemplate>&lt;&lt;beginOptional&gt;&gt;GNU LIBRARY GENERAL PUBLIC LICENSE
+
+Version 2, June 1991
+
+&lt;&lt;endOptional&gt;&gt; &lt;&lt;var;name="copyright";original="Copyright (C) 1991 Free Software Foundation, Inc.  51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA  ";match=".{0,5000}"&gt;&gt;
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+[This is the first released version of the library GPL. It is numbered 2 because it goes with version 2 of the ordinary GPL.]
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public Licenses are intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users.
+
+This license, the Library General Public License, applies to some specially designated Free Software Foundation software, and to any other libraries whose authors decide to use it. You can use it for your libraries, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library, or if you modify it.
+
+For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you link a program with the library, you must provide complete object files to the recipients so that they can relink them with the library, after making changes to the library and recompiling it. And you must show them these terms so they know their rights.
+
+Our method of protecting your rights has two steps: (1) copyright the library, and (2) offer you this license which gives you legal permission to copy, distribute and/or modify the library.
+
+Also, for each distributor's protection, we want to make certain that everyone understands that there is no warranty for this free library. If the library is modified by someone else and passed on, we want its recipients to know that what they have is not the original version, so that any problems introduced by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that companies distributing free software will individually obtain patent licenses, thus in effect transforming the program into proprietary software. To prevent this, we have made it clear that any patent must be licensed for everyone's free use or not licensed at all.
+
+Most GNU software, including some libraries, is covered by the ordinary GNU General Public License, which was designed for utility programs. This license, the GNU Library General Public License, applies to certain designated libraries. This license is quite different from the ordinary one; be sure to read it in full, and don't assume that anything in it is the same as in the ordinary license.
+
+The reason we have a separate public license for some libraries is that they blur the distinction we usually make between modifying or adding to a program and simply using it. Linking a program with a library, without changing the library, is in some sense simply using the library, and is analogous to running a utility program or application program. However, in a textual and legal sense, the linked executable is a combined work, a derivative of the original library, and the ordinary General Public License treats it as such.
+
+Because of this blurred distinction, using the ordinary General Public License for libraries did not effectively promote software sharing, because most developers did not use the libraries. We concluded that weaker conditions might promote sharing better.
+
+However, unrestricted linking of non-free programs would deprive the users of those programs of all benefit from the free status of the libraries themselves. This Library General Public License is intended to permit developers of non-free programs to use free libraries, while preserving your freedom as a user of such programs to change the free libraries that are incorporated in them. (We have not seen how to achieve this as regards changes in header files, but we have achieved it as regards changes in the actual functions of the Library.) The hope is that this will lead to faster development of free libraries.
+
+The precise terms and conditions for copying, distribution and modification follow. Pay close attention to the difference between a "work based on the library" and a "work that uses the library". The former contains code derived from the library, while the latter only works together with the library.
+
+Note that it is possible for a library to be covered by the ordinary General Public License rather than by this special one.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+   &lt;&lt;var;name="bullet";original="0.";match=".{0,20}"&gt;&gt; This License Agreement applies to any software library which contains a notice placed by the copyright holder or other authorized party saying it may be distributed under the terms of this Library General Public License (also called "this License"). Each licensee is addressed as "you".
+
+   A "library" means a collection of software functions and/or data prepared so as to be conveniently linked with application programs (which use some of those functions and data) to form executables.
+
+   The "Library", below, refers to any such software library or work which has been distributed under these terms. A "work based on the Library" means either the Library or any derivative work under copyright law: that is to say, a work containing the Library or a portion of it, either verbatim or with modifications and/or translated straightforwardly into another language. (Hereinafter, translation is included without limitation in the term "modification".)
+
+   "Source code" for a work means the preferred form of the work for making modifications to it. For a library, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the library.
+
+   Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running a program using the Library is not restricted, and output from such a program is covered only if its contents constitute a work based on the Library (independent of the use of the Library in a tool for writing it). Whether that is true depends on what the Library does and what the program that uses the Library does.
+
+   &lt;&lt;var;name="bullet";original="1.";match=".{0,20}"&gt;&gt; You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and distribute a copy of this License along with the Library.
+
+   You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+   &lt;&lt;var;name="bullet";original="2.";match=".{0,20}"&gt;&gt; You may modify your copy or copies of the Library or any portion of it, thus forming a work based on the Library, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+      &lt;&lt;var;name="bullet";original="a)";match=".{0,20}"&gt;&gt; The modified work must itself be a software library.
+
+      &lt;&lt;var;name="bullet";original="b)";match=".{0,20}"&gt;&gt; You must cause the files modified to carry prominent notices stating that you changed the files and the date of any change.
+
+      &lt;&lt;var;name="bullet";original="c)";match=".{0,20}"&gt;&gt; You must cause the whole of the work to be licensed at no charge to all third parties under the terms of this License.
+
+      &lt;&lt;var;name="bullet";original="d)";match=".{0,20}"&gt;&gt; If a facility in the modified Library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful.
+
+      (For example, a function in a library to compute square roots has a purpose that is entirely well-defined independent of the application. Therefore, Subsection 2d requires that any application-supplied function or table used by this function must be optional: if the application does not supply it, the square root function must still compute square roots.)
+
+   These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Library, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Library, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+   Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Library.
+
+   In addition, mere aggregation of another work not based on the Library with the Library (or with a work based on the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+   &lt;&lt;var;name="bullet";original="3.";match=".{0,20}"&gt;&gt; You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if you wish.) Do not make any other change in these notices.
+
+   Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU General Public License applies to all subsequent copies and derivative works made from that copy.
+
+   This option is useful when you wish to copy part of the code of the Library into a program that is not a library.
+
+   &lt;&lt;var;name="bullet";original="4.";match=".{0,20}"&gt;&gt; You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange.
+
+   If distribution of object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place satisfies the requirement to distribute the source code, even though third parties are not compelled to copy the source along with the object code.
+
+   &lt;&lt;var;name="bullet";original="5.";match=".{0,20}"&gt;&gt; A program that contains no derivative of any portion of the Library, but is designed to work with the Library by being compiled or linked with it, is called a "work that uses the Library". Such a work, in isolation, is not a derivative work of the Library, and therefore falls outside the scope of this License.
+
+   However, linking a "work that uses the Library" with the Library creates an executable that is a derivative of the Library (because it contains portions of the Library), rather than a "work that uses the library". The executable is therefore covered by this License. Section 6 states terms for distribution of such executables.
+
+   When a "work that uses the Library" uses material from a header file that is part of the Library, the object code for the work may be a derivative work of the Library even though the source code is not. Whether this is true is especially significant if the work can be linked without the Library, or if the work is itself a library. The threshold for this to be true is not precisely defined by law.
+
+   If such an object file uses only numerical parameters, data structure layouts and accessors, and small macros and small inline functions (ten lines or less in length), then the use of the object file is unrestricted, regardless of whether it is legally a derivative work. (Executables containing this object code plus portions of the Library will still fall under Section 6.)
+
+   Otherwise, if the work is a derivative of the Library, you may distribute the object code for the work under the terms of Section 6. Any executables containing that work also fall under Section 6, whether or not they are linked directly with the Library itself.
+
+   &lt;&lt;var;name="bullet";original="6.";match=".{0,20}"&gt;&gt; As an exception to the Sections above, you may also compile or link a "work that uses the Library" with the Library to produce a work containing portions of the Library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's own use and reverse engineering for debugging such modifications.
+
+   You must give prominent notice with each copy of the work that the Library is used in it and that the Library and its use are covered by this License. You must supply a copy of this License. If the work during execution displays copyright notices, you must include the copyright notice for the Library among them, as well as a reference directing the user to the copy of this License. Also, you must do one of these things:
+
+      &lt;&lt;var;name="bullet";original="a)";match=".{0,20}"&gt;&gt; Accompany the work with the complete corresponding machine-readable source code for the Library including whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the work is an executable linked with the Library, with the complete machine-readable "work that uses the Library", as object code and/or source code, so that the user can modify the Library and then relink to produce a modified executable containing the modified Library. (It is understood that the user who changes the contents of definitions files in the Library will not necessarily be able to recompile the application to use the modified definitions.)
+
+      &lt;&lt;var;name="bullet";original="b)";match=".{0,20}"&gt;&gt; Accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of performing this distribution.
+
+      &lt;&lt;var;name="bullet";original="c)";match=".{0,20}"&gt;&gt; If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place.
+
+      &lt;&lt;var;name="bullet";original="d)";match=".{0,20}"&gt;&gt; Verify that the user has already received a copy of these materials or that you have already sent this user a copy.
+
+   For an executable, the required form of the "work that uses the Library" must include any data and utility programs needed for reproducing the executable from it. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+   It may happen that this requirement contradicts the license restrictions of other proprietary libraries that do not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library together in an executable that you distribute.
+
+   &lt;&lt;var;name="bullet";original="7.";match=".{0,20}"&gt;&gt; You may place library facilities that are a work based on the Library side-by-side in a single library together with other library facilities not covered by this License, and distribute such a combined library, provided that the separate distribution of the work based on the Library and of the other library facilities is otherwise permitted, and provided that you do these two things:
+
+      &lt;&lt;var;name="bullet";original="a)";match=".{0,20}"&gt;&gt; Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities. This must be distributed under the terms of the Sections above.
+
+      &lt;&lt;var;name="bullet";original="b)";match=".{0,20}"&gt;&gt; Give prominent notice with the combined library of the fact that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+   &lt;&lt;var;name="bullet";original="8.";match=".{0,20}"&gt;&gt; You may not copy, modify, sublicense, link with, or distribute the Library except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or distribute the Library is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+   &lt;&lt;var;name="bullet";original="9.";match=".{0,20}"&gt;&gt; You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Library or works based on it.
+
+   &lt;&lt;var;name="bullet";original="10.";match=".{0,20}"&gt;&gt; Each time you redistribute the Library (or any work based on the Library), the recipient automatically receives a license from the original licensor to copy, distribute, link with or modify the Library subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties to this License.
+
+   &lt;&lt;var;name="bullet";original="11.";match=".{0,20}"&gt;&gt; If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license would not permit royalty-free redistribution of the Library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Library.
+
+   If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply, and the section as a whole is intended to apply in other circumstances.
+
+   It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+   This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+   &lt;&lt;var;name="bullet";original="12.";match=".{0,20}"&gt;&gt; If the distribution and/or use of the Library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Library under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+   &lt;&lt;var;name="bullet";original="13.";match=".{0,20}"&gt;&gt; The Free Software Foundation may publish revised and/or new versions of the Library General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+   Each version is given a distinguishing version number. If the Library specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Library does not specify a license version number, you may choose any version ever published by the Free Software Foundation.
+
+   &lt;&lt;var;name="bullet";original="14.";match=".{0,20}"&gt;&gt; If you wish to incorporate parts of the Library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+   NO WARRANTY
+
+   &lt;&lt;var;name="bullet";original="15.";match=".{0,20}"&gt;&gt; BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+   &lt;&lt;var;name="bullet";original="16.";match=".{0,20}"&gt;&gt; IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.&lt;&lt;beginOptional&gt;&gt; END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Libraries
+
+If you develop a new library, and you want it to be of the greatest possible use to the public, we recommend making it free software that everyone can redistribute and change. You can do so by permitting redistribution under these terms (or, alternatively, under the terms of the ordinary General Public License).
+
+To apply these terms, attach the following notices to the library. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+one line to give the library's name and an idea of what it does.
+
+Copyright (C) year name of author
+
+This library is free software; you can redistribute it and/or modify it under the terms of the GNU Library General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the library, if necessary. Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in
+
+the library `Frob' (a library for tweaking knobs) written
+
+by James Random Hacker.
+
+signature of Ty Coon, 1 April 1990
+
+Ty Coon, President of Vice
+
+That's all there is to it!
+
+&lt;&lt;endOptional&gt;&gt;</spdx:standardLicenseTemplate>
+                    <rdfs:comment>This license was released: June 1991. This license has been superseded by LGPL-2.1. This license identifier refers to the choice to use the code under LGPL-2.0-only, as distinguished from use of code under LGPL-2.0-or-later (i.e., LGPL-2.0 or some later version). The license notice (as seen in the Standard License Header field below) states which of these applies to the code in the file. The example in the exhibit to the license shows the license notice for the "or later" approach.</rdfs:comment>
+                    <spdx:name>GNU Library General Public License v2 only</spdx:name>
+                    <spdx:standardLicenseHeaderTemplate>Copyright (C) &lt;&lt;var;name="copyright";original="year name of author";match=".+"&gt;&gt;
+
+This library is free software; you can redistribute it and/or modify it under the terms of the GNU Library General Public License as published by the Free Software Foundation; version 2.
+
+This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+
+</spdx:standardLicenseHeaderTemplate>
+                    <spdx:standardLicenseHeaderHtml>
+      Copyright (C) &lt;var class="replacable-license-text"&gt; year name of author&lt;/var&gt;
+      &lt;p&gt;This library is free software; you can redistribute it and/or modify it
+      under the terms of the GNU Library General Public License as published
+        by the Free Software Foundation; version 2.&lt;/p&gt;
+
+      &lt;p&gt;This library is distributed
+      in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+      even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+        PURPOSE. See the GNU Library General Public License for more details.&lt;/p&gt;
+
+      &lt;p&gt;You should have received a copy of the GNU Library General Public
+      License along with this library; if not, write to the Free Software
+      Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+	  &lt;/p&gt;
+
+    </spdx:standardLicenseHeaderHtml>
+                  </spdx:ListedLicense>
+                </spdx:member>
+              </spdx:DisjunctiveLicenseSet>
+            </spdx:licenseConcluded>
+            <spdx:attributionText>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</spdx:attributionText>
+            <spdx:licenseDeclared>
+              <spdx:ConjunctiveLicenseSet>
+                <spdx:member rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-3"/>
+                <spdx:member rdf:resource="http://spdx.org/licenses/LGPL-2.0-only"/>
+              </spdx:ConjunctiveLicenseSet>
+            </spdx:licenseDeclared>
+            <spdx:originator>Organization: ExampleCodeInspect (contact@example.com)</spdx:originator>
+            <spdx:checksum>
+              <spdx:Checksum>
+                <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha256"/>
+                <spdx:checksumValue>11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd</spdx:checksumValue>
+              </spdx:Checksum>
+            </spdx:checksum>
+            <spdx:licenseInfoFromFiles>
+              <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-2">
+                <spdx:licenseId>LicenseRef-2</spdx:licenseId>
+                <spdx:extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</spdx:extractedText>
+              </spdx:ExtractedLicensingInfo>
+            </spdx:licenseInfoFromFiles>
+            <spdx:relationship>
+              <spdx:Relationship>
+                <spdx:relatedSpdxElement>
+                  <spdx:File rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-JenaLib">
+                    <spdx:licenseConcluded rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-1"/>
+                    <spdx:licenseComments>This license is used by Jena</spdx:licenseComments>
+                    <spdx:checksum>
+                      <spdx:Checksum>
+                        <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+                        <spdx:checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</spdx:checksumValue>
+                      </spdx:Checksum>
+                    </spdx:checksum>
+                    <spdx:fileContributor>Hewlett Packard Inc.</spdx:fileContributor>
+                    <spdx:fileType rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
+                    <spdx:copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</spdx:copyrightText>
+                    <spdx:fileContributor>Apache Software Foundation</spdx:fileContributor>
+                    <spdx:relationship>
+                      <spdx:Relationship>
+                        <spdx:relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package"/>
+                        <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_contains"/>
+                      </spdx:Relationship>
+                    </spdx:relationship>
+                    <spdx:licenseInfoInFile rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-1"/>
+                    <rdfs:comment>This file belongs to Jena</rdfs:comment>
+                    <spdx:fileName>./lib-source/jena-2.6.3-sources.jar</spdx:fileName>
+                  </spdx:File>
+                </spdx:relatedSpdxElement>
+                <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_contains"/>
+              </spdx:Relationship>
+            </spdx:relationship>
+            <spdx:releaseDate>2012-01-29T18:30:22Z</spdx:releaseDate>
+            <spdx:packageVerificationCode>
+              <spdx:PackageVerificationCode>
+                <spdx:packageVerificationCodeValue>d6a770ba38583ed4bb4525bd96e50461655d2758</spdx:packageVerificationCodeValue>
+                <spdx:packageVerificationCodeExcludedFile>./package.spdx</spdx:packageVerificationCodeExcludedFile>
+              </spdx:PackageVerificationCode>
+            </spdx:packageVerificationCode>
+            <spdx:checksum>
+              <spdx:Checksum>
+                <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+                <spdx:checksumValue>85ed0817af83a24ad8da68c2b5094de69833983c</spdx:checksumValue>
+              </spdx:Checksum>
+            </spdx:checksum>
+            <spdx:annotation>
+              <spdx:Annotation>
+                <spdx:annotator>Person: Package Commenter</spdx:annotator>
+                <rdfs:comment>Package level annotation</rdfs:comment>
+                <spdx:annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_other"/>
+                <spdx:annotationDate>2011-01-29T18:30:22Z</spdx:annotationDate>
+              </spdx:Annotation>
+            </spdx:annotation>
+            <spdx:sourceInfo>uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.</spdx:sourceInfo>
+            <spdx:packageFileName>glibc-2.11.1.tar.gz</spdx:packageFileName>
+            <spdx:validUntilDate>2014-01-29T18:30:22Z</spdx:validUntilDate>
+            <spdx:summary>GNU C library.</spdx:summary>
+            <spdx:relationship>
+              <spdx:Relationship>
+                <spdx:relatedSpdxElement>
+                  <spdx:Package rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Saxon">
+                    <spdx:name>Saxon</spdx:name>
+                    <spdx:checksum>
+                      <spdx:Checksum>
+                        <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+                        <spdx:checksumValue>85ed0817af83a24ad8da68c2b5094de69833983c</spdx:checksumValue>
+                      </spdx:Checksum>
+                    </spdx:checksum>
+                    <spdx:description>The Saxon package is a collection of tools for processing XML documents.</spdx:description>
+                    <doap:homepage>http://saxon.sourceforge.net/</doap:homepage>
+                    <spdx:versionInfo>8.8</spdx:versionInfo>
+                    <spdx:licenseComments>Other versions available for a commercial license</spdx:licenseComments>
+                    <spdx:downloadLocation>https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download</spdx:downloadLocation>
+                    <spdx:packageFileName>saxonB-8.8.zip</spdx:packageFileName>
+                    <spdx:licenseConcluded>
+                      <spdx:ListedLicense rdf:about="http://spdx.org/licenses/MPL-1.0">
+                        <rdfs:seeAlso>https://opensource.org/licenses/MPL-1.0</rdfs:seeAlso>
+                        <spdx:licenseText>MOZILLA PUBLIC LICENSE
+Version 1.0
+
+1. Definitions.
+
+     1.1. ``Contributor'' means each entity that creates or contributes to the creation of Modifications.
+
+     1.2. ``Contributor Version'' means the combination of the Original Code, prior Modifications used by a Contributor, and the Modifications made by that particular Contributor.
+
+     1.3. ``Covered Code'' means the Original Code or Modifications or the combination of the Original Code and Modifications, in each case including portions thereof.
+
+     1.4. ``Electronic Distribution Mechanism'' means a mechanism generally accepted in the software development community for the electronic transfer of data.
+
+     1.5. ``Executable'' means Covered Code in any form other than Source Code.
+
+     1.6. ``Initial Developer'' means the individual or entity identified as the Initial Developer in the Source Code notice required by Exhibit A.
+
+     1.7. ``Larger Work'' means a work which combines Covered Code or portions thereof with code not governed by the terms of this License.
+
+     1.8. ``License'' means this document.
+
+     1.9. ``Modifications'' means any addition to or deletion from the substance or structure of either the Original Code or any previous Modifications. When Covered Code is released as a series of files, a Modification is:
+
+          A. Any addition to or deletion from the contents of a file containing Original Code or previous Modifications.
+
+          B. Any new file that contains any part of the Original Code or previous Modifications.
+
+     1.10. ``Original Code'' means Source Code of computer software code which is described in the Source Code notice required by Exhibit A as Original Code, and which, at the time of its release under this License is not already Covered Code governed by this License.
+
+     1.11. ``Source Code'' means the preferred form of the Covered Code for making modifications to it, including all modules it contains, plus any associated interface definition files, scripts used to control compilation and installation of an Executable, or a list of source code differential comparisons against either the Original Code or another well known, available Covered Code of the Contributor's choice. The Source Code can be in a compressed or archival form, provided the appropriate decompression or de-archiving software is widely available for no charge.
+
+     1.12. ``You'' means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License or a future version of this License issued under Section 6.1. For legal entities, ``You'' includes any entity which controls, is controlled by, or is under common control with You. For purposes of this definition, ``control'' means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of fifty percent (50%) or more of the outstanding shares or beneficial ownership of such entity.
+
+2. Source Code License.
+
+     2.1. The Initial Developer Grant.
+The Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive license, subject to third party intellectual property claims:
+
+          (a) to use, reproduce, modify, display, perform, sublicense and distribute the Original Code (or portions thereof) with or without Modifications, or as part of a Larger Work; and
+
+          (b) under patents now or hereafter owned or controlled by Initial Developer, to make, have made, use and sell (``Utilize'') the Original Code (or portions thereof), but solely to the extent that any such patent is reasonably necessary to enable You to Utilize 	the Original Code (or portions thereof) and not to any greater extent that may be necessary to Utilize further Modifications or combinations.
+
+     2.2. Contributor Grant.
+Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license, subject to third party intellectual property claims:
+
+          (a) to use, reproduce, modify, display, perform, sublicense and distribute the Modifications created by such Contributor (or portions thereof) either on an unmodified basis, with other Modifications, as Covered Code or as part of a Larger Work; and
+
+          (b) under patents now or hereafter owned or controlled by Contributor, to Utilize the Contributor Version (or portions thereof), but solely to the extent that any such patent is reasonably necessary to enable You to Utilize the Contributor Version (or portions 	thereof), and not to any greater extent that may be necessary to Utilize further Modifications or combinations.
+
+3. Distribution Obligations.
+
+     3.1. Application of License.
+     The Modifications which You create or to which You contribute are governed by the terms of this License, including without limitation Section 2.2. The Source Code version of Covered Code may be distributed only under the terms of this License or a future version of this License released under Section 6.1, and You must include a copy of this License with every copy of the Source Code You distribute. You may not offer or impose any terms on any Source Code version that alters or restricts the applicable version of this License or the recipients' rights hereunder. However, You may include an additional document offering the additional rights described in Section 3.5.
+
+     3.2. Availability of Source Code.
+     Any Modification which You create or to which You contribute must be made available in Source Code form under the terms of this License either on the same media as an Executable version or via an accepted Electronic Distribution Mechanism to anyone to whom you made an Executable version available; and if made available via Electronic Distribution Mechanism, must remain available for at least twelve (12) months after the date it initially became available, or at least six (6) months after a subsequent version of that particular Modification has been made available to such recipients. You are responsible for ensuring that the Source Code version remains available even if the Electronic Distribution Mechanism is maintained by a third party.
+
+     3.3. Description of Modifications.
+     You must cause all Covered Code to which you contribute to contain a file documenting the changes You made to create that Covered Code and the date of any change. You must include a prominent statement that the Modification is derived, directly or indirectly, from Original Code provided by the Initial Developer and including the name of the Initial Developer in (a) the Source Code, and (b) in any notice in an Executable version or related documentation in which You describe the origin or ownership of the Covered Code.
+
+     3.4. Intellectual Property Matters
+
+          (a) Third Party Claims.
+          If You have knowledge that a party claims an intellectual property right in particular functionality or code (or its utilization under this License), you must include a text file with the source code distribution titled ``LEGAL'' which describes the claim and the party making the claim in sufficient detail that a recipient will know whom to contact. If you obtain such knowledge after You make Your Modification available as described in Section 3.2, You shall promptly modify the LEGAL file in all copies You make available thereafter and shall take other steps (such as notifying appropriate mailing lists or newsgroups) reasonably calculated to inform those who received the Covered Code that new knowledge has been obtained.
+
+          (b) Contributor APIs.
+          If Your Modification is an application programming interface and You own or control patents which are reasonably necessary to implement that API, you must also include this information in the LEGAL file.
+
+     3.5. Required Notices.
+     You must duplicate the notice in Exhibit A in each file of the Source Code, and this License in any documentation for the Source Code, where You describe recipients' rights relating to Covered Code. If You created one or more Modification(s), You may add your name as a Contributor to the notice described in Exhibit A. If it is not possible to put such notice in a particular Source Code file due to its structure, then you must include such notice in a location (such as a relevant directory file) where a user would be likely to look for such a notice. You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Code. However, You may do so only on Your own behalf, and not on behalf of the Initial Developer or any Contributor. You must make it absolutely clear than any such warranty, support, indemnity or liability obligation is offered by You alone, and You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of warranty, support, indemnity or liability terms You offer.
+
+     3.6. Distribution of Executable Versions.
+     You may distribute Covered Code in Executable form only if the requirements of Section 3.1-3.5 have been met for that Covered Code, and if You include a notice stating that the Source Code version of the Covered Code is available under the terms of this License, including a description of how and where You have fulfilled the obligations of Section 3.2. The notice must be conspicuously included in any notice in an Executable version, related documentation or collateral in which You describe recipients' rights relating to the Covered Code. You may distribute the Executable version of Covered Code under a license of Your choice, which may contain terms different from this License, provided that You are in compliance with the terms of this License and that the license for the Executable version does not attempt to limit or alter the recipient's rights in the Source Code version from the rights set forth in this License. If You distribute the Executable version under a different license You must make it absolutely clear that any terms which differ from this License are offered by You alone, not by the Initial Developer or any Contributor. You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of any such terms You offer.
+
+     3.7. Larger Works.
+     You may create a Larger Work by combining Covered Code with other code not governed by the terms of this License and distribute the Larger Work as a single product. In such a case, You must make sure the requirements of this License are fulfilled for the Covered Code.
+
+4. Inability to Comply Due to Statute or Regulation.
+If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Covered Code due to statute or regulation then You must: (a) comply with the terms of this License to the maximum extent possible; and (b) describe the limitations and the code they affect. Such description must be included in the LEGAL file described in Section 3.4 and must be included with all distributions of the Source Code. Except to the extent prohibited by statute or regulation, such description must be sufficiently detailed for a recipient of ordinary skill to be able to understand it.
+
+5. Application of this License.
+This License applies to code to which the Initial Developer has attached the notice in Exhibit A, and to related Covered Code.
+
+6. Versions of the License.
+
+     6.1. New Versions.
+     Netscape Communications Corporation (``Netscape'') may publish revised and/or new versions of the License from time to time. Each version will be given a distinguishing version number.
+
+     6.2. Effect of New Versions.
+     Once Covered Code has been published under a particular version of the License, You may always continue to use it under the terms of that version. You may also choose to use such Covered Code under the terms of any subsequent version of the License published by Netscape. No one other than Netscape has the right to modify the terms applicable to Covered Code created under this License.
+
+     6.3. Derivative Works.
+     If you create or use a modified version of this License (which you may only do in order to apply it to code which is not already Covered Code governed by this License), you must (a) rename Your license so that the phrases ``Mozilla'', ``MOZILLAPL'', ``MOZPL'', ``Netscape'', ``NPL'' or any confusingly similar phrase do not appear anywhere in your license and (b) otherwise make it clear that your version of the license contains terms which differ from the Mozilla Public License and Netscape Public License. (Filling in the name of the Initial Developer, Original Code or Contributor in the notice described in Exhibit A shall not of themselves be deemed to be modifications of this License.)
+
+7. DISCLAIMER OF WARRANTY.
+COVERED CODE IS PROVIDED UNDER THIS LICENSE ON AN ``AS IS'' BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED CODE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED CODE IS WITH YOU. SHOULD ANY COVERED CODE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY COVERED CODE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
+
+8. TERMINATION.
+This License and the rights granted hereunder will terminate automatically if You fail to comply with terms herein and fail to cure such breach within 30 days of becoming aware of the breach. All sublicenses to the Covered Code which are properly granted shall survive any termination of this License. Provisions which, by their nature, must remain in effect beyond the termination of this License shall survive.
+
+9. LIMITATION OF LIABILITY.
+UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL THE INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED CODE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO YOU OR ANY OTHER PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THAT EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
+
+10. U.S. GOVERNMENT END USERS.
+The Covered Code is a ``commercial item,'' as that term is defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of ``commercial computer software'' and ``commercial computer software documentation,'' as such terms are used in 48 C.F.R. 12.212 (Sept. 1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1 through 227.7202-4 (June 1995), all U.S. Government End Users acquire Covered Code with only those rights set forth herein.
+
+11. MISCELLANEOUS.
+This License represents the complete agreement concerning subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. This License shall be governed by California law provisions (except to the extent applicable law, if any, provides otherwise), excluding its conflict-of-law provisions. With respect to disputes in which at least one party is a citizen of, or an entity chartered or registered to do business in, the United States of America: (a) unless otherwise agreed in writing, all disputes relating to this License (excepting any dispute relating to intellectual property rights) shall be subject to final and binding arbitration, with the losing party paying all costs of arbitration; (b) any arbitration relating to this Agreement shall be held in Santa Clara County, California, under the auspices of JAMS/EndDispute; and (c) any litigation relating to this Agreement shall be subject to the jurisdiction of the Federal Courts of the Northern District of California, with venue lying in Santa Clara County, California, with the losing party responsible for costs, including without limitation, court costs and reasonable attorneys fees and expenses. The application of the United Nations Convention on Contracts for the International Sale of Goods is expressly excluded. Any law or regulation which provides that the language of a contract shall be construed against the drafter shall not apply to this License.
+
+12. RESPONSIBILITY FOR CLAIMS.
+Except in cases where another Contributor has failed to comply with Section 3.4, You are responsible for damages arising, directly or indirectly, out of Your utilization of rights under this License, based on the number of copies of Covered Code you made available, the revenues you received from utilizing such rights, and other relevant factors. You agree to work with affected parties to distribute responsibility on an equitable basis.
+
+EXHIBIT A.
+
+``The contents of this file are subject to the Mozilla Public License Version 1.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.mozilla.org/MPL/
+
+Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the specific language governing rights and limitations under the License.
+
+The Original Code is ______________________________________.
+
+The Initial Developer of the Original Code is ________________________. Portions created by ______________________ are Copyright (C) ______ _______________________. All Rights Reserved.
+
+Contributor(s): ______________________________________.''
+</spdx:licenseText>     <rdfs:comment>This license has been superseded by v1.1</rdfs:comment>
+                        <rdfs:seeAlso>http://www.mozilla.org/MPL/MPL-1.0.html</rdfs:seeAlso>
+                        <spdx:name>Mozilla Public License 1.0</spdx:name>
+                        <spdx:standardLicenseHeader>"The contents of this file are subject to the Mozilla Public License Version 1.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.mozilla.org/MPL/
+
+Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the specific language governing rights and limitations under the License.
+
+The Original Code is _____ . The Initial Developer of the Original Code is _____ . Portions created by _____ are Copyright (C) _____ . All Rights Reserved. Contributor(s): _____ ."
+
+</spdx:standardLicenseHeader>
+                        <spdx:standardLicenseHeaderTemplate>&lt;&lt;beginOptional&gt;&gt;"&lt;&lt;endOptional&gt;&gt;The contents of this file are subject to the Mozilla Public License Version 1.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.mozilla.org/MPL/
+
+Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the specific language governing rights and limitations under the License.
+
+The Original Code is &lt;&lt;var;name="code";original="_____";match=".+"&gt;&gt; . The Initial Developer of the Original Code is &lt;&lt;var;name="InitialDeveloper";original="_____";match=".+"&gt;&gt; . Portions created by &lt;&lt;var;name="createdby";original="_____";match=".+"&gt;&gt; are Copyright (C) &lt;&lt;var;name="copyright";original="_____";match=".+"&gt;&gt; . All Rights Reserved. Contributor(s): &lt;&lt;var;name="contributor";original="_____";match=".+"&gt;&gt; .&lt;&lt;beginOptional&gt;&gt;"&lt;&lt;endOptional&gt;&gt;
+
+</spdx:standardLicenseHeaderTemplate>
+                        <spdx:standardLicenseTemplate>&lt;&lt;beginOptional&gt;&gt;MOZILLA PUBLIC LICENSE
+
+Version 1.0
+
+&lt;&lt;endOptional&gt;&gt;
+
+   &lt;&lt;var;name="bullet";original="1.";match=".{0,20}"&gt;&gt; Definitions.
+
+      &lt;&lt;var;name="bullet";original="1.1.";match=".{0,20}"&gt;&gt; "Contributor" means each entity that creates or contributes to the creation of Modifications.
+
+      &lt;&lt;var;name="bullet";original="1.2.";match=".{0,20}"&gt;&gt; "Contributor Version" means the combination of the Original Code, prior Modifications used by a Contributor, and the Modifications made by that particular Contributor.
+
+      &lt;&lt;var;name="bullet";original="1.3.";match=".{0,20}"&gt;&gt; "Covered Code" means the Original Code or Modifications or the combination of the Original Code and Modifications, in each case including portions thereof.
+
+      &lt;&lt;var;name="bullet";original="1.4.";match=".{0,20}"&gt;&gt; "Electronic Distribution Mechanism" means a mechanism generally accepted in the software development community for the electronic transfer of data.
+
+      &lt;&lt;var;name="bullet";original="1.5.";match=".{0,20}"&gt;&gt; "Executable" means Covered Code in any form other than Source Code.
+
+      &lt;&lt;var;name="bullet";original="1.6.";match=".{0,20}"&gt;&gt; "Initial Developer" means the individual or entity identified as the Initial Developer in the Source Code notice required by Exhibit A.
+
+      &lt;&lt;var;name="bullet";original="1.7.";match=".{0,20}"&gt;&gt; "Larger Work" means a work which combines Covered Code or portions thereof with code not governed by the terms of this License.
+
+      &lt;&lt;var;name="bullet";original="1.8.";match=".{0,20}"&gt;&gt; "License" means this document.
+
+      &lt;&lt;var;name="bullet";original="1.9.";match=".{0,20}"&gt;&gt; "Modifications" means any addition to or deletion from the substance or structure of either the Original Code or any previous Modifications. When Covered Code is released as a series of files, a Modification is:
+
+         &lt;&lt;var;name="bullet";original="A.";match=".{0,20}"&gt;&gt; Any addition to or deletion from the contents of a file containing Original Code or previous Modifications.
+
+         &lt;&lt;var;name="bullet";original="B.";match=".{0,20}"&gt;&gt; Any new file that contains any part of the Original Code or previous Modifications.
+
+      &lt;&lt;var;name="bullet";original="1.10.";match=".{0,20}"&gt;&gt; "Original Code" means Source Code of computer software code which is described in the Source Code notice required by Exhibit A as Original Code, and which, at the time of its release under this License is not already Covered Code governed by this License.
+
+      &lt;&lt;var;name="bullet";original="1.11.";match=".{0,20}"&gt;&gt; "Source Code" means the preferred form of the Covered Code for making modifications to it, including all modules it contains, plus any associated interface definition files, scripts used to control compilation and installation of an Executable, or a list of source code differential comparisons against either the Original Code or another well known, available Covered Code of the Contributor's choice. The Source Code can be in a compressed or archival form, provided the appropriate decompression or de-archiving software is widely available for no charge.
+
+      &lt;&lt;var;name="bullet";original="1.12.";match=".{0,20}"&gt;&gt; "You" means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License or a future version of this License issued under Section 6.1. For legal entities, "You" includes any entity which controls, is controlled by, or is under common control with You. For purposes of this definition, "control" means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of fifty percent (50%) or more of the outstanding shares or beneficial ownership of such entity.
+
+   &lt;&lt;var;name="bullet";original="2.";match=".{0,20}"&gt;&gt; Source Code License.
+
+      &lt;&lt;var;name="bullet";original="2.1.";match=".{0,20}"&gt;&gt; The Initial Developer Grant.
+
+      The Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive license, subject to third party intellectual property claims:
+
+         &lt;&lt;var;name="bullet";original="(a)";match=".{0,20}"&gt;&gt; to use, reproduce, modify, display, perform, sublicense and distribute the Original Code (or portions thereof) with or without Modifications, or as part of a Larger Work; and
+
+         &lt;&lt;var;name="bullet";original="(b)";match=".{0,20}"&gt;&gt; under patents now or hereafter owned or controlled by Initial Developer, to make, have made, use and sell ("Utilize") the Original Code (or portions thereof), but solely to the extent that any such patent is reasonably necessary to enable You to Utilize the Original Code (or portions thereof) and not to any greater extent that may be necessary to Utilize further Modifications or combinations.
+
+      &lt;&lt;var;name="bullet";original="2.2.";match=".{0,20}"&gt;&gt; Contributor Grant.
+
+      Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license, subject to third party intellectual property claims:
+
+         &lt;&lt;var;name="bullet";original="(a)";match=".{0,20}"&gt;&gt; to use, reproduce, modify, display, perform, sublicense and distribute the Modifications created by such Contributor (or portions thereof) either on an unmodified basis, with other Modifications, as Covered Code or as part of a Larger Work; and
+
+         &lt;&lt;var;name="bullet";original="(b)";match=".{0,20}"&gt;&gt; under patents now or hereafter owned or controlled by Contributor, to Utilize the Contributor Version (or portions thereof), but solely to the extent that any such patent is reasonably necessary to enable You to Utilize the Contributor Version (or portions thereof), and not to any greater extent that may be necessary to Utilize further Modifications or combinations.
+
+   &lt;&lt;var;name="bullet";original="3.";match=".{0,20}"&gt;&gt; Distribution Obligations.
+
+      &lt;&lt;var;name="bullet";original="3.1.";match=".{0,20}"&gt;&gt; Application of License.
+
+      The Modifications which You create or to which You contribute are governed by the terms of this License, including without limitation Section 2.2. The Source Code version of Covered Code may be distributed only under the terms of this License or a future version of this License released under Section 6.1, and You must include a copy of this License with every copy of the Source Code You distribute. You may not offer or impose any terms on any Source Code version that alters or restricts the applicable version of this License or the recipients' rights hereunder. However, You may include an additional document offering the additional rights described in Section 3.5.
+
+      &lt;&lt;var;name="bullet";original="3.2.";match=".{0,20}"&gt;&gt; Availability of Source Code.
+
+      Any Modification which You create or to which You contribute must be made available in Source Code form under the terms of this License either on the same media as an Executable version or via an accepted Electronic Distribution Mechanism to anyone to whom you made an Executable version available; and if made available via Electronic Distribution Mechanism, must remain available for at least twelve (12) months after the date it initially became available, or at least six (6) months after a subsequent version of that particular Modification has been made available to such recipients. You are responsible for ensuring that the Source Code version remains available even if the Electronic Distribution Mechanism is maintained by a third party.
+
+      &lt;&lt;var;name="bullet";original="3.3.";match=".{0,20}"&gt;&gt; Description of Modifications.
+
+      You must cause all Covered Code to which you contribute to contain a file documenting the changes You made to create that Covered Code and the date of any change. You must include a prominent statement that the Modification is derived, directly or indirectly, from Original Code provided by the Initial Developer and including the name of the Initial Developer in (a) the Source Code, and (b) in any notice in an Executable version or related documentation in which You describe the origin or ownership of the Covered Code.
+
+      &lt;&lt;var;name="bullet";original="3.4.";match=".{0,20}"&gt;&gt; Intellectual Property Matters
+
+         &lt;&lt;var;name="bullet";original="(a)";match=".{0,20}"&gt;&gt; Third Party Claims.
+
+         If You have knowledge that a party claims an intellectual property right in particular functionality or code (or its utilization under this License), you must include a text file with the source code distribution titled "LEGAL" which describes the claim and the party making the claim in sufficient detail that a recipient will know whom to contact. If you obtain such knowledge after You make Your Modification available as described in Section 3.2, You shall promptly modify the LEGAL file in all copies You make available thereafter and shall take other steps (such as notifying appropriate mailing lists or newsgroups) reasonably calculated to inform those who received the Covered Code that new knowledge has been obtained.
+
+         &lt;&lt;var;name="bullet";original="(b)";match=".{0,20}"&gt;&gt; Contributor APIs.
+
+         If Your Modification is an application programming interface and You own or control patents which are reasonably necessary to implement that API, you must also include this information in the LEGAL file.
+
+      &lt;&lt;var;name="bullet";original="3.5.";match=".{0,20}"&gt;&gt; Required Notices.
+
+      You must duplicate the notice in Exhibit A in each file of the Source Code, and this License in any documentation for the Source Code, where You describe recipients' rights relating to Covered Code. If You created one or more Modification(s), You may add your name as a Contributor to the notice described in Exhibit A. If it is not possible to put such notice in a particular Source Code file due to its structure, then you must include such notice in a location (such as a relevant directory file) where a user would be likely to look for such a notice. You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Code. However, You may do so only on Your own behalf, and not on behalf of the Initial Developer or any Contributor. You must make it absolutely clear than any such warranty, support, indemnity or liability obligation is offered by You alone, and You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of warranty, support, indemnity or liability terms You offer.
+
+      &lt;&lt;var;name="bullet";original="3.6.";match=".{0,20}"&gt;&gt; Distribution of Executable Versions.
+
+      You may distribute Covered Code in Executable form only if the requirements of Section 3.1-3.5 have been met for that Covered Code, and if You include a notice stating that the Source Code version of the Covered Code is available under the terms of this License, including a description of how and where You have fulfilled the obligations of Section 3.2. The notice must be conspicuously included in any notice in an Executable version, related documentation or collateral in which You describe recipients' rights relating to the Covered Code. You may distribute the Executable version of Covered Code under a license of Your choice, which may contain terms different from this License, provided that You are in compliance with the terms of this License and that the license for the Executable version does not attempt to limit or alter the recipient's rights in the Source Code version from the rights set forth in this License. If You distribute the Executable version under a different license You must make it absolutely clear that any terms which differ from this License are offered by You alone, not by the Initial Developer or any Contributor. You hereby agree to indemnify the Initial Developer and every Contributor for any liability incurred by the Initial Developer or such Contributor as a result of any such terms You offer.
+
+      &lt;&lt;var;name="bullet";original="3.7.";match=".{0,20}"&gt;&gt; Larger Works.
+
+      You may create a Larger Work by combining Covered Code with other code not governed by the terms of this License and distribute the Larger Work as a single product. In such a case, You must make sure the requirements of this License are fulfilled for the Covered Code.
+
+   &lt;&lt;var;name="bullet";original="4.";match=".{0,20}"&gt;&gt; Inability to Comply Due to Statute or Regulation.
+
+   If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Covered Code due to statute or regulation then You must: (a) comply with the terms of this License to the maximum extent possible; and (b) describe the limitations and the code they affect. Such description must be included in the LEGAL file described in Section 3.4 and must be included with all distributions of the Source Code. Except to the extent prohibited by statute or regulation, such description must be sufficiently detailed for a recipient of ordinary skill to be able to understand it.
+
+   &lt;&lt;var;name="bullet";original="5.";match=".{0,20}"&gt;&gt; Application of this License.
+
+   This License applies to code to which the Initial Developer has attached the notice in Exhibit A, and to related Covered Code.
+
+   &lt;&lt;var;name="bullet";original="6.";match=".{0,20}"&gt;&gt; Versions of the License.
+
+      &lt;&lt;var;name="bullet";original="6.1.";match=".{0,20}"&gt;&gt; New Versions.
+
+      Netscape Communications Corporation ("Netscape") may publish revised and/or new versions of the License from time to time. Each version will be given a distinguishing version number.
+
+      &lt;&lt;var;name="bullet";original="6.2.";match=".{0,20}"&gt;&gt; Effect of New Versions.
+
+      Once Covered Code has been published under a particular version of the License, You may always continue to use it under the terms of that version. You may also choose to use such Covered Code under the terms of any subsequent version of the License published by Netscape. No one other than Netscape has the right to modify the terms applicable to Covered Code created under this License.
+
+      &lt;&lt;var;name="bullet";original="6.3.";match=".{0,20}"&gt;&gt; Derivative Works.
+
+      If you create or use a modified version of this License (which you may only do in order to apply it to code which is not already Covered Code governed by this License), you must (a) rename Your license so that the phrases "Mozilla", "MOZILLAPL", "MOZPL", "Netscape", "NPL" or any confusingly similar phrase do not appear anywhere in your license and (b) otherwise make it clear that your version of the license contains terms which differ from the Mozilla Public License and Netscape Public License. (Filling in the name of the Initial Developer, Original Code or Contributor in the notice described in Exhibit A shall not of themselves be deemed to be modifications of this License.)
+
+   &lt;&lt;var;name="bullet";original="7.";match=".{0,20}"&gt;&gt; DISCLAIMER OF WARRANTY.
+
+   COVERED CODE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS" BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED CODE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED CODE IS WITH YOU. SHOULD ANY COVERED CODE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY COVERED CODE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
+
+   &lt;&lt;var;name="bullet";original="8.";match=".{0,20}"&gt;&gt; TERMINATION.
+
+   This License and the rights granted hereunder will terminate automatically if You fail to comply with terms herein and fail to cure such breach within 30 days of becoming aware of the breach. All sublicenses to the Covered Code which are properly granted shall survive any termination of this License. Provisions which, by their nature, must remain in effect beyond the termination of this License shall survive.
+
+   &lt;&lt;var;name="bullet";original="9.";match=".{0,20}"&gt;&gt; LIMITATION OF LIABILITY.
+
+   UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL THE INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED CODE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO YOU OR ANY OTHER PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THAT EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
+
+   &lt;&lt;var;name="bullet";original="10.";match=".{0,20}"&gt;&gt; U.S. GOVERNMENT END USERS.
+
+   The Covered Code is a "commercial item," as that term is defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of "commercial computer software" and "commercial computer software documentation," as such terms are used in 48 C.F.R. 12.212 (Sept. 1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1 through 227.7202-4 (June 1995), all U.S. Government End Users acquire Covered Code with only those rights set forth herein.
+
+   &lt;&lt;var;name="bullet";original="11.";match=".{0,20}"&gt;&gt; MISCELLANEOUS.
+
+   This License represents the complete agreement concerning subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. This License shall be governed by California law provisions (except to the extent applicable law, if any, provides otherwise), excluding its conflict-of-law provisions. With respect to disputes in which at least one party is a citizen of, or an entity chartered or registered to do business in, the United States of America: (a) unless otherwise agreed in writing, all disputes relating to this License (excepting any dispute relating to intellectual property rights) shall be subject to final and binding arbitration, with the losing party paying all costs of arbitration; (b) any arbitration relating to this Agreement shall be held in Santa Clara County, California, under the auspices of JAMS/EndDispute; and (c) any litigation relating to this Agreement shall be subject to the jurisdiction of the Federal Courts of the Northern District of California, with venue lying in Santa Clara County, California, with the losing party responsible for costs, including without limitation, court costs and reasonable attorneys fees and expenses. The application of the United Nations Convention on Contracts for the International Sale of Goods is expressly excluded. Any law or regulation which provides that the language of a contract shall be construed against the drafter shall not apply to this License.
+
+   &lt;&lt;var;name="bullet";original="12.";match=".{0,20}"&gt;&gt; RESPONSIBILITY FOR CLAIMS.
+
+   Except in cases where another Contributor has failed to comply with Section 3.4, You are responsible for damages arising, directly or indirectly, out of Your utilization of rights under this License, based on the number of copies of Covered Code you made available, the revenues you received from utilizing such rights, and other relevant factors. You agree to work with affected parties to distribute responsibility on an equitable basis.&lt;&lt;beginOptional&gt;&gt; EXHIBIT A.
+
+&lt;&lt;beginOptional&gt;&gt;"&lt;&lt;endOptional&gt;&gt;The contents of this file are subject to the Mozilla Public License Version 1.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.mozilla.org/MPL/
+
+Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the specific language governing rights and limitations under the License.
+
+The Original Code is &lt;&lt;var;name="code";original="_____";match=".+"&gt;&gt; . The Initial Developer of the Original Code is &lt;&lt;var;name="InitialDeveloper";original="_____";match=".+"&gt;&gt; . Portions created by &lt;&lt;var;name="createdby";original="_____";match=".+"&gt;&gt; are Copyright (C) &lt;&lt;var;name="copyright";original="_____";match=".+"&gt;&gt; . All Rights Reserved. Contributor(s): &lt;&lt;var;name="contributor";original="_____";match=".+"&gt;&gt; .&lt;&lt;beginOptional&gt;&gt;"&lt;&lt;endOptional&gt;&gt;
+
+&lt;&lt;endOptional&gt;&gt;</spdx:standardLicenseTemplate>
+                        <spdx:isOsiApproved rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                        >true</spdx:isOsiApproved>
+                        <spdx:crossRef>
+                          <spdx:CrossRef>
+                            <spdx:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+                            >0</spdx:order>
+                            <spdx:timestamp>2022-05-09T00:08:11Z</spdx:timestamp>
+                            <spdx:url>http://www.mozilla.org/MPL/MPL-1.0.html</spdx:url>
+                            <spdx:match>true</spdx:match>
+                            <spdx:isWayBackLink rdf:datatype=
+                            "http://www.w3.org/2001/XMLSchema#boolean"
+                            >false</spdx:isWayBackLink>
+                            <spdx:isValid rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                            >true</spdx:isValid>
+                            <spdx:isLive rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                            >true</spdx:isLive>
+                          </spdx:CrossRef>
+                        </spdx:crossRef>
+                        <spdx:standardLicenseHeaderHtml>
+         &lt;p&gt;&lt;var class="optional-license-text"&gt;&amp;quot;&lt;/var&gt;The contents of this file are subject to the Mozilla Public License Version 1.0 (the
+         &amp;quot;License&amp;quot;); you may not use this file except in compliance with the License. You may obtain
+         a copy of the License at http://www.mozilla.org/MPL/&lt;/p&gt;
+
+         &lt;p&gt;Software distributed under the License is distributed on an &amp;quot;AS IS&amp;quot; basis, WITHOUT WARRANTY OF
+         ANY KIND, either express or implied. See the License for the specific language governing rights and
+         limitations under the License.&lt;/p&gt;
+
+         &lt;p&gt;The Original Code is
+        &lt;var class="replacable-license-text"&gt; _____&lt;/var&gt;. The Initial Developer of the Original Code is
+        &lt;var class="replacable-license-text"&gt; _____&lt;/var&gt;. Portions created by
+        &lt;var class="replacable-license-text"&gt; _____&lt;/var&gt; are Copyright (C)
+        &lt;var class="replacable-license-text"&gt; _____&lt;/var&gt;. All Rights Reserved. Contributor(s):
+        &lt;var class="replacable-license-text"&gt; _____&lt;/var&gt;.&lt;var class="optional-license-text"&gt;&amp;quot;&lt;/var&gt;
+      &lt;/p&gt;
+
+        </spdx:standardLicenseHeaderHtml>
+                        <spdx:isDeprecatedLicenseId rdf:datatype=
+                        "http://www.w3.org/2001/XMLSchema#boolean"
+                        >false</spdx:isDeprecatedLicenseId>
+                        <spdx:licenseTextHtml>
+      &lt;div class="optional-license-text"&gt; 
+         &lt;p&gt;MOZILLA PUBLIC LICENSE
+        &lt;br /&gt;
+
+Version 1.0
+      &lt;/p&gt;
+
+      &lt;/div&gt;
+      
+&lt;ul style="list-style:none"&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 1.&lt;/var&gt;
+          Definitions.
+          
+&lt;ul style="list-style:none"&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 1.1.&lt;/var&gt;
+              &amp;quot;Contributor&amp;quot; means each entity that creates or contributes to the creation of
+                 Modifications.
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 1.2.&lt;/var&gt;
+              &amp;quot;Contributor Version&amp;quot; means the combination of the Original Code, prior
+                 Modifications used by a Contributor, and the Modifications made by that particular
+                 Contributor.
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 1.3.&lt;/var&gt;
+              &amp;quot;Covered Code&amp;quot; means the Original Code or Modifications or the combination of the
+                 Original Code and Modifications, in each case including portions thereof.
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 1.4.&lt;/var&gt;
+              &amp;quot;Electronic Distribution Mechanism&amp;quot; means a mechanism generally accepted in the
+                 software development community for the electronic transfer of data.
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 1.5.&lt;/var&gt;
+              &amp;quot;Executable&amp;quot; means Covered Code in any form other than Source Code.
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 1.6.&lt;/var&gt;
+              &amp;quot;Initial Developer&amp;quot; means the individual or entity identified as the Initial
+                 Developer in the Source Code notice required by Exhibit A.
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 1.7.&lt;/var&gt;
+              &amp;quot;Larger Work&amp;quot; means a work which combines Covered Code or portions thereof with
+                 code not governed by the terms of this License.
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 1.8.&lt;/var&gt;
+              &amp;quot;License&amp;quot; means this document.
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 1.9.&lt;/var&gt;
+              &amp;quot;Modifications&amp;quot; means any addition to or deletion from the substance or structure
+                 of either the Original Code or any previous Modifications. When Covered Code is released
+                 as a series of files, a Modification is:
+              
+&lt;ul style="list-style:none"&gt;
+                     
+&lt;li&gt;
+                        &lt;var class="replacable-license-text"&gt; A.&lt;/var&gt;
+                  Any addition to or deletion from the contents of a file containing Original Code or
+                     previous Modifications.
+                &lt;/li&gt;
+                     
+&lt;li&gt;
+                        &lt;var class="replacable-license-text"&gt; B.&lt;/var&gt;
+                  Any new file that contains any part of the Original Code or previous Modifications.
+                &lt;/li&gt;
+                  
+&lt;/ul&gt;
+               &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 1.10.&lt;/var&gt;
+              &amp;quot;Original Code&amp;quot; means Source Code of computer software code which is described in
+                 the Source Code notice required by Exhibit A as Original Code, and which, at the time of
+                 its release under this License is not already Covered Code governed by this License.
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 1.11.&lt;/var&gt;
+              &amp;quot;Source Code&amp;quot; means the preferred form of the Covered Code for making
+                 modifications to it, including all modules it contains, plus any associated interface
+                 definition files, scripts used to control compilation and installation of an Executable,
+                 or a list of source code differential comparisons against either the Original Code or
+                 another well known, available Covered Code of the Contributor&amp;apos;s choice. The Source
+                 Code can be in a compressed or archival form, provided the appropriate decompression or
+                 de-archiving software is widely available for no charge.
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 1.12.&lt;/var&gt;
+              &amp;quot;You&amp;quot; means an individual or a legal entity exercising rights under, and
+                 complying with all of the terms of, this License or a future version of this License
+                 issued under Section 6.1. For legal entities, &amp;quot;You&amp;quot; includes any entity which
+                 controls, is controlled by, or is under common control with You. For purposes of this
+                 definition, &amp;quot;control&amp;quot; means (a) the power, direct or indirect, to cause the
+                 direction or management of such entity, whether by contract or otherwise, or (b) ownership
+                 of fifty percent (50%) or more of the outstanding shares or beneficial ownership of such
+                 entity.
+            &lt;/li&gt;
+            
+&lt;/ul&gt;
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 2.&lt;/var&gt;
+          Source Code License.
+          
+&lt;ul style="list-style:none"&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 2.1.&lt;/var&gt;
+              The Initial Developer Grant.
+                &lt;br /&gt;
+
+      The Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive
+                     license, subject to third party intellectual property claims:
+
+&lt;ul style="list-style:none"&gt;
+                     
+&lt;li&gt;
+                        &lt;var class="replacable-license-text"&gt; (a)&lt;/var&gt;
+                  to use, reproduce, modify, display, perform, sublicense and distribute the Original Code
+                     (or portions thereof) with or without Modifications, or as part of a Larger Work;
+                     and
+                &lt;/li&gt;
+                     
+&lt;li&gt;
+                        &lt;var class="replacable-license-text"&gt; (b)&lt;/var&gt;
+                  under patents now or hereafter owned or controlled by Initial Developer, to make, have
+                     made, use and sell (&amp;quot;Utilize&amp;quot;) the Original Code (or portions thereof),
+                     but solely to the extent that any such patent is reasonably necessary to enable You to
+                     Utilize the Original Code (or portions thereof) and not to any greater extent that may
+                     be necessary to Utilize further Modifications or combinations.
+                &lt;/li&gt;
+                  
+&lt;/ul&gt;
+               &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 2.2.&lt;/var&gt;
+              Contributor Grant.
+                &lt;br /&gt;
+
+      Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license,
+                     subject to third party intellectual property claims:
+
+&lt;ul style="list-style:none"&gt;
+                     
+&lt;li&gt;
+                        &lt;var class="replacable-license-text"&gt; (a)&lt;/var&gt;
+                  to use, reproduce, modify, display, perform, sublicense and distribute the Modifications
+                     created by such Contributor (or portions thereof) either on an unmodified basis, with
+                     other Modifications, as Covered Code or as part of a Larger Work; and
+                &lt;/li&gt;
+                     
+&lt;li&gt;
+                        &lt;var class="replacable-license-text"&gt; (b)&lt;/var&gt;
+                  under patents now or hereafter owned or controlled by Contributor, to Utilize the
+                     Contributor Version (or portions thereof), but solely to the extent that any such
+                     patent is reasonably necessary to enable You to Utilize the Contributor Version (or
+                     portions thereof), and not to any greater extent that may be necessary to Utilize
+                     further Modifications or combinations.
+                &lt;/li&gt;
+                  
+&lt;/ul&gt;
+               &lt;/li&gt;
+            
+&lt;/ul&gt;
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 3.&lt;/var&gt;
+          Distribution Obligations.
+          
+&lt;ul style="list-style:none"&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 3.1.&lt;/var&gt;
+              Application of License.
+                &lt;br /&gt;
+
+      The Modifications which You create or to which You contribute are governed by the terms
+                     of this License, including without limitation Section 2.2. The Source Code version
+                     of Covered Code may be distributed only under the terms of this License or a
+                     future version of this License released under Section 6.1, and You must include a
+                     copy of this License with every copy of the Source Code You distribute. You may
+                     not offer or impose any terms on any Source Code version that alters or restricts
+                     the applicable version of this License or the recipients&amp;apos; rights hereunder.
+                     However, You may include an additional document offering the additional rights
+                     described in Section 3.5.
+
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 3.2.&lt;/var&gt;
+              Availability of Source Code.
+                &lt;br /&gt;
+
+      Any Modification which You create or to which You contribute must be made available in
+                     Source Code form under the terms of this License either on the same media as an
+                     Executable version or via an accepted Electronic Distribution Mechanism to anyone
+                     to whom you made an Executable version available; and if made available via
+                     Electronic Distribution Mechanism, must remain available for at least twelve (12)
+                     months after the date it initially became available, or at least six (6) months
+                     after a subsequent version of that particular Modification has been made available
+                     to such recipients. You are responsible for ensuring that the Source Code version
+                     remains available even if the Electronic Distribution Mechanism is maintained by a
+                     third party.
+
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 3.3.&lt;/var&gt;
+              Description of Modifications.
+                &lt;br /&gt;
+
+      You must cause all Covered Code to which you contribute to contain a file documenting
+                     the changes You made to create that Covered Code and the date of any change. You
+                     must include a prominent statement that the Modification is derived, directly or
+                     indirectly, from Original Code provided by the Initial Developer and including the
+                     name of the Initial Developer in (a) the Source Code, and (b) in any notice in an
+                     Executable version or related documentation in which You describe the origin or
+                     ownership of the Covered Code.
+
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 3.4.&lt;/var&gt;
+              Intellectual Property Matters
+              
+&lt;ul style="list-style:none"&gt;
+                     
+&lt;li&gt;
+                        &lt;var class="replacable-license-text"&gt; (a)&lt;/var&gt;
+                  Third Party Claims.
+                    &lt;br /&gt;
+
+         If You have knowledge that a party claims an intellectual property right in
+                         particular functionality or code (or its utilization under this License), you
+                         must include a text file with the source code distribution titled
+                         &amp;quot;LEGAL&amp;quot; which describes the claim and the party making the claim
+                         in sufficient detail that a recipient will know whom to contact. If you obtain
+                         such knowledge after You make Your Modification available as described in
+                         Section 3.2, You shall promptly modify the LEGAL file in all copies You make
+                         available thereafter and shall take other steps (such as notifying appropriate
+                         mailing lists or newsgroups) reasonably calculated to inform those who
+                         received the Covered Code that new knowledge has been obtained.
+
+                &lt;/li&gt;
+                     
+&lt;li&gt;
+                        &lt;var class="replacable-license-text"&gt; (b)&lt;/var&gt;
+                  Contributor APIs.
+                    &lt;br /&gt;
+
+         If Your Modification is an application programming interface and You own or control
+                         patents which are reasonably necessary to implement that API, you must also
+                         include this information in the LEGAL file.
+
+                &lt;/li&gt;
+                  
+&lt;/ul&gt;
+               &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 3.5.&lt;/var&gt;
+              Required Notices.
+                &lt;br /&gt;
+
+      You must duplicate the notice in Exhibit A in each file of the Source Code, and this
+                     License in any documentation for the Source Code, where You describe
+                     recipients&amp;apos; rights relating to Covered Code. If You created one or more
+                     Modification(s), You may add your name as a Contributor to the notice described in
+                     Exhibit A. If it is not possible to put such notice in a particular Source Code
+                     file due to its structure, then you must include such notice in a location (such
+                     as a relevant directory file) where a user would be likely to look for such a
+                     notice. You may choose to offer, and to charge a fee for, warranty, support,
+                     indemnity or liability obligations to one or more recipients of Covered Code.
+                     However, You may do so only on Your own behalf, and not on behalf of the Initial
+                     Developer or any Contributor. You must make it absolutely clear than any such
+                     warranty, support, indemnity or liability obligation is offered by You alone, and
+                     You hereby agree to indemnify the Initial Developer and every Contributor for any
+                     liability incurred by the Initial Developer or such Contributor as a result of
+                     warranty, support, indemnity or liability terms You offer.
+
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 3.6.&lt;/var&gt;
+              Distribution of Executable Versions.
+                &lt;br /&gt;
+
+      You may distribute Covered Code in Executable form only if the requirements of Section
+                     3.1-3.5 have been met for that Covered Code, and if You include a notice stating
+                     that the Source Code version of the Covered Code is available under the terms of
+                     this License, including a description of how and where You have fulfilled the
+                     obligations of Section 3.2. The notice must be conspicuously included in any
+                     notice in an Executable version, related documentation or collateral in which You
+                     describe recipients&amp;apos; rights relating to the Covered Code. You may distribute
+                     the Executable version of Covered Code under a license of Your choice, which may
+                     contain terms different from this License, provided that You are in compliance
+                     with the terms of this License and that the license for the Executable version
+                     does not attempt to limit or alter the recipient&amp;apos;s rights in the Source Code
+                     version from the rights set forth in this License. If You distribute the
+                     Executable version under a different license You must make it absolutely clear
+                     that any terms which differ from this License are offered by You alone, not by the
+                     Initial Developer or any Contributor. You hereby agree to indemnify the Initial
+                     Developer and every Contributor for any liability incurred by the Initial
+                     Developer or such Contributor as a result of any such terms You offer.
+
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 3.7.&lt;/var&gt;
+              Larger Works.
+                &lt;br /&gt;
+
+      You may create a Larger Work by combining Covered Code with other code not governed by
+                     the terms of this License and distribute the Larger Work as a single product. In
+                     such a case, You must make sure the requirements of this License are fulfilled for
+                     the Covered Code.
+
+            &lt;/li&gt;
+            
+&lt;/ul&gt;
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 4.&lt;/var&gt;
+          Inability to Comply Due to Statute or Regulation.
+            &lt;br /&gt;
+
+   If it is impossible for You to comply with any of the terms of this License with respect to
+                 some or all of the Covered Code due to statute or regulation then You must: (a) comply
+                 with the terms of this License to the maximum extent possible; and (b) describe the
+                 limitations and the code they affect. Such description must be included in the LEGAL
+                 file described in Section 3.4 and must be included with all distributions of the
+                 Source Code. Except to the extent prohibited by statute or regulation, such
+                 description must be sufficiently detailed for a recipient of ordinary skill to be able
+                 to understand it.
+
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 5.&lt;/var&gt;
+          Application of this License.
+            &lt;br /&gt;
+
+   This License applies to code to which the Initial Developer has attached the notice in
+                 Exhibit A, and to related Covered Code.
+
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 6.&lt;/var&gt;
+          Versions of the License.
+          
+&lt;ul style="list-style:none"&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 6.1.&lt;/var&gt;
+              New Versions.
+                &lt;br /&gt;
+
+      Netscape Communications Corporation (&amp;quot;Netscape&amp;quot;) may publish revised and/or
+                     new versions of the License from time to time. Each version will be given a
+                     distinguishing version number.
+
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 6.2.&lt;/var&gt;
+              Effect of New Versions.
+                &lt;br /&gt;
+
+      Once Covered Code has been published under a particular version of the License, You may
+                     always continue to use it under the terms of that version. You may also choose to
+                     use such Covered Code under the terms of any subsequent version of the License
+                     published by Netscape. No one other than Netscape has the right to modify the
+                     terms applicable to Covered Code created under this License.
+
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; 6.3.&lt;/var&gt;
+              Derivative Works.
+                &lt;br /&gt;
+
+      If you create or use a modified version of this License (which you may only do in order
+                     to apply it to code which is not already Covered Code governed by this License),
+                     you must (a) rename Your license so that the phrases &amp;quot;Mozilla&amp;quot;,
+                     &amp;quot;MOZILLAPL&amp;quot;, &amp;quot;MOZPL&amp;quot;, &amp;quot;Netscape&amp;quot;,
+                     &amp;quot;NPL&amp;quot; or any confusingly similar phrase do not appear anywhere in your
+                     license and (b) otherwise make it clear that your version of the license contains
+                     terms which differ from the Mozilla Public License and Netscape Public License.
+                     (Filling in the name of the Initial Developer, Original Code or Contributor in the
+                     notice described in Exhibit A shall not of themselves be deemed to be
+                     modifications of this License.)
+
+            &lt;/li&gt;
+            
+&lt;/ul&gt;
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 7.&lt;/var&gt;
+          DISCLAIMER OF WARRANTY.
+            &lt;br /&gt;
+
+   COVERED CODE IS PROVIDED UNDER THIS LICENSE ON AN &amp;quot;AS IS&amp;quot; BASIS, WITHOUT
+                 WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION,
+                 WARRANTIES THAT THE COVERED CODE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A
+                 PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND
+                 PERFORMANCE OF THE COVERED CODE IS WITH YOU. SHOULD ANY COVERED CODE PROVE DEFECTIVE
+                 IN ANY RESPECT, YOU (NOT THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE
+                 COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY
+                 CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY COVERED CODE IS
+                 AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
+
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 8.&lt;/var&gt;
+          TERMINATION.
+            &lt;br /&gt;
+
+   This License and the rights granted hereunder will terminate automatically if You fail to
+                 comply with terms herein and fail to cure such breach within 30 days of becoming aware
+                 of the breach. All sublicenses to the Covered Code which are properly granted shall
+                 survive any termination of this License. Provisions which, by their nature, must
+                 remain in effect beyond the termination of this License shall survive.
+
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 9.&lt;/var&gt;
+          LIMITATION OF LIABILITY.
+            &lt;br /&gt;
+
+   UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING NEGLIGENCE),
+                 CONTRACT, OR OTHERWISE, SHALL THE INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY
+                 DISTRIBUTOR OF COVERED CODE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO YOU
+                 OR ANY OTHER PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF
+                 ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK
+                 STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR
+                 LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH
+                 DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR
+                 PERSONAL INJURY RESULTING FROM SUCH PARTY&amp;apos;S NEGLIGENCE TO THE EXTENT APPLICABLE
+                 LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR
+                 LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THAT EXCLUSION AND LIMITATION
+                 MAY NOT APPLY TO YOU.
+
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 10.&lt;/var&gt;
+          U.S. GOVERNMENT END USERS.
+            &lt;br /&gt;
+
+   The Covered Code is a &amp;quot;commercial item,&amp;quot; as that term is defined in 48 C.F.R.
+                 2.101 (Oct. 1995), consisting of &amp;quot;commercial computer software&amp;quot; and
+                 &amp;quot;commercial computer software documentation,&amp;quot; as such terms are used in 48
+                 C.F.R. 12.212 (Sept. 1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1
+                 through 227.7202-4 (June 1995), all U.S. Government End Users acquire Covered Code
+                 with only those rights set forth herein.
+
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 11.&lt;/var&gt;
+          MISCELLANEOUS.
+            &lt;br /&gt;
+
+   This License represents the complete agreement concerning subject matter hereof. If any
+                 provision of this License is held to be unenforceable, such provision shall be
+                 reformed only to the extent necessary to make it enforceable. This License shall be
+                 governed by California law provisions (except to the extent applicable law, if any,
+                 provides otherwise), excluding its conflict-of-law provisions. With respect to
+                 disputes in which at least one party is a citizen of, or an entity chartered or
+                 registered to do business in, the United States of America: (a) unless otherwise
+                 agreed in writing, all disputes relating to this License (excepting any dispute
+                 relating to intellectual property rights) shall be subject to final and binding
+                 arbitration, with the losing party paying all costs of arbitration; (b) any
+                 arbitration relating to this Agreement shall be held in Santa Clara County,
+                 California, under the auspices of JAMS/EndDispute; and (c) any litigation relating to
+                 this Agreement shall be subject to the jurisdiction of the Federal Courts of the
+                 Northern District of California, with venue lying in Santa Clara County, California,
+                 with the losing party responsible for costs, including without limitation, court costs
+                 and reasonable attorneys fees and expenses. The application of the United Nations
+                 Convention on Contracts for the International Sale of Goods is expressly excluded. Any
+                 law or regulation which provides that the language of a contract shall be construed
+                 against the drafter shall not apply to this License.
+
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 12.&lt;/var&gt;
+          RESPONSIBILITY FOR CLAIMS.
+            &lt;br /&gt;
+
+   Except in cases where another Contributor has failed to comply with Section 3.4, You are responsible for
+                 damages arising, directly or indirectly, out of Your utilization of rights under this License, based
+                 on the number of copies of Covered Code you made available, the revenues you received from utilizing
+                 such rights, and other relevant factors. You agree to work with affected parties to distribute
+                 responsibility on an equitable basis.
+        &lt;/li&gt;
+      
+&lt;/ul&gt;
+      &lt;div class="optional-license-text"&gt; 
+         &lt;p&gt;EXHIBIT A.&lt;/p&gt;
+
+         &lt;p&gt;&lt;var class="optional-license-text"&gt;&amp;quot;&lt;/var&gt;The contents of this file are subject to the Mozilla Public License Version 1.0 (the
+         &amp;quot;License&amp;quot;); you may not use this file except in compliance with the License. You may obtain
+         a copy of the License at http://www.mozilla.org/MPL/&lt;/p&gt;
+
+         &lt;p&gt;Software distributed under the License is distributed on an &amp;quot;AS IS&amp;quot; basis, WITHOUT WARRANTY OF
+         ANY KIND, either express or implied. See the License for the specific language governing rights and
+         limitations under the License.&lt;/p&gt;
+
+         &lt;p&gt;The Original Code is
+        &lt;var class="replacable-license-text"&gt; _____&lt;/var&gt;. The Initial Developer of the Original Code is
+        &lt;var class="replacable-license-text"&gt; _____&lt;/var&gt;. Portions created by
+        &lt;var class="replacable-license-text"&gt; _____&lt;/var&gt; are Copyright (C)
+        &lt;var class="replacable-license-text"&gt; _____&lt;/var&gt;. All Rights Reserved. Contributor(s):
+        &lt;var class="replacable-license-text"&gt; _____&lt;/var&gt;.&lt;var class="optional-license-text"&gt;&amp;quot;&lt;/var&gt;
+      &lt;/p&gt;
+
+      &lt;/div&gt;
+    </spdx:licenseTextHtml>
+                        <spdx:licenseId>MPL-1.0</spdx:licenseId>
+                        <spdx:crossRef>
+                          <spdx:CrossRef>
+                            <spdx:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+                            >1</spdx:order>
+                            <spdx:timestamp>2022-05-09T00:08:12Z</spdx:timestamp>
+                            <spdx:url>https://opensource.org/licenses/MPL-1.0</spdx:url>
+                            <spdx:match>true</spdx:match>
+                            <spdx:isWayBackLink rdf:datatype=
+                            "http://www.w3.org/2001/XMLSchema#boolean"
+                            >false</spdx:isWayBackLink>
+                            <spdx:isValid rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                            >true</spdx:isValid>
+                            <spdx:isLive rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                            >true</spdx:isLive>
+                          </spdx:CrossRef>
+                        </spdx:crossRef>
+                      </spdx:ListedLicense>
+                    </spdx:licenseConcluded>
+                    <spdx:filesAnalyzed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+                    >false</spdx:filesAnalyzed>
+                    <spdx:copyrightText>Copyright Saxonica Ltd</spdx:copyrightText>
+                    <spdx:licenseDeclared rdf:resource="http://spdx.org/licenses/MPL-1.0"/>
+                  </spdx:Package>
+                </spdx:relatedSpdxElement>
+                <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_dynamicLink"/>
+              </spdx:Relationship>
+            </spdx:relationship>
+            <spdx:copyrightText>Copyright 2008-2010 John Smith</spdx:copyrightText>
+            <spdx:description>The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.</spdx:description>
+            <spdx:relationship>
+              <spdx:Relationship>
+                <spdx:relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+                <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_contains"/>
+              </spdx:Relationship>
+            </spdx:relationship>
+          </spdx:Package>
+        </spdx:relatedSpdxElement>
+        <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+      </spdx:Relationship>
+    </spdx:relationship>
+    <spdx:annotation>
+      <spdx:Annotation>
+        <spdx:annotator>Person: Suzanne Reviewer</spdx:annotator>
+        <rdfs:comment>Another example reviewer.</rdfs:comment>
+        <spdx:annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_review"/>
+        <spdx:annotationDate>2011-03-13T00:00:00Z</spdx:annotationDate>
+      </spdx:Annotation>
+    </spdx:annotation>
+    <spdx:relationship>
+      <spdx:Relationship>
+        <spdx:relatedSpdxElement>
+          <spdx:File rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File">
+            <spdx:fileName>./package/foo.c</spdx:fileName>
+            <spdx:licenseComments>The concluded license was taken from the package level that the file was included in.</spdx:licenseComments>
+            <spdx:checksum>
+              <spdx:Checksum>
+                <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+                <spdx:checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2758</spdx:checksumValue>
+              </spdx:Checksum>
+            </spdx:checksum>
+            <spdx:licenseInfoInFile rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-2"/>
+            <spdx:relationship>
+              <spdx:Relationship>
+                <spdx:relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-fromDoap-0"/>
+                <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_generatedFrom"/>
+              </spdx:Relationship>
+            </spdx:relationship>
+            <spdx:licenseInfoInFile rdf:resource="http://spdx.org/licenses/GPL-2.0-only"/>
+            <spdx:licenseConcluded>
+              <spdx:DisjunctiveLicenseSet>
+                <spdx:member rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-2"/>
+                <spdx:member rdf:resource="http://spdx.org/licenses/LGPL-2.0-only"/>
+              </spdx:DisjunctiveLicenseSet>
+            </spdx:licenseConcluded>
+            <spdx:copyrightText>Copyright 2008-2010 John Smith</spdx:copyrightText>
+            <spdx:fileContributor>The Regents of the University of California</spdx:fileContributor>
+            <spdx:checksum>
+              <spdx:Checksum>
+                <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_md5"/>
+                <spdx:checksumValue>624c1abb3664f4b35547e7c73864ad24</spdx:checksumValue>
+              </spdx:Checksum>
+            </spdx:checksum>
+            <spdx:fileContributor>Modified by Paul Mundt lethal@linux-sh.org</spdx:fileContributor>
+            <spdx:fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+            <spdx:fileContributor>IBM Corporation</spdx:fileContributor>
+            <spdx:noticeText>Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</spdx:noticeText>
+            <rdfs:comment>The concluded license was taken from the package level that the file was included in.
+This information was found in the COPYING.txt file in the xyz directory.</rdfs:comment>
+            <spdx:annotation>
+              <spdx:Annotation>
+                <spdx:annotator>Person: File Commenter</spdx:annotator>
+                <rdfs:comment>File level annotation</rdfs:comment>
+                <spdx:annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_other"/>
+                <spdx:annotationDate>2011-01-29T18:30:22Z</spdx:annotationDate>
+              </spdx:Annotation>
+            </spdx:annotation>
+          </spdx:File>
+        </spdx:relatedSpdxElement>
+        <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+      </spdx:Relationship>
+    </spdx:relationship>
+    <spdx:dataLicense>
+      <spdx:ListedLicense rdf:about="http://spdx.org/licenses/CC0-1.0">
+        <spdx:isOsiApproved rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+        >false</spdx:isOsiApproved>
+        <spdx:isFsfLibre rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+        >true</spdx:isFsfLibre>
+        <spdx:standardLicenseTemplate>&lt;&lt;beginOptional&gt;&gt;&lt;&lt;beginOptional&gt;&gt;Creative Commons&lt;&lt;beginOptional&gt;&gt; Legal Code&lt;&lt;endOptional&gt;&gt;
+
+&lt;&lt;endOptional&gt;&gt;
+
+CC0 1.0 Universal
+
+&lt;&lt;endOptional&gt;&gt;&lt;&lt;beginOptional&gt;&gt; CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER.
+
+&lt;&lt;endOptional&gt;&gt;
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer exclusive Copyright and Related Rights (defined below) upon the creator and subsequent owner(s) (each and all, an "owner") of an original work of authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the purpose of contributing to a commons of creative, cultural and scientific works ("Commons") that the public can reliably and without fear of later claims of infringement build upon, modify, incorporate in other works, reuse and redistribute as freely as possible in any form whatsoever and for any purposes, including without limitation commercial purposes. These owners may contribute to the Commons to promote the ideal of a free culture and the further production of creative, cultural and scientific works, or to gain reputation or greater distribution for their Work in part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation of additional consideration or compensation, the person associating CC0 with a Work (the "Affirmer"), to the extent that he or she is an owner of Copyright and Related Rights in the Work, voluntarily elects to apply CC0 to the Work and publicly distribute the Work under its terms, with knowledge of his or her Copyright and Related Rights in the Work and the meaning and intended legal effect of CC0 on those rights.
+
+   &lt;&lt;var;name="bullet";original="1.";match=".{0,20}"&gt;&gt; Copyright and Related Rights. A Work made available under CC0 may be protected by copyright and related or neighboring rights ("Copyright and Related Rights"). Copyright and Related Rights include, but are not limited to, the following:
+
+      &lt;&lt;var;name="bullet";original="i.";match=".{0,20}"&gt;&gt; the right to reproduce, adapt, distribute, perform, display, communicate, and translate a Work;
+
+      &lt;&lt;var;name="bullet";original="ii.";match=".{0,20}"&gt;&gt; moral rights retained by the original author(s) and/or performer(s);
+
+      &lt;&lt;var;name="bullet";original="iii.";match=".{0,20}"&gt;&gt; publicity and privacy rights pertaining to a person's image or likeness depicted in a Work;
+
+      &lt;&lt;var;name="bullet";original="iv.";match=".{0,20}"&gt;&gt; rights protecting against unfair competition in regards to a Work, subject to the limitations in paragraph 4(a), below;
+
+      &lt;&lt;var;name="bullet";original="v.";match=".{0,20}"&gt;&gt; rights protecting the extraction, dissemination, use and reuse of data in a Work;
+
+      &lt;&lt;var;name="bullet";original="vi.";match=".{0,20}"&gt;&gt; database rights (such as those arising under Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, and under any national implementation thereof, including any amended or successor version of such directive); and
+
+      &lt;&lt;var;name="bullet";original="vii.";match=".{0,20}"&gt;&gt; other similar, equivalent or corresponding rights throughout the world based on applicable law or treaty, and any national implementations thereof.
+
+   &lt;&lt;var;name="bullet";original="2.";match=".{0,20}"&gt;&gt; Waiver. To the greatest extent permitted by, but not in contravention of, applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and unconditionally waives, abandons, and surrenders all of Affirmer's Copyright and Related Rights and associated claims and causes of action, whether now known or unknown (including existing as well as future claims and causes of action), in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each member of the public at large and to the detriment of Affirmer's heirs and successors, fully intending that such Waiver shall not be subject to revocation, rescission, cancellation, termination, or any other legal or equitable action to disrupt the quiet enjoyment of the Work by the public as contemplated by Affirmer's express Statement of Purpose.
+
+   &lt;&lt;var;name="bullet";original="3.";match=".{0,20}"&gt;&gt; Public License Fallback. Should any part of the Waiver for any reason be judged legally invalid or ineffective under applicable law, then the Waiver shall be preserved to the maximum extent permitted taking into account Affirmer's express Statement of Purpose. In addition, to the extent the Waiver is so judged Affirmer hereby grants to each affected person a royalty-free, non transferable, non sublicensable, non exclusive, irrevocable and unconditional license to exercise Affirmer's Copyright and Related Rights in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "License"). The License shall be deemed effective as of the date CC0 was applied by Affirmer to the Work. Should any part of the License for any reason be judged legally invalid or ineffective under applicable law, such partial invalidity or ineffectiveness shall not invalidate the remainder of the License, and in such case Affirmer hereby affirms that he or she will not (i) exercise any of his or her remaining Copyright and Related Rights in the Work or (ii) assert any associated claims and causes of action with respect to the Work, in either case contrary to Affirmer's express Statement of Purpose.
+
+   &lt;&lt;var;name="bullet";original="4.";match=".{0,20}"&gt;&gt; Limitations and Disclaimers.
+
+      &lt;&lt;var;name="bullet";original="a.";match=".{0,20}"&gt;&gt; No trademark or patent rights held by Affirmer are waived, abandoned, surrendered, licensed or otherwise affected by this document.
+
+      &lt;&lt;var;name="bullet";original="b.";match=".{0,20}"&gt;&gt; Affirmer offers the Work as-is and makes no representations or warranties of any kind concerning the Work, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non infringement, or the absence of latent or other defects, accuracy, or the present or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.
+
+      &lt;&lt;var;name="bullet";original="c.";match=".{0,20}"&gt;&gt; Affirmer disclaims responsibility for clearing rights of other persons that may apply to the Work or any use thereof, including without limitation any person's Copyright and Related Rights in the Work. Further, Affirmer disclaims responsibility for obtaining any necessary consents, permissions or other rights required for any use of the Work.
+
+      &lt;&lt;var;name="bullet";original="d.";match=".{0,20}"&gt;&gt; Affirmer understands and acknowledges that Creative Commons is not a party to this document and has no duty or obligation with respect to this CC0 or use of the Work.&lt;&lt;beginOptional&gt;&gt; &lt;&lt;var;name="upstreamLink";original="";match="For more information, please see &lt;http://creativecommons.org/publicdomain/zero/1.0/&gt;"&gt;&gt;&lt;&lt;endOptional&gt;&gt;</spdx:standardLicenseTemplate>
+        <spdx:licenseTextHtml>
+      &lt;div class="optional-license-text"&gt; 
+         &lt;div class="optional-license-text"&gt; 
+            &lt;p&gt;Creative Commons&lt;var class="optional-license-text"&gt;  Legal Code&lt;/var&gt;&lt;/p&gt;
+
+         &lt;/div&gt;
+         &lt;p&gt;CC0 1.0 Universal&lt;/p&gt;
+
+      &lt;/div&gt;
+      &lt;div class="optional-license-text"&gt; 
+         &lt;p&gt;CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS
+         DOCUMENT DOES NOT CREATE AN ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION
+         ON AN &amp;quot;AS-IS&amp;quot; BASIS. CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE USE OF THIS DOCUMENT
+         OR THE INFORMATION OR WORKS PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM THE
+         USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER.&lt;/p&gt;
+
+      &lt;/div&gt;
+
+      &lt;p&gt;Statement of Purpose&lt;/p&gt;
+
+      &lt;p&gt;The laws of most jurisdictions throughout the world automatically confer exclusive Copyright and Related
+         Rights (defined below) upon the creator and subsequent owner(s) (each and all, an &amp;quot;owner&amp;quot;)
+         of an original work of authorship and/or a database (each, a &amp;quot;Work&amp;quot;).&lt;/p&gt;
+
+      &lt;p&gt;Certain owners wish to permanently relinquish those rights to a Work for the purpose of contributing to a
+         commons of creative, cultural and scientific works (&amp;quot;Commons&amp;quot;) that the public can reliably
+         and without fear of later claims of infringement build upon, modify, incorporate in other works, reuse
+         and redistribute as freely as possible in any form whatsoever and for any purposes, including without
+         limitation commercial purposes. These owners may contribute to the Commons to promote the ideal of a
+         free culture and the further production of creative, cultural and scientific works, or to gain
+         reputation or greater distribution for their Work in part through the use and efforts of others.&lt;/p&gt;
+
+      &lt;p&gt;For these and/or other purposes and motivations, and without any expectation of additional consideration
+         or compensation, the person associating CC0 with a Work (the &amp;quot;Affirmer&amp;quot;), to the extent that
+         he or she is an owner of Copyright and Related Rights in the Work, voluntarily elects to apply CC0 to
+         the Work and publicly distribute the Work under its terms, with knowledge of his or her Copyright and
+         Related Rights in the Work and the meaning and intended legal effect of CC0 on those rights.&lt;/p&gt;
+
+&lt;ul style="list-style:none"&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 1.&lt;/var&gt;
+          Copyright and Related Rights. A Work made available under CC0 may be protected by copyright and
+             related or neighboring rights (&amp;quot;Copyright and Related Rights&amp;quot;). Copyright and
+             Related Rights include, but are not limited to, the following:
+          
+&lt;ul style="list-style:none"&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; i.&lt;/var&gt;
+              the right to reproduce, adapt, distribute, perform, display, communicate, and translate a Work;
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; ii.&lt;/var&gt;
+              moral rights retained by the original author(s) and/or performer(s);
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; iii.&lt;/var&gt;
+              publicity and privacy rights pertaining to a person&amp;apos;s image or likeness depicted in a Work;
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; iv.&lt;/var&gt;
+              rights protecting against unfair competition in regards to a Work, subject to the limitations
+                 in paragraph 4(a), below;
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; v.&lt;/var&gt;
+              rights protecting the extraction, dissemination, use and reuse of data in a Work;
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; vi.&lt;/var&gt;
+              database rights (such as those arising under Directive 96/9/EC of the European Parliament and
+                 of the Council of 11 March 1996 on the legal protection of databases, and under any
+                 national implementation thereof, including any amended or successor version of such
+                 directive); and
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; vii.&lt;/var&gt;
+              other similar, equivalent or corresponding rights throughout the world based on applicable
+                 law or treaty, and any national implementations thereof.
+            &lt;/li&gt;
+            
+&lt;/ul&gt;
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 2.&lt;/var&gt;
+          Waiver. To the greatest extent permitted by, but not in contravention of, applicable law,
+             Affirmer hereby overtly, fully, permanently, irrevocably and unconditionally waives, abandons,
+             and surrenders all of Affirmer&amp;apos;s Copyright and Related Rights and associated claims and
+             causes of action, whether now known or unknown (including existing as well as future claims
+             and causes of action), in the Work (i) in all territories worldwide, (ii) for the maximum
+             duration provided by applicable law or treaty (including future time extensions), (iii) in any
+             current or future medium and for any number of copies, and (iv) for any purpose whatsoever,
+             including without limitation commercial, advertising or promotional purposes (the
+             &amp;quot;Waiver&amp;quot;). Affirmer makes the Waiver for the benefit of each member of the public at
+             large and to the detriment of Affirmer&amp;apos;s heirs and successors, fully intending that such
+             Waiver shall not be subject to revocation, rescission, cancellation, termination, or any other
+             legal or equitable action to disrupt the quiet enjoyment of the Work by the public as
+             contemplated by Affirmer&amp;apos;s express Statement of Purpose.
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 3.&lt;/var&gt;
+          Public License Fallback. Should any part of the Waiver for any reason be judged legally invalid
+             or ineffective under applicable law, then the Waiver shall be preserved to the maximum extent
+             permitted taking into account Affirmer&amp;apos;s express Statement of Purpose. In addition, to
+             the extent the Waiver is so judged Affirmer hereby grants to each affected person a
+             royalty-free, non transferable, non sublicensable, non exclusive, irrevocable and
+             unconditional license to exercise Affirmer&amp;apos;s Copyright and Related Rights in the Work (i)
+             in all territories worldwide, (ii) for the maximum duration provided by applicable law or
+             treaty (including future time extensions), (iii) in any current or future medium and for any
+             number of copies, and (iv) for any purpose whatsoever, including without limitation
+             commercial, advertising or promotional purposes (the &amp;quot;License&amp;quot;). The License shall
+             be deemed effective as of the date CC0 was applied by Affirmer to the Work. Should any part of
+             the License for any reason be judged legally invalid or ineffective under applicable law, such
+             partial invalidity or ineffectiveness shall not invalidate the remainder of the License, and
+             in such case Affirmer hereby affirms that he or she will not (i) exercise any of his or her
+             remaining Copyright and Related Rights in the Work or (ii) assert any associated claims and
+             causes of action with respect to the Work, in either case contrary to Affirmer&amp;apos;s express
+             Statement of Purpose.
+        &lt;/li&gt;
+        
+&lt;li&gt;
+            &lt;var class="replacable-license-text"&gt; 4.&lt;/var&gt;
+          Limitations and Disclaimers.
+          
+&lt;ul style="list-style:none"&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; a.&lt;/var&gt;
+              No trademark or patent rights held by Affirmer are waived, abandoned, surrendered, licensed
+                 or otherwise affected by this document.
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; b.&lt;/var&gt;
+              Affirmer offers the Work as-is and makes no representations or warranties of any kind
+                 concerning the Work, express, implied, statutory or otherwise, including without
+                 limitation warranties of title, merchantability, fitness for a particular purpose, non
+                 infringement, or the absence of latent or other defects, accuracy, or the present or
+                 absence of errors, whether or not discoverable, all to the greatest extent permissible
+                 under applicable law.
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; c.&lt;/var&gt;
+              Affirmer disclaims responsibility for clearing rights of other persons that may apply to the
+                 Work or any use thereof, including without limitation any person&amp;apos;s Copyright and
+                 Related Rights in the Work. Further, Affirmer disclaims responsibility for obtaining any
+                 necessary consents, permissions or other rights required for any use of the Work.
+            &lt;/li&gt;
+               
+&lt;li&gt;
+                  &lt;var class="replacable-license-text"&gt; d.&lt;/var&gt;
+              Affirmer understands and acknowledges that Creative Commons is not a party to this document
+                 and has no duty or obligation with respect to this CC0 or use of the Work.
+            &lt;/li&gt;
+            
+&lt;/ul&gt;
+        &lt;/li&gt;
+      
+&lt;/ul&gt;
+      &lt;var class="optional-license-text"&gt; &lt;var class="replacable-license-text"&gt; &lt;/var&gt;&lt;/var&gt;
+    </spdx:licenseTextHtml>
+        <spdx:isDeprecatedLicenseId rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+        >false</spdx:isDeprecatedLicenseId>
+        <spdx:name>Creative Commons Zero v1.0 Universal</spdx:name>
+        <spdx:licenseId>CC0-1.0</spdx:licenseId>
+        <spdx:crossRef>
+          <spdx:CrossRef>
+            <spdx:order rdf:datatype="http://www.w3.org/2001/XMLSchema#int"
+            >0</spdx:order>
+            <spdx:timestamp>2022-05-08T23:56:45Z</spdx:timestamp>
+            <spdx:url>https://creativecommons.org/publicdomain/zero/1.0/legalcode</spdx:url>
+            <spdx:match>false</spdx:match>
+            <spdx:isWayBackLink rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >false</spdx:isWayBackLink>
+            <spdx:isValid rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >true</spdx:isValid>
+            <spdx:isLive rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+            >true</spdx:isLive>
+          </spdx:CrossRef>
+        </spdx:crossRef>
+        <spdx:licenseText>Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.
+</spdx:licenseText>
+        <rdfs:seeAlso>https://creativecommons.org/publicdomain/zero/1.0/legalcode</rdfs:seeAlso>
+      </spdx:ListedLicense>
+    </spdx:dataLicense>
+    <spdx:hasExtractedLicensingInfo rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-3"/>
+    <spdx:hasExtractedLicensingInfo>
+      <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-Beerware-4.2">
+        <rdfs:seeAlso>http://people.freebsd.org/~phk/</rdfs:seeAlso>
+        <spdx:licenseId>LicenseRef-Beerware-4.2</spdx:licenseId>
+        <rdfs:comment>The beerware license has a couple of other standard variants.</rdfs:comment>
+        <spdx:extractedText>"THE BEER-WARE LICENSE" (Revision 42):
+phk@FreeBSD.ORG wrote this file. As long as you retain this notice you
+can do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a beer in return Poul-Henning Kamp</spdx:extractedText>
+        <spdx:name>Beer-Ware License (Version 42)</spdx:name>
+      </spdx:ExtractedLicensingInfo>
+    </spdx:hasExtractedLicensingInfo>
+    <spdx:externalDocumentRef>
+      <spdx:ExternalDocumentRef rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#DocumentRef-spdx-tool-1.2">
+        <spdx:spdxDocument rdf:resource="http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301"/>
+        <spdx:checksum>
+          <spdx:Checksum>
+            <spdx:algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+            <spdx:checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</spdx:checksumValue>
+          </spdx:Checksum>
+        </spdx:checksum>
+      </spdx:ExternalDocumentRef>
+    </spdx:externalDocumentRef>
+    <spdx:hasExtractedLicensingInfo>
+      <spdx:ExtractedLicensingInfo rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-4">
+        <spdx:licenseId>LicenseRef-4</spdx:licenseId>
+        <spdx:extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/</spdx:extractedText>
+      </spdx:ExtractedLicensingInfo>
+    </spdx:hasExtractedLicensingInfo>
+    <spdx:relationship>
+      <spdx:Relationship>
+        <spdx:relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-ToolsElement"/>
+        <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_copyOf"/>
+      </spdx:Relationship>
+    </spdx:relationship>
+    <spdx:hasExtractedLicensingInfo rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-2"/>
+    <spdx:specVersion>SPDX-2.3</spdx:specVersion>
+    <rdfs:comment>This document was created using SPDX 2.0 using licenses from the web site.</rdfs:comment>
+    <spdx:relationship>
+      <spdx:Relationship>
+        <spdx:relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package"/>
+        <spdx:relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_contains"/>
+      </spdx:Relationship>
+    </spdx:relationship>
+    <spdx:annotation>
+      <spdx:Annotation>
+        <spdx:annotator>Person: Jane Doe ()</spdx:annotator>
+        <rdfs:comment>Document level annotation</rdfs:comment>
+        <spdx:annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_other"/>
+        <spdx:annotationDate>2010-01-29T18:30:22Z</spdx:annotationDate>
+      </spdx:Annotation>
+    </spdx:annotation>
+    <spdx:annotation>
+      <spdx:Annotation>
+        <spdx:annotator>Person: Joe Reviewer</spdx:annotator>
+        <rdfs:comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <spdx:annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_review"/>
+        <spdx:annotationDate>2010-02-10T00:00:00Z</spdx:annotationDate>
+      </spdx:Annotation>
+    </spdx:annotation>
+    <spdx:name>SPDX-Tools-v2.0</spdx:name>
+    <spdx:hasExtractedLicensingInfo rdf:resource="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#LicenseRef-1"/>
+  </spdx:SpdxDocument>
+  <spdx:Package rdf:about="http://spdx.org/spdxdocs/spdx-example-rdf-2-3-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-fromDoap-1">
+    <doap:homepage>http://commons.apache.org/proper/commons-lang/</doap:homepage>
+    <spdx:copyrightText>NOASSERTION</spdx:copyrightText>
+    <spdx:licenseDeclared rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
+    <spdx:downloadLocation>NOASSERTION</spdx:downloadLocation>
+    <spdx:name>Apache Commons Lang</spdx:name>
+    <spdx:licenseConcluded rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
+    <spdx:filesAnalyzed rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean"
+    >false</spdx:filesAnalyzed>
+  </spdx:Package>
+</rdf:RDF>


### PR DESCRIPTION
Fixing #530 

Had some free time, trying to make all tests run successfully - both locally and via PyCharm.
PyCharm debugger is very helpful to fix these issues faster.
Will be fixing more tests in app/tests.py as well.

- Fixed test_checklicense_api where response structure changed
- Fixed core.py with proper exception handling

Now only 2 tests in api are failing - both with rdf file 
<img width="1266" alt="Screenshot 2024-04-07 at 2 56 53 PM" src="https://github.com/spdx/spdx-online-tools/assets/17159160/533b2eb3-fe2b-4246-bbe0-709be212db2c">

@goneall Has there been any change with verifying RDF files. Both the remaining tests are failing as an exception is raised by `verifyclass.verify` JVM call to verify RDF files - `'org.spdx.library.model.SpdxIdInUseException: Can not create Apache-2.0.  It is already in use with type License which is incompatible with type ListedLicense')`
