### PR TITLE
Fix mismatch in error object structure in postscreenshot.js (function…

### DIFF
--- a/src/app/static/js/editor/postscreenshot.js
+++ b/src/app/static/js/editor/postscreenshot.js
@@ -54,12 +54,15 @@ async function postToGithub(data) {
             $("#modal-header").removeClass("green-modal");
             try {
             var obj = JSON.parse(e.responseText);
-            if (obj.type=="error"){
+            // The server sets: data["type"] = "error"
+            if (obj.data && obj.data.type=="error"){
                 $("#modal-header").removeClass("yellow-modal");
                 $("#modal-header").addClass("red-modal");
                 $("#modal-title").html("Error!");
             }
-            $("#modal-body").text(obj.data);
+
+            // Show the server's error message in the modal
+            $("#modal-body").text(obj.message);
             $(".modal-footer").html('<button id="ok"><span class="glyphicon glyphicon-ok"></span> Ok</button>');
             $("#ok").on("click",function(){
                 $("#myModal").modal("hide");
@@ -67,6 +70,7 @@ async function postToGithub(data) {
             })
             }
             catch (e){
+                // If we cannot parse e.responseText or something else fails
                 $("#modal-header").removeClass("yellow-modal");
                 $("#modal-header").addClass("red-modal");
                 $("#modal-title").html("Error!");


### PR DESCRIPTION
### Brief Explanation of Changes

1. Correctly matched the JSON structure returned by the Django view. The server returns the error type in `obj.data.type` and the message in `obj.message`.
2. Updated the `error:` callback in `postscreenshot.js` to check `if (obj.data && obj.data.type === "error")` and display `obj.message`, ensuring the modal shows the actual error text instead of `[object Object]`.