### PR TITLE
Add ntia-conformance-checker compliance selector to UI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ gunicorn==22.0.0
 selenium==3.14.1
 django-oauth-toolkit==1.5.0
 django-rest-framework-social-oauth2==1.1.0
-spdx-tools==0.8.2
+spdx-tools==0.8.3
 ntia-conformance-checker==3.0.2
 -e git+https://github.com/spdx/spdx-license-matcher.git@v2.7#egg=spdx-license-matcher

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ selenium==3.14.1
 django-oauth-toolkit==1.5.0
 django-rest-framework-social-oauth2==1.1.0
 spdx-tools==0.8.2
-ntia-conformance-checker==1.1.0
+ntia-conformance-checker==3.0.2
 -e git+https://github.com/spdx/spdx-license-matcher.git@v2.7#egg=spdx-license-matcher

--- a/src/app/core.py
+++ b/src/app/core.py
@@ -1,8 +1,5 @@
 """This file contains the core logic used in the SPDX Online Tools' APP and API"""
 
-import json
-
-from django.http.response import JsonResponse
 import jpype
 import os
 import sys
@@ -11,7 +8,7 @@ from django.utils.datastructures import MultiValueDictKeyError
 from django.core.files.storage import FileSystemStorage
 from django.conf import settings
 
-from json import dumps, loads
+from json import dumps
 from time import time
 from traceback import format_exc
 from urllib.parse import urljoin
@@ -56,7 +53,7 @@ def license_compare_helper(request):
             erroroccurred = False
             warningoccurred = False
             if (len(request.FILES.getlist("files")) < 2):
-                context_dict["error"] = "Please select atleast 2 files"
+                context_dict["error"] = "Please select at least 2 files"
                 result['status'] = 404
                 result['context'] = context_dict
                 return result
@@ -178,7 +175,7 @@ def license_compare_helper(request):
         """ If no files uploaded"""
         if (request.is_ajax()):
             filelist.append("Files not selected.")
-            errorlist.append("Please select atleast 2 files.")
+            errorlist.append("Please select at least 2 files.")
             ajaxdict["files"] = filelist
             ajaxdict["type"] = "error"
             ajaxdict["errors"] = errorlist
@@ -186,7 +183,7 @@ def license_compare_helper(request):
             result['status'] = 404
             result['response'] = response
             return result
-        context_dict["error"] = "Select atleast two files"
+        context_dict["error"] = "Select at least two files"
         context_dict["type"] = "error"
         result['status'] = 404
         result['context'] = context_dict
@@ -194,7 +191,7 @@ def license_compare_helper(request):
 
 def ntia_check_helper(request):
     """
-       A helper function to check the ntia elements in a given file in various formats.
+       A helper function to check the NTIA elements in a given file in various formats.
     """
     ajaxdict = dict()
     context_dict = {}
@@ -209,8 +206,10 @@ def ntia_check_helper(request):
                                    )
             filename = fs.save(utils.removeSpecialCharacters(myfile.name), myfile)
             uploaded_file_url = fs.url(filename).replace("%20", " ")
-            """ Call the python SBOM Checker """
-            schecker = SbomChecker(str(settings.APP_DIR + uploaded_file_url))
+            """ Get other request parameters """
+            compliance = request.POST.get("compliance", "ntia")  # Default: "ntia"
+            """ Call the Python SBOM Checker """
+            schecker = SbomChecker(str(settings.APP_DIR + uploaded_file_url), compliance=compliance)
             oldStdout = sys.stdout
             tempstdout = StringIO()
             sys.stdout = tempstdout

--- a/src/app/core.py
+++ b/src/app/core.py
@@ -207,9 +207,10 @@ def ntia_check_helper(request):
             filename = fs.save(utils.removeSpecialCharacters(myfile.name), myfile)
             uploaded_file_url = fs.url(filename).replace("%20", " ")
             """ Get other request parameters """
-            compliance = request.POST.get("compliance", "ntia")  # Default: "ntia"
+            # compliance = request.POST.get("compliance", "ntia")  # Default: "ntia"
             """ Call the Python SBOM Checker """
-            schecker = SbomChecker(str(settings.APP_DIR + uploaded_file_url), compliance=compliance)
+            schecker = SbomChecker(str(settings.APP_DIR + uploaded_file_url))
+            # schecker = SbomChecker(str(settings.APP_DIR + uploaded_file_url), compliance=compliance)  # Post-3.0.2
             oldStdout = sys.stdout
             tempstdout = StringIO()
             sys.stdout = tempstdout

--- a/src/app/templates/app/ntia_conformance_checker.html
+++ b/src/app/templates/app/ntia_conformance_checker.html
@@ -18,7 +18,6 @@
       &nbsp; File Type &nbsp;
       <select name="format" id="format">
         <option value="0" data-value="0" selected="">-</option>
-        <option value="XLSX">XLSX Spreadsheet</option>
         <option value="XLS">XLS Spreadsheet</option>
         <option value="RDFXML">RDF/XML</option>
         <option value="TAG">Tag/Value</option>

--- a/src/app/templates/app/ntia_conformance_checker.html
+++ b/src/app/templates/app/ntia_conformance_checker.html
@@ -21,7 +21,6 @@
         <option value="RDFXML">RDF/XML</option>
         <option value="TAG">Tag/Value</option>
         <option value="JSON">JSON</option>
-        <option value="YAML">YAML</option>
         <option value="XML">XML</option>
       </select>
     </div>

--- a/src/app/templates/app/ntia_conformance_checker.html
+++ b/src/app/templates/app/ntia_conformance_checker.html
@@ -8,36 +8,41 @@
 {% block body1 %}
 <div id="messages" class="messages">
 </div>
-<p class ="lead"> {{ error }}</p>
+<p class ="lead">{{ error }}</p>
 <div class="panel panel-default">
 <div class="panel-heading"> <p class="lead">Tag-Value, RDF, JSON, Spreadsheet, XML SPDX Document</p> </div>
 <div class="panel-body">
-	<form id="checkform" enctype="multipart/form-data" class="form-horizontal" method="post">
-	  {% csrf_token %}
-	  <div class = "form-group">
-			&nbsp; File Type &nbsp;
-				<select name="format" id="format">
-					  <option value="0" data-value="0" selected="">-</option>
-					  <option value="XLSX">XLSX Spreadsheet</option>
-					  <option value="XLS">XLS Spreadsheet</option>
-					  <option value="RDFXML">RDF/XML</option>
-					  <option value="TAG">Tag/Value</option>
-					  <option value="JSON">JSON</option>
-					  <option value="YAML">YAML</option>
-					  <option value="XML">XML</option>
-                </select>
-		</div>
-		<div id="drop-area" class="container">
-		  <h4>Upload file using the button or by dragging and dropping onto the dashed region </h4>
-		  <input type="file" id="file" onchange="handleFiles(this.files)">
-		  <label class="button" for="file">Select file</label>
-		  <p class="file-name">No file selected</p>
-		</div>
-    </form>
+  <form id="checkform" enctype="multipart/form-data" class="form-horizontal" method="post">
+    {% csrf_token %}
+    <div class = "form-group">
+      &nbsp; File Type &nbsp;
+      <select name="format" id="format">
+        <option value="0" data-value="0" selected="">-</option>
+        <option value="XLSX">XLSX Spreadsheet</option>
+        <option value="XLS">XLS Spreadsheet</option>
+        <option value="RDFXML">RDF/XML</option>
+        <option value="TAG">Tag/Value</option>
+        <option value="JSON">JSON</option>
+        <option value="YAML">YAML</option>
+        <option value="XML">XML</option>
+      </select>
+    </div>
+    <div class = "form-group">
+      &nbsp; Compliance &nbsp;
+      <select name="compliance" id="compliance">
+        <option value="ntia" selected="">NTIA Minimum Elements</option>
+      </select>
+    </div>
+    <div id="drop-area" class="container">
+      <h4>Upload file using the button or by dragging and dropping onto the dashed region </h4>
+      <input type="file" id="file" onchange="handleFiles(this.files)">
+      <label class="button" for="file">Select file</label>
+      <p class="file-name">No file selected</p>
+    </div>
+  </form>
 <hr>
-    <button id="checkbutton" name="checkbutton" class="btn btn-md btn-info" type="submit" disabled="true">Check NTIA's Required Elements</button>
+  <button id="checkbutton" name="checkbutton" class="btn btn-md btn-info" type="submit" disabled="true">Check Required Elements</button>
   {% include "app/modal.html" %}
-
 </div>
 
 {% endblock %}
@@ -45,7 +50,7 @@
 {% block script_block %}
 
 <script type="text/javascript">
-  /* Javascript to handel drag and drop */
+  /* JavaScript to handle drag and drop */
   let dropArea = document.getElementById('drop-area');
   var selected_file = "";
   ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
@@ -85,7 +90,7 @@
     ([...files]).forEach(checkFile)
   }
 
-  function checkFile(file){
+  function checkFile(file) {
     if(file){
       $(".file-name").html("<b>Selected File: </b>"+file.name);
       $("#checkbutton").prop('disabled', false);

--- a/src/app/templates/app/ntia_conformance_checker.html
+++ b/src/app/templates/app/ntia_conformance_checker.html
@@ -18,7 +18,6 @@
       &nbsp; File Type &nbsp;
       <select name="format" id="format">
         <option value="0" data-value="0" selected="">-</option>
-        <option value="XLS">XLS Spreadsheet</option>
         <option value="RDFXML">RDF/XML</option>
         <option value="TAG">Tag/Value</option>
         <option value="JSON">JSON</option>


### PR DESCRIPTION
Changes to ntia-conformance-checker related code, to prepare it for [more compliance checkers](https://github.com/spdx/ntia-conformance-checker/pull/224) in the future.

These changes are effectively only in the UI side for now and there's nothing change on the backend side apart from the upgrade of the library.

- Update ntia-conformance-checker version to 3.0.2
- Add compliance selector to UI
  - There's only one option now, which is the selected default "ntia"
- Add a (commented) code to get compliance request value
  - If the value is not exist, use "ntia" as default
  - This value will be used post-3.0.2 to let SbomChecker knows which compliance it should check against
- Remove unused imports
- Fix few typos