### PR TITLE
Report License Matcher and Python Model versions

### DIFF
--- a/src/app/templates/app/about.html
+++ b/src/app/templates/app/about.html
@@ -69,15 +69,14 @@
         <a href="https://github.com/spdx/tools-python">SPDX Python Tools</a>:
         <span style="color:#0097c4;">{{ python_tools_version }}</span>
       </li>
-<!-- Ommited for now, since SPDX License Matcher wrongly reports version as '0.0.1' -->
-<!-- Remove comment once this PR resolved: -->
-<!-- https://github.com/spdx/spdx-license-matcher/pull/30 -->
-<!-- 
+      <li>
+        <a href="https://github.com/spdx/spdx-python-model">SPDX Python Model</a>:
+        <span style="color:#0097c4;">{{ spdx_python_model_version }}</span>
+      </li>
       <li>
         <a href=https://github.com/spdx/spdx-license-matcher>SPDX License Matcher</a>:
         <span style="color:#0097c4;">{{ spdx_license_matcher_version }}</span>
       </li>
--->
       <li>
         <a href="https://github.com/spdx/ntia-conformance-checker">NTIA Conformance Checker</a>:
         <span style="color:#0097c4;">{{ ntia_conformance_checker_version }}</span>

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -20,6 +20,7 @@ from src.version import (
     spdx_license_list_version,
     spdx_license_matcher_version,
     spdx_online_tools_version,
+    spdx_python_model_version,
 )
 
 import codecs
@@ -36,7 +37,6 @@ from urllib.parse import urljoin
 import datetime
 import uuid
 from wsgiref.util import FileWrapper
-import os
 import subprocess
 
 from social_django.models import UserSocialAuth
@@ -80,6 +80,7 @@ def about(request):
         "spdx_license_list_version": spdx_license_list_version,
         "spdx_license_matcher_version": spdx_license_matcher_version,
         "spdx_online_tools_version": spdx_online_tools_version,
+        "spdx_python_model_version": spdx_python_model_version,
     }
     return render(request, "app/about.html", context_dict)
 

--- a/src/src/version.py
+++ b/src/src/version.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2020-2025 SPDX Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """
@@ -5,16 +6,17 @@ Version file for displaying the respective version of
 the tools and online-tools repositories.
 """
 
+import json
 from importlib.metadata import version
 from os.path import abspath, dirname, exists, join
-from subprocess import run, PIPE
 from re import search
-import json
+from subprocess import PIPE, run
+from typing import Any, Dict, cast
 
 from .settings import LICENSE_ROOT
 
 
-def get_tools_version(jar_name):
+def get_tools_version(jar_name: str) -> str:
     """Returns SPDX Java Tools version.
 
     Visit https://github.com/spdx/tools-java/releases to know about the tools releases.
@@ -35,7 +37,7 @@ def get_tools_version(jar_name):
     return "Unknown"
 
 
-def get_spdx_license_list_version():
+def get_spdx_license_list_version() -> str:
     """
     Determine license list version from a local copy of licenses.json if available.
 
@@ -52,15 +54,18 @@ def get_spdx_license_list_version():
             with open(p, "r", encoding="utf-8") as fh:
                 data = json.load(fh)
             if isinstance(data, dict) and "licenseListVersion" in data:
-                return data["licenseListVersion"]
+                data_dict = cast(Dict[str, Any], data)
+                return data_dict.get("licenseListVersion", "Unknown")
         except (OSError, json.JSONDecodeError, UnicodeDecodeError):
             continue
     return "Unknown"
 
-spdx_online_tools_version = "1.3.3" # Update this when releasing new version
+
+spdx_online_tools_version = "1.3.3"  # Update this when releasing new version
 
 java_tools_version = get_tools_version("tool.jar")
 ntia_conformance_checker_version = version("ntia-conformance-checker")
 python_tools_version = version("spdx-tools")
 spdx_license_list_version = get_spdx_license_list_version()
 spdx_license_matcher_version = version("spdx-license-matcher")
+spdx_python_model_version = version("spdx-python-model")


### PR DESCRIPTION
Report versions of these packages in the About page, to assist debugging and also make awareness to the packages:

- SPDX License Matcher
  - was omitted, put back after https://github.com/spdx/spdx-license-matcher/pull/30 got merged and has new release (2.8) https://github.com/spdx/spdx-license-matcher/releases/tag/v2.8
- SPDX Python Model

Also remove unused `os` import in src/app/views.py