### PR TITLE
Move media cleanup scheduling out of the web app container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
 # Keep the Docker build context small;
 # exclude files not needed to build the image.
 
+# crontab is for the host's cron configuration, not needed in the image
+crontab
+
 # ========================
 # 1. Python artifacts
 # ========================

--- a/README-PRODUCTION.md
+++ b/README-PRODUCTION.md
@@ -46,9 +46,9 @@ This runtime environment is configured to host a Django web application using Gu
 - Install host cron entry from this repository file (on EC2 host, not in container):
   - `crontab crontab`
 - Verify it is installed:
-  - `crontab -l | grep spdx_cleanup`
+  - `crontab -l | grep cleanup_media`
 - Check recent cleanup logs:
-  - `journalctl -t spdx_cleanup --since "1 day ago"`
+  - `tail -n 50 container_logs/deletedFiles.log`
 
 ## Updating the image
 

--- a/README-PRODUCTION.md
+++ b/README-PRODUCTION.md
@@ -41,6 +41,15 @@ This runtime environment is configured to host a Django web application using Gu
 - Customization of Supervisor or Gunicorn configurations can be done by modifying the respective configuration files (`supervisor_api.conf` for Supervisor and Gunicorn configuration files).
 - Adjustments to Django settings or additional dependencies should be appropriately managed within the Django application.
 
+## Daily media cleanup schedule
+
+- Install host cron entry from this repository file (on EC2 host, not in container):
+  - `crontab crontab`
+- Verify it is installed:
+  - `crontab -l | grep spdx_cleanup`
+- Check recent cleanup logs:
+  - `journalctl -t spdx_cleanup --since "1 day ago"`
+
 ## Updating the image
 
 Following are the steps for updating the images:
@@ -62,6 +71,7 @@ Following are the steps for updating the images:
     replacing the region and account ID
   - Push the images by running `docker-compose -f docker-compose.prod.yml push`
   - Launch the containers with the command `docker-compose -f docker-compose.prod.yml up -d`
+  - Ensure host cron is installed (see "Daily media cleanup schedule").
 
 ## Clean Initial Install
 
@@ -126,6 +136,7 @@ Following are the steps for a clean initial installation of the application:
     ```
 
 - Launch the containers with the command `docker-compose -f docker-compose.prod.yml up -d`
+  - Ensure host cron is installed (see "Daily media cleanup schedule").
 
 ## Credits
 

--- a/crontab
+++ b/crontab
@@ -4,4 +4,5 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Every day at 15:30 UTC, finds the container by docker-compose
 # service label ("spdx"), and runs the media cleanup job.
-30 15 * * * c=$(docker ps -qf "label=com.docker.compose.service=spdx" | head -n 1) && [ -n "$c" ] && docker exec "$c" /usr/local/bin/python /spdx/src/manage.py cleanup_media
+# If no such container is running, logs a warning to the same log file used by the cleanup script.
+30 15 * * * c=$(docker ps -qf "label=com.docker.compose.service=spdx" | head -n 1) && [ -n "$c" ] && docker exec "$c" /usr/local/bin/python /spdx/src/manage.py cleanup_media || { d=$(docker inspect -f '{{index .Config.Labels "com.docker.compose.project.working_dir"}}' $(docker ps -aqf "label=com.docker.compose.service=spdx" | head -n 1) 2>/dev/null); echo "$(date -u +'\%Y-\%m-\%d \%H:\%M:\%S,000') - app.cleanup - WARNING - cleanup_media: no running container" >> "$d/container_logs/deletedFiles.log"; }

--- a/crontab
+++ b/crontab
@@ -1,2 +1,6 @@
-# Run the cleanup script every day at 3:30 pm
-30 15 * * * python /spdx/app/scripts/cleanup.py
+# Host cron template (install on the EC2 host, not inside Docker).
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Run the Django media cleanup job every day at 15:30 UTC.
+30 15 * * * sh -c 'if docker ps --format "{{.Names}}" | grep -qx spdx_prod; then docker exec spdx_prod /usr/local/bin/python /spdx/src/manage.py cleanup_media; else echo "spdx_cleanup skipped: container spdx_prod is not running"; fi' 2>&1 | logger -t spdx_cleanup

--- a/crontab
+++ b/crontab
@@ -3,4 +3,4 @@ SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Run the Django media cleanup job every day at 15:30 UTC.
-30 15 * * * sh -c 'if docker ps --format "{{.Names}}" | grep -qx spdx_prod; then docker exec spdx_prod /usr/local/bin/python /spdx/src/manage.py cleanup_media; else echo "spdx_cleanup skipped: container spdx_prod is not running"; fi' 2>&1 | logger -t spdx_cleanup
+30 15 * * * docker exec spdx_prod /usr/local/bin/python /spdx/src/manage.py cleanup_media

--- a/crontab
+++ b/crontab
@@ -2,5 +2,6 @@
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-# Run the Django media cleanup job every day at 15:30 UTC.
-30 15 * * * docker exec spdx_prod /usr/local/bin/python /spdx/src/manage.py cleanup_media
+# Every day at 15:30 UTC, finds the container by docker-compose
+# service label ("spdx"), and runs the media cleanup job.
+30 15 * * * c=$(docker ps -qf "label=com.docker.compose.service=spdx" | head -n 1) && [ -n "$c" ] && docker exec "$c" /usr/local/bin/python /spdx/src/manage.py cleanup_media

--- a/src/app/management/__init__.py
+++ b/src/app/management/__init__.py
@@ -1,0 +1,1 @@
+# Django management package for the app.

--- a/src/app/management/__init__.py
+++ b/src/app/management/__init__.py
@@ -1,1 +1,4 @@
-# Django management package for the app.
+# SPDX-FileCopyrightText: 2026-present SPDX contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Django management package for the app."""

--- a/src/app/management/commands/__init__.py
+++ b/src/app/management/commands/__init__.py
@@ -1,0 +1,1 @@
+# Django management commands package for the app.

--- a/src/app/management/commands/__init__.py
+++ b/src/app/management/commands/__init__.py
@@ -1,1 +1,4 @@
-# Django management commands package for the app.
+# SPDX-FileCopyrightText: 2026-present SPDX contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Django management commands package for the app."""

--- a/src/app/management/commands/cleanup_media.py
+++ b/src/app/management/commands/cleanup_media.py
@@ -1,5 +1,4 @@
 import argparse
-from datetime import datetime, timezone
 
 from django.core.management.base import BaseCommand
 
@@ -25,17 +24,4 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        started_at = datetime.now(tz=timezone.utc).isoformat()
-        self.stdout.write(f"Cleanup started at {started_at}")
-
-        deleted_files = clean_media(days_threshold=options["days_threshold"])
-        for file_info in deleted_files:
-            self.stdout.write(
-                f"Deleted file: {file_info['name']} (modified at {file_info['modified_at']})"
-            )
-
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"Cleanup completed; deleted {len(deleted_files)} file(s)."
-            )
-        )
+        clean_media(days_threshold=options["days_threshold"])

--- a/src/app/management/commands/cleanup_media.py
+++ b/src/app/management/commands/cleanup_media.py
@@ -29,4 +29,5 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        clean_media(days_threshold=options["days_threshold"])
+        deleted = clean_media(days_threshold=options["days_threshold"])
+        self.stdout.write(f"Deleted {len(deleted)} file(s).")

--- a/src/app/management/commands/cleanup_media.py
+++ b/src/app/management/commands/cleanup_media.py
@@ -3,7 +3,7 @@
 
 """Django management command for cleaning up old media files."""
 
-import argparse
+from argparse import ArgumentTypeError
 
 from django.core.management.base import BaseCommand
 
@@ -13,7 +13,7 @@ from app.scripts.cleanup import clean_media
 def _non_negative_int(value):
     parsed = int(value)
     if parsed < 0:
-        raise argparse.ArgumentTypeError("days-threshold must be non-negative")
+        raise ArgumentTypeError("days-threshold must be non-negative")
     return parsed
 
 

--- a/src/app/management/commands/cleanup_media.py
+++ b/src/app/management/commands/cleanup_media.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2026-present SPDX contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Django management command for cleaning up old media files."""
+
 import argparse
 
 from django.core.management.base import BaseCommand

--- a/src/app/management/commands/cleanup_media.py
+++ b/src/app/management/commands/cleanup_media.py
@@ -1,0 +1,41 @@
+import argparse
+from datetime import datetime, timezone
+
+from django.core.management.base import BaseCommand
+
+from app.scripts.cleanup import clean_media
+
+
+def _non_negative_int(value):
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("days-threshold must be non-negative")
+    return parsed
+
+
+class Command(BaseCommand):
+    help = "Delete AnonymousUser media files older than the retention threshold."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--days-threshold",
+            type=_non_negative_int,
+            default=10,
+            help="Delete files older than this many days.",
+        )
+
+    def handle(self, *args, **options):
+        started_at = datetime.now(tz=timezone.utc).isoformat()
+        self.stdout.write(f"Cleanup started at {started_at}")
+
+        deleted_files = clean_media(days_threshold=options["days_threshold"])
+        for file_info in deleted_files:
+            self.stdout.write(
+                f"Deleted file: {file_info['name']} (modified at {file_info['modified_at']})"
+            )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Cleanup completed; deleted {len(deleted_files)} file(s)."
+            )
+        )

--- a/src/app/scripts/__init__.py
+++ b/src/app/scripts/__init__.py
@@ -1,1 +1,4 @@
-# Django scripts package for the app.
+# SPDX-FileCopyrightText: 2017-present SPDX contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Django scripts package for the app."""

--- a/src/app/scripts/__init__.py
+++ b/src/app/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Django scripts package for the app.

--- a/src/app/scripts/cleanup.py
+++ b/src/app/scripts/cleanup.py
@@ -6,7 +6,7 @@ Cleanup script for removing old files from the media directory.
 """
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from time import time
 
@@ -14,7 +14,7 @@ from django.conf import settings
 
 ANONYMOUS_MEDIA_SUBDIR = "AnonymousUser"
 DEFAULT_DAYS_THRESHOLD = 10
-SECONDS_PER_DAY = int(timedelta(days=1).total_seconds())
+SECONDS_PER_DAY = 86400  # 1 day
 logger = logging.getLogger("app.cleanup")
 logger.setLevel(logging.INFO)
 

--- a/src/app/scripts/cleanup.py
+++ b/src/app/scripts/cleanup.py
@@ -1,3 +1,10 @@
+# SPDX-FileCopyrightText: 2017-present SPDX contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Cleanup script for removing old files from the media directory.
+"""
+
 import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -8,26 +15,28 @@ from django.conf import settings
 ANONYMOUS_MEDIA_SUBDIR = "AnonymousUser"
 DEFAULT_DAYS_THRESHOLD = 10
 SECONDS_PER_DAY = int(timedelta(days=1).total_seconds())
-LOG_FILE = Path(settings.PROJECT_ROOT) / "container_logs" / "deletedFiles.log"
-LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
-
-
 logger = logging.getLogger("app.cleanup")
 logger.setLevel(logging.INFO)
 
-if not any(
-    isinstance(handler, logging.FileHandler) and Path(handler.baseFilename) == LOG_FILE
-    for handler in logger.handlers
-):
-    handler = logging.FileHandler(LOG_FILE)
-    handler.setLevel(logging.INFO)
-    handler.setFormatter(
-        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-    )
-    logger.addHandler(handler)
+
+def _setup_logger():
+    log_file = Path(settings.PROJECT_ROOT) / "container_logs" / "deletedFiles.log"
+    
+    if not any(
+        isinstance(handler, logging.FileHandler) and Path(handler.baseFilename) == log_file
+        for handler in logger.handlers
+    ):
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        handler = logging.FileHandler(log_file)
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+        )
+        logger.addHandler(handler)
 
 
 def clean_media(days_threshold=DEFAULT_DAYS_THRESHOLD, media_root=None):
+    _setup_logger()
     if days_threshold < 0:
         raise ValueError("days_threshold must be non-negative")
 

--- a/src/app/scripts/cleanup.py
+++ b/src/app/scripts/cleanup.py
@@ -1,32 +1,40 @@
-import os
-import time
-import datetime
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from time import time
+
 from django.conf import settings
-import logging
 
-logger = logging.getLogger('my_logger')
-logger.setLevel(logging.INFO)
-handler = logging.FileHandler(os.path.join(os.getcwd(), "deletedFiles.log"))
-handler.setLevel(logging.INFO)
+ANONYMOUS_MEDIA_SUBDIR = "AnonymousUser"
+DEFAULT_DAYS_THRESHOLD = 10
+SECONDS_PER_DAY = int(timedelta(days=1).total_seconds())
 
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-handler.setFormatter(formatter)
 
-logger.addHandler(handler)
+def clean_media(days_threshold=DEFAULT_DAYS_THRESHOLD, media_root=None):
+    if days_threshold < 0:
+        raise ValueError("days_threshold must be non-negative")
 
-def cleanMedia():
-    MEDIA_DIR = os.path.join(settings.MEDIA_ROOT, "AnonymousUser")
-    DAYS_THRESHOLD = 10
+    media_dir = Path(media_root or settings.MEDIA_ROOT) / ANONYMOUS_MEDIA_SUBDIR
+    deleted_files = []
+    now = time()
+    cutoff_seconds = days_threshold * SECONDS_PER_DAY
 
-    now = time.time()
+    if not media_dir.is_dir():
+        return deleted_files
 
-    # log the time of the cron job
-    logger.info('Cron job ran at %s', now)
+    for filepath in sorted(media_dir.iterdir()):
+        if not filepath.is_file():
+            continue
 
-    for filename in os.listdir(MEDIA_DIR):
-        filepath = os.path.join(MEDIA_DIR, filename)
-        if os.path.isfile(filepath) and (now - os.stat(filepath).st_mtime) > (DAYS_THRESHOLD * 86400):
-            # log the file being deleted and the date of the file
-            file_date = datetime.datetime.fromtimestamp(os.path.getmtime(filepath))
-            logger.info('Deleting file %s with date %s', filename, file_date)
-            os.remove(filepath)
+        modified_at = filepath.stat().st_mtime
+        if (now - modified_at) <= cutoff_seconds:
+            continue
+
+        filepath.unlink()
+        deleted_files.append(
+            {
+                "name": filepath.name,
+                "modified_at": datetime.fromtimestamp(modified_at, tz=timezone.utc).isoformat(),
+            }
+        )
+
+    return deleted_files

--- a/src/app/scripts/cleanup.py
+++ b/src/app/scripts/cleanup.py
@@ -21,9 +21,10 @@ logger.setLevel(logging.INFO)
 
 def _setup_logger():
     log_file = Path(settings.PROJECT_ROOT) / "container_logs" / "deletedFiles.log"
-    
+
     if not any(
-        isinstance(handler, logging.FileHandler) and Path(handler.baseFilename) == log_file
+        isinstance(handler, logging.FileHandler)
+        and Path(handler.baseFilename).resolve() == log_file.resolve()
         for handler in logger.handlers
     ):
         log_file.parent.mkdir(parents=True, exist_ok=True)
@@ -44,7 +45,10 @@ def clean_media(days_threshold=DEFAULT_DAYS_THRESHOLD, media_root=None):
     deleted_files = []
     now = time()
     cutoff_seconds = days_threshold * SECONDS_PER_DAY
-    logger.info("Cleanup job started at %s", datetime.fromtimestamp(now, tz=timezone.utc).isoformat())
+    logger.info(
+        "Cleanup job started at %s",
+        datetime.fromtimestamp(now, tz=timezone.utc).isoformat(),
+    )
 
     if not media_dir.is_dir():
         logger.info("Cleanup skipped because directory does not exist: %s", media_dir)
@@ -58,12 +62,22 @@ def clean_media(days_threshold=DEFAULT_DAYS_THRESHOLD, media_root=None):
         if (now - modified_at) <= cutoff_seconds:
             continue
 
-        filepath.unlink()
-        logger.info("Deleting file %s with date %s", filepath.name, datetime.fromtimestamp(modified_at, tz=timezone.utc).isoformat())
+        try:
+            filepath.unlink()
+        except OSError:
+            logger.exception("Failed to delete %s", filepath.name)
+            continue
+        logger.info(
+            "Deleted file %s with modified date %s",
+            filepath.name,
+            datetime.fromtimestamp(modified_at, tz=timezone.utc).strftime("%Y-%m-%d"),
+        )
         deleted_files.append(
             {
                 "name": filepath.name,
-                "modified_at": datetime.fromtimestamp(modified_at, tz=timezone.utc).isoformat(),
+                "modified_at": datetime.fromtimestamp(
+                    modified_at, tz=timezone.utc
+                ).isoformat(),
             }
         )
 

--- a/src/app/scripts/cleanup.py
+++ b/src/app/scripts/cleanup.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from time import time
@@ -7,6 +8,23 @@ from django.conf import settings
 ANONYMOUS_MEDIA_SUBDIR = "AnonymousUser"
 DEFAULT_DAYS_THRESHOLD = 10
 SECONDS_PER_DAY = int(timedelta(days=1).total_seconds())
+LOG_FILE = Path(settings.PROJECT_ROOT) / "container_logs" / "deletedFiles.log"
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+logger = logging.getLogger("app.cleanup")
+logger.setLevel(logging.INFO)
+
+if not any(
+    isinstance(handler, logging.FileHandler) and Path(handler.baseFilename) == LOG_FILE
+    for handler in logger.handlers
+):
+    handler = logging.FileHandler(LOG_FILE)
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    )
+    logger.addHandler(handler)
 
 
 def clean_media(days_threshold=DEFAULT_DAYS_THRESHOLD, media_root=None):
@@ -17,8 +35,10 @@ def clean_media(days_threshold=DEFAULT_DAYS_THRESHOLD, media_root=None):
     deleted_files = []
     now = time()
     cutoff_seconds = days_threshold * SECONDS_PER_DAY
+    logger.info("Cleanup job started at %s", datetime.fromtimestamp(now, tz=timezone.utc).isoformat())
 
     if not media_dir.is_dir():
+        logger.info("Cleanup skipped because directory does not exist: %s", media_dir)
         return deleted_files
 
     for filepath in sorted(media_dir.iterdir()):
@@ -30,6 +50,7 @@ def clean_media(days_threshold=DEFAULT_DAYS_THRESHOLD, media_root=None):
             continue
 
         filepath.unlink()
+        logger.info("Deleting file %s with date %s", filepath.name, datetime.fromtimestamp(modified_at, tz=timezone.utc).isoformat())
         deleted_files.append(
             {
                 "name": filepath.name,

--- a/src/app/tests.py
+++ b/src/app/tests.py
@@ -1624,20 +1624,11 @@ class TestCronJob(TestCase):
                 self.assertTrue(os.path.exists(file_path), f'{file_path} should not have been deleted')
 
     def test_cleanup_management_command(self):
-        """cleanup_media command delegates to clean_media and formats output"""
-        stdout = StringIO()
-        deleted_files = [
-            {
-                'name': 'expired.txt',
-                'modified_at': '2026-01-01T00:00:00+00:00',
-            }
-        ]
+        """cleanup_media command delegates with correct threshold values"""
+        with patch('app.management.commands.cleanup_media.clean_media', return_value=[]) as clean_media_mock:
+            call_command('cleanup_media')
+            call_command('cleanup_media', '--days-threshold', '30')
 
-        with patch('app.management.commands.cleanup_media.clean_media', return_value=deleted_files) as clean_media_mock:
-            call_command('cleanup_media', '--days-threshold', '30', stdout=stdout)
-
-        clean_media_mock.assert_called_once_with(days_threshold=30)
-        output = stdout.getvalue()
-        self.assertIn('Cleanup started at', output)
-        self.assertIn('Deleted file: expired.txt (modified at 2026-01-01T00:00:00+00:00)', output)
-        self.assertIn('Cleanup completed; deleted 1 file(s).', output)
+        self.assertEqual(clean_media_mock.call_count, 2)
+        clean_media_mock.assert_any_call(days_threshold=10)
+        clean_media_mock.assert_any_call(days_threshold=30)

--- a/src/app/tests.py
+++ b/src/app/tests.py
@@ -5,6 +5,7 @@
 
 import datetime
 import os
+import shutil
 import time
 from io import StringIO
 from unittest import skipIf
@@ -1594,9 +1595,10 @@ class EditLicenseNamespaceXmlViewsTestCase(TestCase):
 
 class TestCronJob(TestCase):
     def test_clean_media_deletes_only_expired_files(self):
-        """ Check if the files older than 10 days are getting deleted"""
+        """Check if the files older than 10 days are getting deleted"""
         test_dir = os.path.join(settings.MEDIA_ROOT, 'AnonymousUser')
         os.makedirs(test_dir, exist_ok=True)
+        self.addCleanup(shutil.rmtree, test_dir, True)
         for i in range(1, 11):
             file_path = os.path.join(test_dir, f'test_file_{i}.txt')
             with open(file_path, 'w') as f:

--- a/src/app/tests.py
+++ b/src/app/tests.py
@@ -3,35 +3,36 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2017 Rohit Lodha
 
-from django.test import TestCase
+import datetime
+import os
+import time
+from io import StringIO
 from unittest import skipIf
 from unittest.mock import patch
-from src.secret import getAccessToken, getGithubUserId, getGithubUserName
-from django.contrib.auth.models import User
+
 from django.conf import settings
-from django.urls import reverse
+from django.contrib.auth import authenticate
+from django.contrib.auth.models import User
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.core.management import call_command
+from django.test import TestCase
+from django.urls import reverse
 
 from selenium import webdriver
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.firefox.service import Service
-from webdriver_manager.firefox import GeckoDriverManager
-import time
-import datetime
-
-from app.models import UserID
-from app.models import LicenseRequest, LicenseNamespace
-from app.generateXml import generateLicenseXml
-from django.contrib.auth.models import User
-from django.contrib.auth import authenticate
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 from social_django.models import UserSocialAuth
-from django.conf import settings
-import os
+from webdriver_manager.firefox import GeckoDriverManager
 
-from app.scripts.cleanup import cleanMedia
+from app.generateXml import generateLicenseXml
+from app.models import LicenseRequest, LicenseNamespace
+from app.models import UserID
+from app.scripts.cleanup import clean_media
+
+from src.secret import getAccessToken, getGithubUserId, getGithubUserName
 
 service = Service(GeckoDriverManager().install())
 
@@ -1592,9 +1593,8 @@ class EditLicenseNamespaceXmlViewsTestCase(TestCase):
         self.assertEqual(resp.resolver_match.func.__name__,"licenseNamespaceRequests")
 
 class TestCronJob(TestCase):
-    def test_delete_old_files(self):
-        """Check if the files older than 10 days are getting deleted or not"""
-        # create a test directory with some files
+    def test_clean_media_deletes_only_expired_files(self):
+        """ Check if the files older than 10 days are getting deleted"""
         test_dir = os.path.join(settings.MEDIA_ROOT, 'AnonymousUser')
         os.makedirs(test_dir, exist_ok=True)
         for i in range(1, 11):
@@ -1605,14 +1605,39 @@ class TestCronJob(TestCase):
             if i<=5: 
                 creation_time = datetime.datetime.now() - datetime.timedelta(days=11)
                 os.utime(file_path, (creation_time.timestamp(), creation_time.timestamp()))
-        
-        cleanMedia()
 
         # check that only files older than 10 days were deleted
+        deleted_files = clean_media()
+
+        self.assertEqual(
+            [file_info['name'] for file_info in deleted_files],
+            [f'test_file_{i}.txt' for i in range(1, 6)],
+        )
+        for file_info in deleted_files:
+            self.assertIn('modified_at', file_info)
+
         for i in range(1, 11):
             file_path = os.path.join(test_dir, f'test_file_{i}.txt')
             if i <= 5:
                 self.assertFalse(os.path.exists(file_path), f'{file_path} should have been deleted')
             else:
                 self.assertTrue(os.path.exists(file_path), f'{file_path} should not have been deleted')
-            
+
+    def test_cleanup_management_command(self):
+        """cleanup_media command delegates to clean_media and formats output"""
+        stdout = StringIO()
+        deleted_files = [
+            {
+                'name': 'expired.txt',
+                'modified_at': '2026-01-01T00:00:00+00:00',
+            }
+        ]
+
+        with patch('app.management.commands.cleanup_media.clean_media', return_value=deleted_files) as clean_media_mock:
+            call_command('cleanup_media', '--days-threshold', '30', stdout=stdout)
+
+        clean_media_mock.assert_called_once_with(days_threshold=30)
+        output = stdout.getvalue()
+        self.assertIn('Cleanup started at', output)
+        self.assertIn('Deleted file: expired.txt (modified at 2026-01-01T00:00:00+00:00)', output)
+        self.assertIn('Cleanup completed; deleted 1 file(s).', output)


### PR DESCRIPTION
To bring back the media cleanup task, which was dropped at some point during recent updates, as reported by #625.

Previously, media cleanup was scheduled inside the web app container. That setup can trigger duplicate cleanup runs when multiple web app containers are running.

This change moves scheduling to host cron and refactors cleanup into a Django management command. The command can now be executed consistently from host cron and from Docker CLI commands.

Tested with `python src/manage.py test app.tests.TestCronJob`