### PR TITLE
add dots in iframe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==3.2.25
 jpype1==1.3.0
 numpy==1.22.0
-djangorestframework==3.15.2
+djangorestframework==3.12.2
 bs4==0.0.1
 requests==2.32.0
 lxml==4.9.1

--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -138,6 +138,7 @@ div p {
             <!-- <li><a href="/app/diff/" id="licensediffpage">License Diff</a></li> -->
             <li><a href="/app/xml_upload" id="license-xml-editor">License XML Editor</a></li>
             <li><a href="/app/ntia_checker/" id="checkerpage">NTIA Conformance Checker</a></li>
+            <li><a href="/app/dots" id="dots">Visual Editor</a></li>
             <li>
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="licenserequest">License requests
                 <span class="caret"></span>
@@ -181,13 +182,15 @@ div p {
     </div><!--/.nav-collapse -->
   </nav>
 
-    <div class="container body1">
+  {% block dots %}
+  <div class="container body1">
 
       <div class="starter-template">
         {% block body1 %}{% endblock %}
       </div>
 
     </div><!-- /.container -->
+    {% endblock %}
 		{% block body2 %}{% endblock %}
 
     <!-- Bootstrap core JavaScript

--- a/src/app/templates/app/dots.html
+++ b/src/app/templates/app/dots.html
@@ -1,0 +1,12 @@
+{% extends 'app/base.html' %} {% load static %} {% block dots %}
+<iframe
+  src="http://151.145.81.233"
+  style="width: 100%; min-height: -webkit-fill-available; position: fixed"
+></iframe>
+{% endblock %} {% block script_block %}
+<script type="text/javascript">
+  $(document).ready(function () {
+    $('#dots').addClass('linkactive')
+  })
+</script>
+{% endblock %}

--- a/src/app/templates/app/dots.html
+++ b/src/app/templates/app/dots.html
@@ -1,7 +1,8 @@
 {% extends 'app/base.html' %} {% load static %} {% block dots %}
 <iframe
-  src="http://151.145.81.233"
+  src="https://condots.duckdns.org"
   style="width: 100%; min-height: -webkit-fill-available; position: fixed"
+  sandbox="allow-scripts allow-same-origin allow-downloads"
 ></iframe>
 {% endblock %} {% block script_block %}
 <script type="text/javascript">

--- a/src/app/urls.py
+++ b/src/app/urls.py
@@ -39,6 +39,7 @@ urlpatterns = [
     path('profile/', views.profile, name='profile'),
     path('checkusername/', views.checkusername, name='check-username'),
     path('xml_upload/',views.xml_upload, name='xml-upload'),
+    path('dots/',views.dots, name='dots'),
     re_path(r'^edit/(?P<page_id>[0-9a-z]+)/$', views.license_xml_edit, name='editor'),
     re_path(r'^edit_license_xml/(?P<license_id>[0-9]+)/$', views.edit_license_xml, name='license_xml_editor'),
     path('edit_license_xml/', views.edit_license_xml, name='license_xml_editor_none'),

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -835,6 +835,16 @@ def xml_upload(request):
     else:
         return HttpResponseRedirect(settings.LOGIN_URL)
 
+def dots(request):
+    """ View for dots tool
+    returns dots.html
+    """
+    if request.user.is_authenticated or settings.ANONYMOUS_LOGIN_ENABLED:
+        return render(request, 'app/dots.html', {})
+    else:
+        return HttpResponseRedirect(settings.LOGIN_URL)
+
+
 def autocompleteModel(request):
     if 'term' in request.GET:
         result = LicenseNames.objects.filter(name__icontains=request.GET['term']).values_list('name',flat=True)


### PR DESCRIPTION
- Added a "Visual Editor" tab to the nav bar.
- Embedded "dots" in an iframe using https.
- Wrapped "block1" with a "dots" block so the iframe could stretch the entire height. If the "dots" block don's have any content then "block1" is rendered as usual, so it shouldn't affect existing templates. 