### PR TITLE
Support SPDX Spec version 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ pip-selfcheck.json
 .project
 .pydevproject
 .idea
+*.iml
 org.eclipse.core.resources.prefs
 .vscode
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ django-oauth-toolkit==1.5.0
 django-rest-framework-social-oauth2==1.1.0
 spdx-tools==0.8.2
 ntia-conformance-checker==1.1.0
--e git+https://github.com/spdx/spdx-license-matcher.git@v2.6#egg=spdx-license-matcher
+-e git+https://github.com/spdx/spdx-license-matcher.git@v2.7#egg=spdx-license-matcher

--- a/src/app/core.py
+++ b/src/app/core.py
@@ -29,9 +29,9 @@ def initialise_jpype():
     if not jpype.isJVMStarted():
         classpath = settings.JAR_ABSOLUTE_PATH
         jpype.startJVM(jpype.getDefaultJVMPath(), "-ea", "-Djava.class.path=%s"%classpath)
-            
     # Attach a thread to JVM and start processing
     jpype.attachThreadToJVM()
+    jpype.JPackage("org.spdx.library").SpdxModelFactory.init()
 
 
 def license_compare_helper(request):

--- a/src/app/templates/app/compare.html
+++ b/src/app/templates/app/compare.html
@@ -11,7 +11,7 @@
 <p class ="lead"> {{ medialink }}</p>
 <p class ="lead"> {{ error }}</p>
 <div class="panel panel-default">
-<div class="panel-heading"> <p class="lead">Compare SPDX RDF Documents</p> </div>
+<div class="panel-heading"> <p class="lead">Compare SPDX Spec Version 2 Documents</p> </div>
 <div class="panel-body">
 <form id="compareform" enctype="multipart/form-data" class="form-horizontal" method="post">
 		{% csrf_token %}

--- a/src/app/templates/app/convert.html
+++ b/src/app/templates/app/convert.html
@@ -19,26 +19,27 @@
 		&nbsp; From &nbsp;
 			 <select name="from_format" id="from_format">
 			 	  <option value="0" selected="">-</option>
-				  <option value="TAG">Tag/Value</option>
-				  <option value="RDFXML">RDF/XML</option>
-				  <option value="RDFTTL">RDF/TTL</option>
-				  <option value="XLSX">XLSX Spreadsheet</option>
-				  <option value="XLS">XLS Spreadsheet</option>
-				  <option value="JSON">JSON</option>
-				  <option value="XML">XML</option>
-				  <option value="YAML">YAML</option>
+				  <option value="TAG">V2 Tag/Value</option>
+				  <option value="RDFXML">V2 RDF/XML</option>
+				  <option value="RDFTTL">V2 RDF/TTL</option>
+				  <option value="XLSX">V2 XLSX Spreadsheet</option>
+				  <option value="XLS">V2 XLS Spreadsheet</option>
+				  <option value="JSON">V2 JSON</option>
+				  <option value="XML">V2 XML</option>
+				  <option value="YAML">V2 YAML</option>
 			</select>
 			&nbsp; To &nbsp;
 			<select name="to_format" id="to_format">
 			 	  <option value="0" data-value="INGORE" data-ext="" selected="">-</option>
-				  <option value="TAG" data-value="TAG" data-ext=".spdx">Tag/Value</option>
-				  <option value="RDFXML" data-value="RDFXML" data-ext=".rdf.xml">RDF/XML</option>
-				  <option value="RDFTTL" data-value="RDFTTL" data-ext=".rdf.ttl">RDF/TTL</option>
-				  <option value="XLSX" data-value="XLSX" data-ext=".xlsx">XLSX Spreadsheet</option>
-				  <option value="XLS" data-value="XLS" data-ext=".xls">XLS Spreadsheet</option>
-				  <option value="JSON" data-value="JSON" data-ext=".json">JSON</option>
-				  <option value="XML" data-value="XML" data-ext=".xml">XML</option>
-				  <option value="YAML" data-value="YAML" data-ext=".yaml">YAML</option>
+				  <option value="JSONLD" data-value="JSONLD" data-ext=".jsonld.json">V3 JSON-LD</option>
+				  <option value="TAG" data-value="TAG" data-ext=".spdx">V2 Tag/Value</option>
+				  <option value="RDFXML" data-value="RDFXML" data-ext=".rdf.xml">V2 RDF/XML</option>
+				  <option value="RDFTTL" data-value="RDFTTL" data-ext=".rdf.ttl">V2 RDF/TTL</option>
+				  <option value="XLSX" data-value="XLSX" data-ext=".xlsx">V2 XLSX Spreadsheet</option>
+				  <option value="XLS" data-value="XLS" data-ext=".xls">V2 XLS Spreadsheet</option>
+				  <option value="JSON" data-value="JSON" data-ext=".json">V2 JSON</option>
+				  <option value="XML" data-value="XML" data-ext=".xml">V2 XML</option>
+				  <option value="YAML" data-value="YAML" data-ext=".yaml">V2 YAML</option>
             </select>
     </div>
     <div id="drop-area" class="container">

--- a/src/app/templates/app/validate.html
+++ b/src/app/templates/app/validate.html
@@ -18,13 +18,14 @@
 			&nbsp; File Type &nbsp;
 				<select name="format" id="format">
 					  <option value="0" data-value="0" selected="">-</option>
-					  <option value="XLSX">XLSX Spreadsheet</option>
-					  <option value="XLS">XLS Spreadsheet</option>
-					  <option value="RDFXML">RDF/XML</option>
-					  <option value="TAG">Tag/Value</option>
-					  <option value="JSON">JSON</option>
-					  <option value="YAML">YAML</option>
-					  <option value="XML">XML</option>
+					  <option value="JSONLD">V3 JSON-LD</option>
+					  <option value="XLSX">V2 XLSX Spreadsheet</option>
+					  <option value="XLS">V2 XLS Spreadsheet</option>
+					  <option value="RDFXML">V2 RDF/XML</option>
+					  <option value="TAG">V2 Tag/Value</option>
+					  <option value="JSON">V2 JSON</option>
+					  <option value="YAML">V2 YAML</option>
+					  <option value="XML">V2 XML</option>
                 </select>	
 		</div>
 		<div id="drop-area" class="container">

--- a/src/app/utils.py
+++ b/src/app/utils.py
@@ -611,7 +611,7 @@ def formatToContentType(to_format):
         return "application/vnd.ms-excel"
     elif (to_format=="XLSX"):
         return "application/vnd.ms-excel"
-    elif (to_format=="JSON"):
+    elif (to_format=="JSON" or to_format=="JSONLD"):
         return "application/json"
     elif (to_format=="YAML"):
         return "text/yaml"

--- a/src/src/version.py
+++ b/src/src/version.py
@@ -20,13 +20,13 @@ def get_tools_version(jar_name):
     """
     jar_path = join(dirname(abspath(__file__)), '..', jar_name)
     output = run(['java', '-jar', jar_path, 'Version'], stdout=PIPE).stdout.decode('utf-8')
-    match = search('SPDX Tool Version: ([0-9]+(\.[0-9]+)+);', output)
+    match = search('SPDX Tool Version: ([^;]+);', output)
     if match:
         return match.group(1)
     return 'Unknown'
 
 
-spdx_online_tools_version = '1.2.3'
+spdx_online_tools_version = '1.3.0'
 
 """
 Visit https://github.com/spdx/tools-java/releases to know about the tools releases.


### PR DESCRIPTION
Changes include:
- Updating the SPDX Java Tools to version 2.0.0
- Changes to the API to the Java tools
- Add V3 JSON-LD as a supported file type in verify
- Add V3 JSON-LD as a supported output file type in convert
- Changed file type selections to prepend the spec version
- Updated the license matcher version to 2.7 (supports SPDX 3)