### PR TITLE
Fix navbar obstructs Visual Editor buttons

### DIFF
--- a/src/app/templates/app/dots.html
+++ b/src/app/templates/app/dots.html
@@ -3,6 +3,7 @@
 
 {% block body1 %}
 <iframe
+  id="dots-iframe"
   src="https://condots.duckdns.org"
   style="width: 100%; height: calc(100vh - 50px); min-height: calc(100vh - 50px); margin-top: 50px; position: absolute; top: 0; left: 0;"
   sandbox="allow-scripts allow-same-origin allow-downloads allow-popups allow-presentation"


### PR DESCRIPTION
The navbar is currently obstruct the visual editor, like this:

<img width="951" height="322" alt="Screenshot 2568-10-25 at 18 13 42" src="https://github.com/user-attachments/assets/49bfa3b4-bfd3-4ff7-944a-40cc5f9d00d1" />

The PR will shift it down, so edit buttons will be usable, like this:

<img width="944" height="297" alt="Screenshot 2568-10-25 at 18 13 19" src="https://github.com/user-attachments/assets/db774c63-8aa8-445a-8bab-8a9639097147" />

The JavaScript code to shift down the iframe is already in base.html (line 209).
We just need an id for the iframe, so it can be referenced by the JavaScript code.

https://github.com/spdx/spdx-online-tools/blob/49bd52e8308c6de9a3851f6e2bcd432f35b2fb15/src/app/templates/app/base.html#L209-L214

A follow up of #578

