### PR TITLE
Fixed Visual Editor narrow window issue in Firefox

### DIFF
--- a/src/app/templates/app/dots.html
+++ b/src/app/templates/app/dots.html
@@ -1,11 +1,16 @@
-{% extends 'app/base.html' %} {% load static %} {% block dots %}
+{% extends 'app/base.html' %} 
+{% load static %} 
+
+{% block dots %}
 <iframe
   src="https://condots.duckdns.org"
-  style="width: 100%; min-height: -webkit-fill-available; position: fixed"
+  style="width: 100%; height: calc(100vh - 50px); min-height: calc(100vh - 50px); margin-top: 50px; position: absolute; top: 0; left: 0;"
   sandbox="allow-scripts allow-same-origin allow-downloads allow-popups allow-presentation"
   allow="clipboard-write"
 ></iframe>
-{% endblock %} {% block script_block %}
+{% endblock %} 
+
+{% block script_block %}
 <script type="text/javascript">
   $(document).ready(function () {
     $('#dots').addClass('linkactive')


### PR DESCRIPTION
Updated inline CSS in `dots.html` to fix layout issues.

Fixes #551

Tested on: Firefox 135 (Fedora Workstation 41)