### PR TITLE
Update generateXml.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,20 @@
-Django==3.2.25
-jpype1==1.3.0
-numpy==1.22.4
-djangorestframework==3.12.2
+Django>=4.2,<4.3
+jpype1==1.4.0
+numpy>=1.25.0
+djangorestframework>=3.14.0
 bs4==0.0.1
 requests==2.32.3
-lxml==4.9.4
-webdriver-manager==3.4.2
-social-auth-core==4.1.0
-social-auth-app-django==4.0.0
-python-dotenv==0.17.1
+lxml>=5.3.0
+webdriver-manager>=3.8.6
+social-auth-core>=4.3,<5.0
+social-auth-app-django>=5.0,<6.0
+python-dotenv>=1.0.0
 gevent==23.9.1
-gunicorn==22.0.0
+gunicorn==23.0.0
 #for testing
-selenium==3.14.1
-django-oauth-toolkit==1.5.0
-django-rest-framework-social-oauth2==1.1.0
+selenium>=4.10.0
+django-oauth-toolkit>=2.0.0
+django-rest-framework-social-oauth2>=1.1.0
 spdx-tools==0.8.3
-ntia-conformance-checker==3.0.2
+ntia-conformance-checker==3.1.0
 -e git+https://github.com/spdx/spdx-license-matcher.git@v2.7#egg=spdx-license-matcher

--- a/src/app/core.py
+++ b/src/app/core.py
@@ -106,7 +106,7 @@ def license_compare_helper(request):
                     compareclass.onlineFunction(callfunc)
                 except Exception as ex:
                     """Error raised by onlineFunction"""
-                    if (request.is_ajax()):
+                    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                         ajaxdict["type"] = "warning2"
                         ajaxdict["files"] = filelist
                         ajaxdict["errors"] = errorlist
@@ -122,7 +122,7 @@ def license_compare_helper(request):
                     return result
                 if (warningoccurred==False):
                     """If no warning raised """
-                    if (request.is_ajax()):
+                    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                         ajaxdict["medialink"] = settings.MEDIA_URL + folder + "/"+ rfilename
                         response = dumps(ajaxdict)
                         result['response'] = response
@@ -134,7 +134,7 @@ def license_compare_helper(request):
                     result['context'] = context_dict
                     return result
                 else :
-                    if (request.is_ajax()):
+                    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                         ajaxdict["type"] = "warning"
                         ajaxdict["files"] = filelist
                         ajaxdict["errors"] = errorlist
@@ -151,7 +151,7 @@ def license_compare_helper(request):
                     result['context'] = context_dict
                     return result
             else :
-                if (request.is_ajax()):
+                if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     ajaxdict["files"] = filelist
                     ajaxdict["type"] = "error"
                     ajaxdict["errors"] = errorlist
@@ -173,7 +173,7 @@ def license_compare_helper(request):
 
     except MultiValueDictKeyError:
         """ If no files uploaded"""
-        if (request.is_ajax()):
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             filelist.append("Files not selected.")
             errorlist.append("Please select at least 2 files.")
             ajaxdict["files"] = filelist
@@ -220,7 +220,7 @@ def ntia_check_helper(request):
             retval = tempstdout.getvalue().replace(",",", ").replace("\n","<br/>")
             if not retval.startswith("No components with missing information."):
                 """ If any warnings are returned """
-                if (request.is_ajax()):
+                if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     ajaxdict["type"] = "warning"
                     warnings = str(retval)
                     ajaxdict["data"] = "The following warning(s) were raised:<br />\n" + warnings.replace('\n', '<br />\n')
@@ -232,7 +232,7 @@ def ntia_check_helper(request):
                 result['context'] = context_dict
                 result['status'] = 400
                 return result
-            if (request.is_ajax()):
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                 """ Valid SPDX Document """
                 ajaxdict["data"] = "This SPDX Document is valid:\n" + retval
                 response = dumps(ajaxdict)
@@ -245,7 +245,7 @@ def ntia_check_helper(request):
             return result
         else:
             """ If no file uploaded."""
-            if (request.is_ajax()):
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                 ajaxdict = dict()
                 ajaxdict["type"] = "error"
                 ajaxdict["data"] = "No file uploaded"
@@ -259,7 +259,7 @@ def ntia_check_helper(request):
             return result
     except jpype.JException as ex:
         """ Error raised by check_anything.check_minimum_elements without exiting the application"""
-        if (request.is_ajax()):
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             ajaxdict = dict()
             ajaxdict["type"] = "error"
             ajaxdict["data"] = jpype.JException.message(ex)
@@ -273,7 +273,7 @@ def ntia_check_helper(request):
         return result
     except MultiValueDictKeyError:
         """ If no files selected"""
-        if (request.is_ajax()):
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             ajaxdict = dict()
             ajaxdict["type"] = "error"
             ajaxdict["data"] = "No files selected."
@@ -287,7 +287,7 @@ def ntia_check_helper(request):
         return result
     except Exception as ex:
         """ Other error raised """
-        if (request.is_ajax()):
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             ajaxdict = dict()
             ajaxdict["type"] = "error"
             ajaxdict["data"] = format_exc()
@@ -327,7 +327,7 @@ def license_validate_helper(request):
             retval = verifyclass.verify(str(settings.APP_DIR+uploaded_file_url), fileformat)
             if (len(retval) > 0):
                 """ If any warnings are returned """
-                if (request.is_ajax()):
+                if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     ajaxdict["type"] = "warning"
                     warnings = str(retval)
                     ajaxdict["data"] = "The following warning(s) were raised:<br />\n" + warnings.replace('\n', '<br />\n')
@@ -339,7 +339,7 @@ def license_validate_helper(request):
                 result['context'] = context_dict
                 result['status'] = 400
                 return result
-            if (request.is_ajax()):
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                 """ Valid SPDX Document """
                 ajaxdict["data"] = "This SPDX Document is valid."
                 response = dumps(ajaxdict)
@@ -352,7 +352,7 @@ def license_validate_helper(request):
             return result
         else :
             """ If no file uploaded."""
-            if (request.is_ajax()):
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                 ajaxdict=dict()
                 ajaxdict["type"] = "error"
                 ajaxdict["data"] = "No file uploaded"
@@ -366,7 +366,7 @@ def license_validate_helper(request):
             return result
     except jpype.JException as ex :
         """ Error raised by verifyclass.verify without exiting the application"""
-        if (request.is_ajax()):
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             ajaxdict=dict()
             ajaxdict["type"] = "error"
             ajaxdict["data"] = jpype.JException.message(ex)
@@ -380,7 +380,7 @@ def license_validate_helper(request):
         return result
     except MultiValueDictKeyError:
         """ If no files selected"""
-        if (request.is_ajax()):
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             ajaxdict=dict()
             ajaxdict["type"] = "error"
             ajaxdict["data"] = "No files selected."
@@ -394,7 +394,7 @@ def license_validate_helper(request):
         return result
     except Exception as ex:
         """ Other error raised """
-        if (request.is_ajax()):
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             ajaxdict=dict()
             ajaxdict["type"] = "error"
             ajaxdict["data"] = format_exc()
@@ -419,7 +419,7 @@ def license_check_helper(request):
     try:
         matchingId, matchingType, _ = utils.check_spdx_license(licensetext)
         if not matchingId:
-            if (request.is_ajax()):
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                 ajaxdict = dict()
                 ajaxdict["data"] = "There are no matching SPDX listed licenses"
                 response = dumps(ajaxdict)
@@ -435,7 +435,7 @@ def license_check_helper(request):
             if isinstance(matchingId, list):
                 matchingId = ",".join(matchingId)
             matching_str += matchingId
-            if request.is_ajax():
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                 ajaxdict = dict()
                 ajaxdict["data"] = matching_str
                 response = dumps(ajaxdict)
@@ -448,7 +448,7 @@ def license_check_helper(request):
             return result
     except jpype.JException as ex :
         """ Java exception raised without exiting the application """
-        if request.is_ajax():
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             ajaxdict = dict()
             ajaxdict["data"] = jpype.JException.message(ex)
             response = dumps(ajaxdict)
@@ -461,7 +461,7 @@ def license_check_helper(request):
         return result
     except Exception as ex:
         """ Other exception raised """
-        if request.is_ajax():
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             ajaxdict = dict()
             ajaxdict["data"] = format_exc()
             response = dumps(ajaxdict)
@@ -508,7 +508,7 @@ def license_convert_helper(request):
             warnings = verifyclass.verify(str(settings.MEDIA_ROOT+"/"+folder+"/"+"/"+convertfile), toFileFormat)
             if (len(warnings) == 0) :
                 """ If no warnings raised """
-                if (request.is_ajax()):
+                if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     ajaxdict["medialink"] = settings.MEDIA_URL + folder + "/"+ convertfile
                     response = dumps(ajaxdict)
                     result['response'] = response
@@ -520,7 +520,7 @@ def license_convert_helper(request):
                 result['status'] = 200
                 return result
             else :
-                if (request.is_ajax()):
+                if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     ajaxdict["type"] = "warning"
                     warnings = str(warnings)
                     ajaxdict["data"] = "The following warning(s) were raised by "+ myfile.name + ":<br />\n" + warnings.replace('\n', '<br />\n')
@@ -545,7 +545,7 @@ def license_convert_helper(request):
             return result
     except jpype.JException as ex :
         """ Java exception raised without exiting the application"""
-        if (request.is_ajax()):
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             ajaxdict["type"] = "error"
             ajaxdict["data"] = jpype.JException.message(ex)
             response = dumps(ajaxdict)
@@ -559,7 +559,7 @@ def license_convert_helper(request):
         return result
     except MultiValueDictKeyError:
         """ If no files uploaded"""
-        if (request.is_ajax()):
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             ajaxdict["type"] = "error"
             ajaxdict["data"] = "No files selected."
             response = dumps(ajaxdict)
@@ -573,7 +573,7 @@ def license_convert_helper(request):
         return result
     except Exception as ex:
         """ Other error raised """
-        if (request.is_ajax()):
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             ajaxdict["type"] = "error"
             ajaxdict["data"] = format_exc()
             response = dumps(ajaxdict)
@@ -615,7 +615,7 @@ def license_diff_helper(request):
             return data
     except jpype.JException as ex :
         """ Java exception raised without exiting the application """
-        if (request.is_ajax()):
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             ajaxdict=dict()
             ajaxdict["data"] = jpype.JException.message(ex)
             response = dumps(ajaxdict)
@@ -628,7 +628,7 @@ def license_diff_helper(request):
         return data
     except Exception as ex:
         """ Other exception raised """
-        if (request.is_ajax()):
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             ajaxdict = dict()
             ajaxdict["data"] = format_exc()
             response = dumps(ajaxdict)

--- a/src/app/generateXml.py
+++ b/src/app/generateXml.py
@@ -1,6 +1,6 @@
-import math
 import re
 import xml.etree.ElementTree as ET
+from xml.dom import minidom
 from itertools import chain, tee
 
 entityMap = {
@@ -23,7 +23,7 @@ def previous_and_current(some_iterable):
 
 def escapeXmlData(string):
     for initial,final in list(entityMap.items()):
-        string.replace(initial, final)
+        string = string.replace(initial, final) # assign changed string back
     return string
 
 
@@ -45,8 +45,9 @@ def wrapBullets(string, item):
     numberBullet = re.search(numberBullets, string)
     symbolBullet = re.search(symbolBullets, string)
     bullet = letterBullet or numberBullet or symbolBullet    
-    ET.SubElement(item, "bullet").text = bullet.group(2)
-    string = string.replace(bullet.group(2), '').strip()
+    if bullet: # Bullet must exist
+        ET.SubElement(item, "bullet").text = bullet.group(2)
+        string = string.replace(bullet.group(2), '').strip()
     return string
 
 
@@ -61,7 +62,7 @@ def groupLines(lines):
             if not matches:
                 depth = 0
             else:
-                depth = int(math.floor(len(matches)/4))
+                depth = len(matches) // 4 # no need to use math.floor()
             tagType = 'item'
             lis.append({'data':line, 'depth':depth, 'tagType':tagType})
         else:
@@ -154,4 +155,16 @@ def generateLicenseXml(licenseOsi, licenseIdentifier, licenseName, listVersionAd
     textElement = getTextElement(points)
     license.append(textElement)
     xmlString = ET.tostring(root, method='xml', encoding='unicode')
+    
+    # Format the XML string with indentation for better readability
+    xmlString = minidom.parseString(xmlString).toprettyxml(indent="  ")
+    
+    # Remove extra blank lines added by `toprettyxml()`, ensuring clean output
+    clean_lines = []
+    for line in xmlString.splitlines():
+        if line.strip():  # Only keep non-empty lines
+            clean_lines.append(line)
+
+    xmlString = "\n".join(clean_lines)
+
     return xmlString

--- a/src/app/tests.py
+++ b/src/app/tests.py
@@ -14,6 +14,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.firefox.options import Options
+from selenium.webdriver.firefox.service import Service
 from webdriver_manager.firefox import GeckoDriverManager
 import time
 import datetime
@@ -648,7 +649,8 @@ class LicenseXMLEditorTestCase(StaticLiveServerTestCase):
     def setUp(self):
         options = Options()
         options.add_argument('-headless')
-        self.selenium = webdriver.Firefox(executable_path=GeckoDriverManager().install(), firefox_options=options)
+        service = Service(GeckoDriverManager().install())
+        self.selenium = webdriver.Firefox(service=service, options=options)
         self.initialXML = '<?xml version="1.0" encoding="UTF-8"?><SPDXLicenseCollection xmlns="http://www.spdx.org/license"><license></license></SPDXLicenseCollection>'
         self.invalidXML = '<?xml version="1.0" encoding="UTF-8"?><SPDXLicenseCollection xmlns="http://www.spdx.org/license"><license></license>'
         super(LicenseXMLEditorTestCase, self).setUp()
@@ -1080,7 +1082,8 @@ class ArchiveLicenseRequestsViewsTestCase(StaticLiveServerTestCase):
     def setUp(self):
         options = Options()
         options.add_argument('-headless')
-        self.selenium = webdriver.Firefox(executable_path=GeckoDriverManager().install(), firefox_options=options)
+        service = Service(GeckoDriverManager().install())
+        self.selenium = webdriver.Firefox(service=service, options=options)
         super(ArchiveLicenseRequestsViewsTestCase, self).setUp()
 
     def tearDown(self):
@@ -1273,7 +1276,8 @@ class PromoteLicenseNamespaceViewsTestCase(StaticLiveServerTestCase):
     def setUp(self):
         options = Options()
         options.add_argument('-headless')
-        self.selenium = webdriver.Firefox(executable_path=GeckoDriverManager().install(), firefox_options=options)
+        service = Service(GeckoDriverManager().install())
+        self.selenium = webdriver.Firefox(service=service, options=options)
         #login
         TEST_LOGIN_INFO = {
         "provider": "github",
@@ -1349,7 +1353,8 @@ class ArchiveLicenseNamespaceViewsTestCase(StaticLiveServerTestCase):
     def setUp(self):
         options = Options()
         options.add_argument('-headless')
-        self.selenium = webdriver.Firefox(executable_path=GeckoDriverManager().install(), firefox_options=options)
+        service = Service(GeckoDriverManager().install())
+        self.selenium = webdriver.Firefox(service=service, options=options)
         super(ArchiveLicenseNamespaceViewsTestCase, self).setUp()
 
     def tearDown(self):

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -90,7 +90,7 @@ def submitNewLicense(request):
     githubIssueId = ""
     if request.method=="POST":
         if not request.user.is_authenticated:
-            if (request.is_ajax()):
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                 ajaxdict["type"] = "auth_error"
                 ajaxdict["data"] = "Please login using GitHub to use this feature."
                 response = dumps(ajaxdict)
@@ -104,7 +104,7 @@ def submitNewLicense(request):
                 token = github_login.extra_data["access_token"]
                 username = github_login.extra_data["login"]
                 form = LicenseRequestForm(request.POST, auto_id='%s')
-                if form.is_valid() and request.is_ajax():
+                if form.is_valid() and request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     licenseAuthorName = form.cleaned_data['licenseAuthorName']
                     licenseName = form.cleaned_data['fullname']
                     licenseIdentifier = form.cleaned_data['shortIdentifier']
@@ -186,7 +186,7 @@ def submitNewLicense(request):
                     return JsonResponse(data)
             except UserSocialAuth.DoesNotExist:
                 """ User not authenticated with GitHub """
-                if (request.is_ajax()):
+                if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     ajaxdict["type"] = "auth_error"
                     ajaxdict["data"] = "Please login using GitHub to use this feature."
                     response = dumps(ajaxdict)
@@ -195,7 +195,7 @@ def submitNewLicense(request):
         except:
             """ Other errors raised """
             logger.error(str(format_exc()))
-            if (request.is_ajax()):
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                 ajaxdict["type"] = "error"
                 ajaxdict["data"] = "Unexpected error, please email the SPDX technical workgroup that the following error has occurred: " + format_exc()
                 response = dumps(ajaxdict)
@@ -228,7 +228,7 @@ def submitNewLicenseNamespace(request):
     ajaxdict = {}
     if request.method=="POST":
         if not request.user.is_authenticated:
-            if (request.is_ajax()):
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                 ajaxdict["type"] = "auth_error"
                 ajaxdict["data"] = "Please login using GitHub to use this feature."
                 response = dumps(ajaxdict)
@@ -242,7 +242,7 @@ def submitNewLicenseNamespace(request):
                 token = github_login.extra_data["access_token"]
                 username = github_login.extra_data["login"]
                 form = LicenseNamespaceRequestForm(request.POST, auto_id='%s')
-                if form.is_valid() and request.is_ajax():
+                if form.is_valid() and request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     statusCode = None
                     licenseAuthorName = form.cleaned_data['licenseAuthorName']
                     fullname = form.cleaned_data['fullname']
@@ -266,7 +266,7 @@ def submitNewLicenseNamespace(request):
                         listVersionAdded, url, licenseHeader, licenseNotes, licenseText)
                     licenseExists = utils.licenseExists(namespace, shortIdentifier, token)
                     if licenseExists["exists"]:
-                        if (request.is_ajax()):
+                        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                             ajaxdict["type"] = "license_exists"
                             ajaxdict["title"] = "License exists"
                             ajaxdict["data"] = """License already exists on the SPDX license list.\n
@@ -300,7 +300,7 @@ def submitNewLicenseNamespace(request):
                     return JsonResponse(data)
             except UserSocialAuth.DoesNotExist:
                 """ User not authenticated with GitHub """
-                if (request.is_ajax()):
+                if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     ajaxdict["type"] = "auth_error"
                     ajaxdict["data"] = "Please login using GitHub to use this feature."
                     response = dumps(ajaxdict)
@@ -309,7 +309,7 @@ def submitNewLicenseNamespace(request):
         except:
             """ Other errors raised """
             logger.error(str(format_exc()))
-            if (request.is_ajax()):
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                 ajaxdict["type"] = "error"
                 ajaxdict["data"] = "Unexpected error, please email the SPDX technical workgroup that the following error has occurred: " + format_exc()
                 response = dumps(ajaxdict)
@@ -537,14 +537,14 @@ def validate_xml(request):
                     try:
                         xmlschema.assertValid(xml_input)
                         """ If the xml is valid """
-                        if (request.is_ajax()):
+                        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                             ajaxdict["type"] = "valid"
                             ajaxdict["data"] = "This XML is valid against SPDX License Schema."
                             response = dumps(ajaxdict)
                             return HttpResponse(response,status=200)
                         return HttpResponse("This XML is valid against SPDX License Schema.",status=200)
                     except Exception as e:
-                        if (request.is_ajax()):
+                        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                             ajaxdict["type"] = "invalid"
                             ajaxdict["data"] = "This XML is not valid against SPDX License Schema.\n"+str(e)
                             response = dumps(ajaxdict)
@@ -552,7 +552,7 @@ def validate_xml(request):
                         return HttpResponse("This XML is not valid against SPDX License Schema.\n"+str(e),status=200)
                 else :
                     """ If no xml text is given."""
-                    if (request.is_ajax()):
+                    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                         ajaxdict["type"] = "error"
                         ajaxdict["data"] = "No XML text given."
                         response = dumps(ajaxdict)
@@ -560,7 +560,7 @@ def validate_xml(request):
                     return HttpResponse("No XML text given.", status=400)
             except etree.XMLSyntaxError as e:
                 """ XML not valid """
-                if (request.is_ajax()):
+                if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     ajaxdict["type"] = "error"
                     ajaxdict["data"] = "XML Parsing Error.\n The XML is not valid. Please correct the XML text and try again."
                     response = dumps(ajaxdict)
@@ -569,7 +569,7 @@ def validate_xml(request):
             except :
                 """ Other error raised """
                 logger.error(str(format_exc()))
-                if (request.is_ajax()):
+                if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     ajaxdict["type"] = "error"
                     ajaxdict["data"] = "Unexpected error, please email the SPDX technical workgroup that the following error has occurred: " + format_exc()
                     response = dumps(ajaxdict)
@@ -696,7 +696,7 @@ def xml_upload(request):
                     if len(request.POST["xmltext"])>0 :
                         page_id = request.POST['page_id']
                         request.session[page_id] = [request.POST["xmltext"], ""]
-                        if(request.is_ajax()):
+                        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                             ajaxdict["redirect_url"] = '/app/edit/'+page_id+'/'
                             response = dumps(ajaxdict)
                             return HttpResponse(response, status=200)
@@ -704,7 +704,7 @@ def xml_upload(request):
                             'app/editor.html',context_dict,status=200
                             )
                     else:
-                        if (request.is_ajax()):
+                        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                             ajaxdict["type"] = "error"
                             ajaxdict["data"] = "No license XML text provided. Please input some license XML text to edit."
                             response = dumps(ajaxdict)
@@ -718,7 +718,7 @@ def xml_upload(request):
                     """ If license name is provided by the user """
                     name = request.POST["licenseName"]
                     if len(name) <= 0:
-                        if (request.is_ajax()):
+                        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                             ajaxdict["type"] = "error"
                             ajaxdict["data"] = "No license name given. Please provide a SPDX license or exception name to edit."
                             response = dumps(ajaxdict)
@@ -730,7 +730,7 @@ def xml_upload(request):
 
                     url = utils.check_license_name(name)
                     if url[0] is False:
-                        if (request.is_ajax()):
+                        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                             ajaxdict["type"] = "error"
                             ajaxdict["data"] = "License or Exception name does not exist. Please provide a valid SPDX license or exception name to edit."
                             response = dumps(ajaxdict)
@@ -744,7 +744,7 @@ def xml_upload(request):
                     if(response.status_code == 200):
                         page_id = request.POST['page_id']
                         request.session[page_id] = [response.text, url[1]]
-                        if (request.is_ajax()):
+                        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                             ajaxdict["redirect_url"] = '/app/edit/'+page_id+'/'
                             response = dumps(ajaxdict)
                             return HttpResponse(response, status=200)
@@ -752,7 +752,7 @@ def xml_upload(request):
                                 'app/editor.html',context_dict,status=200
                                 )
                     else:
-                        if (request.is_ajax()):
+                        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                             ajaxdict["type"] = "error"
                             ajaxdict["data"] = "The application could not be connected. Please try again."
                             response = dumps(ajaxdict)
@@ -768,7 +768,7 @@ def xml_upload(request):
                         """ Saving XML file to the media directory """
                         xml_file = request.FILES['file']
                         if not xml_file.name.endswith(".xml"):
-                            if (request.is_ajax()):
+                            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                                 ajaxdict["type"] = "error"
                                 ajaxdict["data"] = "Please select a SPDX license XML file."
                                 response = dumps(ajaxdict)
@@ -785,7 +785,7 @@ def xml_upload(request):
                         page_id = request.POST['page_id']
                         with open(str(fs.location+'/'+filename), 'rt', encoding='utf-8' ) as f:
                             request.session[page_id] = [f.read(), ""]
-                        if (request.is_ajax()):
+                        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                             ajaxdict["redirect_url"] = '/app/edit/'+page_id+'/'
                             response = dumps(ajaxdict)
                             return HttpResponse(response, status=200)
@@ -794,7 +794,7 @@ def xml_upload(request):
                             )
                     else :
                         """ If no file is uploaded """
-                        if (request.is_ajax()):
+                        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                             ajaxdict["type"] = "error"
                             ajaxdict["data"] = "No file uploaded. Please upload a SPDX license XML file to edit."
                             response = dumps(ajaxdict)
@@ -820,7 +820,7 @@ def xml_upload(request):
                     return HttpResponse(response, status=400)
             except:
                 logger.error(str(format_exc()))
-                if (request.is_ajax()):
+                if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     ajaxdict["type"] = "error"
                     ajaxdict["data"] = "Unexpected error, please email the SPDX technical workgroup that the following error has occurred: " + format_exc()
                     response = dumps(ajaxdict)
@@ -925,7 +925,7 @@ def archiveRequests(request, license_id=None):
             context_dict['authorized'] = "True"
     else:
         github_login = None
-    if request.method == "POST" and request.is_ajax():
+    if request.method == "POST" and request.headers.get('x-requested-with') == 'XMLHttpRequest':
         if not request.user.is_authenticated:
             ajaxdict = {}
             ajaxdict["type"] = "auth_error"
@@ -955,7 +955,7 @@ def archiveNamespaceRequests(request, license_id=None):
     """ View for archive namespace license requests
     returns archive_namespace_requests.html template
     """
-    if request.method == "POST" and request.is_ajax():
+    if request.method == "POST" and request.headers.get('x-requested-with') == 'XMLHttpRequest':
         archive = request.POST.get('archive', False)
         license_id = request.POST.get('license_id', False)
         if license_id:
@@ -971,7 +971,7 @@ def promoteNamespaceRequests(request, license_id=None):
     """ View for promote namespace license requests
     returns promote_namespace_requests.html template
     """
-    if request.method == "POST" and request.is_ajax():
+    if request.method == "POST" and request.headers.get('x-requested-with') == 'XMLHttpRequest':
         promoted = request.POST.get('promoted', False)
         license_id = request.POST.get('license_id', False)
         if license_id:
@@ -1034,7 +1034,7 @@ def licenseRequests(request, license_id=None):
             context_dict['authorized'] = "True"
     else:
         github_login = None
-    if request.method == "POST" and request.is_ajax():
+    if request.method == "POST" and request.headers.get('x-requested-with') == 'XMLHttpRequest':
         if not request.user.is_authenticated:
             ajaxdict = {}
             ajaxdict["type"] = "auth_error"
@@ -1066,7 +1066,7 @@ def licenseNamespaceRequests(request, license_id=None):
     github_login = None
     if request.user.is_authenticated:
         github_login = request.user.social_auth.get(provider='github')
-    if request.method == "POST" and request.is_ajax():
+    if request.method == "POST" and request.headers.get('x-requested-with') == 'XMLHttpRequest':
         archive = request.POST.get('archive', True)
         license_id = request.POST.get('license_id', False)
         if license_id:
@@ -1081,7 +1081,7 @@ def licenseNamespaceRequests(request, license_id=None):
 
 def update_session_variables(request):
     """ View for updating the XML text in the session variable """
-    if request.method == "POST" and request.is_ajax():
+    if request.method == "POST" and request.headers.get('x-requested-with') == 'XMLHttpRequest':
         page_id = request.POST["page_id"]
         request.session[page_id] = [request.POST["xml_text"], request.POST["license_name"]]
         ajaxdict={}
@@ -1114,7 +1114,7 @@ def beautify(request):
                 if commandRun == 0:
                     data = codecs.open("test.xml", 'r', encoding='utf-8').read()
                     os.remove('test.xml')
-                    if (request.is_ajax()):
+                    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                         ajaxdict["type"] = "success"
                         ajaxdict["data"] = data
                         response = dumps(ajaxdict)
@@ -1128,7 +1128,7 @@ def beautify(request):
                     return HttpResponse(response,status=500)
             else:
                 """ Error while getting xml """
-                if (request.is_ajax()):
+                if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     ajaxdict["type"] = "xml_error"
                     ajaxdict["data"] = "Error getting the xml"
                     response = dumps(ajaxdict)
@@ -1137,7 +1137,7 @@ def beautify(request):
         except:
             """ Other errors raised """
             logger.error(str(format_exc()))
-            if (request.is_ajax()):
+            if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                 ajaxdict["type"] = "error"
                 ajaxdict["data"] = "Unexpected error, please email the SPDX technical workgroup that the following error has occurred: " + format_exc()
                 response = dumps(ajaxdict)
@@ -1194,7 +1194,7 @@ def issue(request):
                     return JsonResponse(data)
                 except UserSocialAuth.DoesNotExist:
                     """ User not authenticated with GitHub """
-                    if (request.is_ajax()):
+                    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                         ajaxdict["type"] = "auth_error"
                         ajaxdict["data"] = "Please login using GitHub to use this feature."
                         response = dumps(ajaxdict)
@@ -1203,7 +1203,7 @@ def issue(request):
             except:
                 """ Other errors raised """
                 logger.error(str(format_exc()))
-                if (request.is_ajax()):
+                if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     ajaxdict["type"] = "error"
                     ajaxdict["data"] = "Unexpected error, please email the SPDX technical workgroup that the following error has occurred: " + format_exc()
                     response = dumps(ajaxdict)
@@ -1247,7 +1247,7 @@ def handle_pull_request(request, is_ns):
                     )
                     if response["type"] == "success":
                         """PR made successfully"""
-                        if request.is_ajax():
+                        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                             ajaxdict["type"] = "success"
                             ajaxdict["data"] = response["pr_url"]
                             response = dumps(ajaxdict)
@@ -1255,7 +1255,7 @@ def handle_pull_request(request, is_ns):
                         return HttpResponse(response["pr_url"], status=200)
                     else:
                         """Error while making PR"""
-                        if request.is_ajax():
+                        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                             ajaxdict["type"] = "pr_error"
                             ajaxdict["data"] = response["message"]
                             response = dumps(ajaxdict)
@@ -1263,7 +1263,7 @@ def handle_pull_request(request, is_ns):
                         return HttpResponse(response["message"], status=500)
                 except UserSocialAuth.DoesNotExist:
                     """User not authenticated with GitHub"""
-                    if request.is_ajax():
+                    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                         ajaxdict["type"] = "auth_error"
                         ajaxdict["data"] = "Please login using GitHub to use this feature."
                         response = dumps(ajaxdict)
@@ -1272,7 +1272,7 @@ def handle_pull_request(request, is_ns):
             except:
                 """Other errors raised"""
                 logger.error(str(format_exc()))
-                if request.is_ajax():
+                if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     ajaxdict["type"] = "error"
                     ajaxdict["data"] = (
                         "Unexpected error, please email the SPDX technical workgroup that the following error has occurred: "
@@ -1314,7 +1314,7 @@ def loginuser(request):
                 #add status  choice here
                 if user.is_active:
                     login(request, user)
-                    if (request.is_ajax()):
+                    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                         ajaxdict=dict()
                         ajaxdict["data"] = "Success"
                         ajaxdict["next"] = "/app/"
@@ -1322,14 +1322,14 @@ def loginuser(request):
                         return HttpResponse(response)
                     return HttpResponseRedirect(settings.LOGIN_REDIRECT_URL)
                 else:
-                    if (request.is_ajax()):
+                    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                         return HttpResponse("Your account is disabled.",status=401)
                     context_dict["invalid"] = "Your account is disabled."
                     return render(request,
                         "app/login.html",context_dict,status=401
                         )
             else:
-                if (request.is_ajax()):
+                if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     return HttpResponse("Invalid login details supplied.",status=403)
                 context_dict['invalid']="Invalid login details supplied."
                 return render(request,

--- a/src/app/widgets.py
+++ b/src/app/widgets.py
@@ -2,7 +2,7 @@ from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.forms import widgets
 from django.conf import settings
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 class RelatedFieldWidgetCanAdd(widgets.Select):
 

--- a/src/src/settings.py
+++ b/src/src/settings.py
@@ -234,7 +234,7 @@ JAR_ABSOLUTE_PATH = os.path.join(BASE_DIR, "tool.jar")
 # URL Path Variables
 
 LOGIN_REDIRECT_URL = "/app/"
-REGISTER_REDIRECT_UTL = "/app/login/"
+REGISTER_REDIRECT_URL = "/app/login/"
 LOGIN_URL = "/app/login/"
 HOME_URL="/app/"
 
@@ -248,8 +248,11 @@ DRFSO2_URL_NAMESPACE = 'github_social'
 # Online tool usage without login
 ANONYMOUS_LOGIN_ENABLED = True
 
-# Password reset link expiration limit (in days)
-PASSWORD_RESET_TIMEOUT_DAYS = 3
+# This is deprecated in Django 4.2.x
+# PASSWORD_RESET_TIMEOUT_DAYS = 3
+
+# Password reset link expiration limit (in seconds)
+PASSWORD_RESET_TIMEOUT = 259200  # 3 days in seconds
 
 # this will output emails in the console.
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
- Ensure `escapeXmlData` correctly assigns transformed string back.
- Format XML output with `toprettyxml(indent="  ")` for readability.
- Remove extra blank lines from the formatted XML output for clean structure.
- Add a check in `wrapBullets`.
- Simplify `groupLines` by replacing `math.floor()` with integer division.