### PR TITLE
Descriptive title + Centred filename in drag&drop

### DIFF
--- a/src/app/templates/app/convert.html
+++ b/src/app/templates/app/convert.html
@@ -16,8 +16,8 @@
 <form id="convertform" enctype="multipart/form-data" class = "form-horizontal" method = "post" >
 		{% csrf_token %}
 		<div class = "form-group">
-		&nbsp; From &nbsp;
-			 <select name="from_format" id="from_format">
+      From &nbsp;
+			<select name="from_format" id="from_format">
 			 	  <option value="0" selected="">-</option>
 				  <option value="TAG">V2 Tag/Value</option>
 				  <option value="RDFXML">V2 RDF/XML</option>
@@ -40,13 +40,13 @@
 				  <option value="JSON" data-value="JSON" data-ext=".json">V2 JSON</option>
 				  <option value="XML" data-value="XML" data-ext=".xml">V2 XML</option>
 				  <option value="YAML" data-value="YAML" data-ext=".yaml">V2 YAML</option>
-            </select>
+      </select>
     </div>
     <div id="drop-area" class="container">
       <h4 id="doclabel">Upload SPDX Document using the button or by dragging and dropping onto the dashed region</h4>
       <input type="file" id="file" onchange="handleFiles(this.files)">
       <label class="button" for="file">Select file</label>
-      <p class="file-name">No file selected</p>
+      <div class="file-name">No file selected</div>
     </div>
     <!--
     <div class = "form-group">

--- a/src/app/templates/app/ntia_conformance_checker.html
+++ b/src/app/templates/app/ntia_conformance_checker.html
@@ -10,31 +10,33 @@
 </div>
 <p class ="lead">{{ error }}</p>
 <div class="panel panel-default">
-<div class="panel-heading"> <p class="lead">Tag-Value, RDF, JSON, Spreadsheet, XML SPDX Document</p> </div>
+<div class="panel-heading">
+  <p class="lead">Check required elements</p>
+</div>
 <div class="panel-body">
   <form id="checkform" enctype="multipart/form-data" class="form-horizontal" method="post">
     {% csrf_token %}
     <div class = "form-group">
-      &nbsp; File Type &nbsp;
+      File Type &nbsp;
       <select name="format" id="format">
         <option value="0" data-value="0" selected="">-</option>
-        <option value="RDFXML">RDF/XML</option>
-        <option value="TAG">Tag/Value</option>
-        <option value="JSON">JSON</option>
-        <option value="XML">XML</option>
+        <option value="JSON">V2 JSON</option>
+        <option value="RDFXML">V2 RDF/XML</option>
+        <option value="TAG">V2 Tag/Value</option>
+        <option value="XML">V2 XML Spreadsheet</option>
       </select>
     </div>
     <div class = "form-group">
-      &nbsp; Compliance &nbsp;
+      Compliance &nbsp;
       <select name="compliance" id="compliance">
         <option value="ntia" selected="">NTIA Minimum Elements</option>
       </select>
     </div>
     <div id="drop-area" class="container">
-      <h4>Upload file using the button or by dragging and dropping onto the dashed region </h4>
+      <h4>Upload SPDX Document using the button or by dragging and dropping onto the dashed region</h4>
       <input type="file" id="file" onchange="handleFiles(this.files)">
       <label class="button" for="file">Select file</label>
-      <p class="file-name">No file selected</p>
+      <div class="file-name">No file selected</div>
     </div>
   </form>
 <hr>

--- a/src/app/templates/app/validate.html
+++ b/src/app/templates/app/validate.html
@@ -10,12 +10,14 @@
 </div>
 <p class ="lead"> {{ error }}</p>
 <div class="panel panel-default">
-<div class="panel-heading"> <p class="lead">Tag-Value, RDF, JSON, Spreadsheet, XML SPDX Document</p> </div>
+<div class="panel-heading">
+  <p class="lead">Validate SPDX Document</p>
+</div>
 <div class="panel-body">
 	<form id="validateform" enctype="multipart/form-data" class="form-horizontal" method="post">
 	  {% csrf_token %}
 	  <div class = "form-group">
-			&nbsp; File Type &nbsp;
+			File Type &nbsp;
 				<select name="format" id="format">
 					  <option value="0" data-value="0" selected="">-</option>
 					  <option value="JSONLD">V3 JSON-LD</option>
@@ -26,13 +28,13 @@
 					  <option value="JSON">V2 JSON</option>
 					  <option value="YAML">V2 YAML</option>
 					  <option value="XML">V2 XML</option>
-                </select>	
+        </select>
 		</div>
 		<div id="drop-area" class="container">
-		  <h4>Upload file using the button or by dragging and dropping onto the dashed region</h4>
+		  <h4>Upload SPDX Document using the button or by dragging and dropping onto the dashed region</h4>
 		  <input type="file" id="file" onchange="handleFiles(this.files)">
 		  <label class="button" for="file">Select file</label>
-		  <p class="file-name">No file selected</p>
+		  <div class="file-name">No file selected</div>
 		</div> 
     </form>
 <hr>

--- a/src/app/templates/app/xml_upload.html
+++ b/src/app/templates/app/xml_upload.html
@@ -11,9 +11,11 @@
 <p class ="lead"> {{ error }} </p>
 
 <div class="panel panel-default">
-  <div class="panel-heading"> <p class="lead">Upload the XML File</p> </div>
+  <div class="panel-heading">
+    <p class="lead">License XML Editor</p>
+  </div>
     <div class="panel-body">
-  
+
       <ul class="nav nav-tabs">
         <li class="active"><a data-toggle="tab" href="#text">XML Text</a></li>
         <li><a data-toggle="tab" href="#upload">Upload File</a></li>


### PR DESCRIPTION
- Use `<div>` (instead of `<p>`) for filename display in drag & drop area, so the text will be centred like other HTML elements in the same pane
- Update heading to match the tool title (see current Compare tool for an example)
- Put "V2" into File Type selections, for NTIA Conformance tool

--

**NTIA Conformance tool:** the heading is not descriptive and the filename ("No file selected") is off to the left

![Screenshot 2024-12-29 at 14 51 47](https://github.com/user-attachments/assets/6651f49e-57f8-4667-986e-360885159b9c)

**Compare tool:** the heading is descriptive and the filename is centred

![Screenshot 2024-12-29 at 14 51 38](https://github.com/user-attachments/assets/02fa2ae8-94a9-489a-83b2-8687909b70a5)
