### PR TITLE
Shift the content down if the navbar gets taller to avoid the content being hidden

### DIFF
--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -182,7 +182,6 @@ div p {
     </div><!--/.nav-collapse -->
   </nav>
 
-  {% block dots %}
   <div class="container body1">
 
       <div class="starter-template">
@@ -190,7 +189,6 @@ div p {
       </div>
 
     </div><!-- /.container -->
-    {% endblock %}
 		{% block body2 %}{% endblock %}
 
     <!-- Bootstrap core JavaScript
@@ -199,6 +197,25 @@ div p {
     <script src="{% static 'js/jquery.min.js' %}"></script>
     <script src="{% static 'js/bootstrap.min.js' %}"></script>
     <script src="{% static 'js/warning.js' %}"></script>
+    <script type="text/javascript">
+      // Shift content down if the navbar gets taller,
+      // so the navbar doesn't cover the content.
+      $(function() {
+        function adjustContentPadding() {
+          var navHeight = $('.navbar-fixed-top').height();
+          var newPadding = navHeight + 10; // Add 10px for extra space
+          $('body').css('padding-top', newPadding + 'px');
+          var $dotsIframe = $('#dots-iframe');
+          if ($dotsIframe.length) {
+            $dotsIframe.css('height', 'calc(100vh - ' + newPadding + 'px)');
+            $dotsIframe.css('min-height', 'calc(100vh - ' + newPadding + 'px)');
+            $dotsIframe.css('margin-top', newPadding + 'px');
+          }
+        }
+        // Adjust on load and resize
+        $(window).on("load resize", adjustContentPadding);
+      });
+    </script>
     {% block script_block %}{% endblock %}
   </body>
 </html>

--- a/src/app/templates/app/dots.html
+++ b/src/app/templates/app/dots.html
@@ -1,7 +1,7 @@
 {% extends 'app/base.html' %} 
 {% load static %} 
 
-{% block dots %}
+{% block body1 %}
 <iframe
   src="https://condots.duckdns.org"
   style="width: 100%; height: calc(100vh - 50px); min-height: calc(100vh - 50px); margin-top: 50px; position: absolute; top: 0; left: 0;"


### PR DESCRIPTION
When the screen gets narrower, the navbar will get taller to accommodate all menu items. Currently, this makes the navbar being displayed over the content at the top part of the page, making the content unreadable.

- This PR fixes that by shifting down the content if the navbar gets taller.
- Also fix inconsistent block name, the mini app should be inside blocks name "body1" and "body2", and the base template shouldn't make a reference to mini app names.

### Before fix

<img width="1041" height="308" alt="Screenshot 2568-09-15 at 21 22 28" src="https://github.com/user-attachments/assets/e7eeace5-40d2-4a6d-8c1a-9db9adc2e467" />

### After fix

<img width="1027" height="389" alt="Screenshot 2568-09-15 at 21 22 04" src="https://github.com/user-attachments/assets/62d1c226-fc50-4ccb-85cb-18972ef7c611" />
