### PR TITLE
Update JPype to 1.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Django>=4.2,<4.3
 djangorestframework>=3.14.0
 gevent==25.9.1
 gunicorn==23.0.0
-jpype1==1.6.0
+jpype1==1.7.0
 lxml>=5.4.0,<6.0.0
 ntia-conformance-checker==4.1.2
 python-dotenv>=1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ social-auth-app-django>=5.0,<6.0
 social-auth-core>=4.3,<5.0
 spdx-python-model>=0.0.4,<1.0.0
 spdx-tools>=0.8.5,<1.0.0
-https://github.com/spdx/spdx-license-matcher/archive/refs/tags/v2.8.tar.gz#egg=spdx-license-matcher
+https://github.com/spdx/spdx-license-matcher/archive/refs/tags/v2.9.tar.gz#egg=spdx-license-matcher

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -77,7 +77,7 @@ def validate(request):
 
         if serializer.is_valid():
             core.initialise_jpype()
-            with core._jvm_thread():
+            with core.jvm_thread():
                 response = core.license_validate_helper(request)
             httpstatus, _, result = utils.get_json_response_data(response)
             returnstatus = utils.get_return_code(httpstatus)
@@ -111,7 +111,7 @@ def convert(request):
         serializer = ConvertSerializer(data=request.data)
         if serializer.is_valid():
             core.initialise_jpype()
-            with core._jvm_thread():
+            with core.jvm_thread():
                 response = core.license_convert_helper(request)
             httpstatus, result, message = utils.get_json_response_data(response)
             returnstatus = utils.get_return_code(httpstatus)
@@ -162,7 +162,7 @@ def compare(request):
             file2 = request.data.get('file2')
             files = [file1, file2]
             request.FILES.setlist('files', files)
-            with core._jvm_thread():
+            with core.jvm_thread():
                 response = core.license_compare_helper(request)
             httpstatus, result, message = utils.get_json_response_data(response)
             returnstatus = utils.get_return_code(httpstatus)
@@ -201,7 +201,7 @@ def check_license(request):
         serializer.is_valid(raise_exception=True)
         license_text = serializer.validated_data['file'].read().decode('utf8')
         core.initialise_jpype()
-        with core._jvm_thread():
+        with core.jvm_thread():
             matching_id, matching_type, all_matches = check_spdx_license(license_text)
         response = {
             "matched_license": matching_id,

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -80,7 +80,7 @@ def validate(request):
             core.initialise_jpype()
             response = core.license_validate_helper(request)
             httpstatus, _, result = utils.get_json_response_data(response)
-            jpype.detachThreadFromJVM()
+            jpype.JClass('java.lang.Thread').detach()
             returnstatus = utils.get_return_code(httpstatus)
             uploaded_file_obj = request.FILES.get("file") or request.data.get("file")
             query = ValidateFileUpload.objects.create(
@@ -113,7 +113,7 @@ def convert(request):
         if serializer.is_valid():
             core.initialise_jpype()
             response = core.license_convert_helper(request)
-            jpype.detachThreadFromJVM()
+            jpype.JClass('java.lang.Thread').detach()
             httpstatus, result, message = utils.get_json_response_data(response)
             returnstatus = utils.get_return_code(httpstatus)
             
@@ -165,6 +165,7 @@ def compare(request):
             request.FILES.setlist('files', files)
             response = core.license_compare_helper(request)
             httpstatus, result, message = utils.get_json_response_data(response)
+            jpype.JClass('java.lang.Thread').detach()
             returnstatus = utils.get_return_code(httpstatus)
 
             if httpstatus != 200:
@@ -202,7 +203,7 @@ def check_license(request):
         license_text = serializer.validated_data['file'].read().decode('utf8')
         core.initialise_jpype()
         matching_id, matching_type, all_matches = check_spdx_license(license_text)
-        jpype.detachThreadFromJVM()
+        jpype.JClass('java.lang.Thread').detach()
         response = {
             "matched_license": matching_id,
             "match_type": matching_type,

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -22,7 +22,6 @@ from django.urls import reverse
 from django.conf import settings
 from django.contrib.auth.models import User
 
-import jpype
 import datetime
 
 import app.core as core
@@ -78,9 +77,9 @@ def validate(request):
 
         if serializer.is_valid():
             core.initialise_jpype()
-            response = core.license_validate_helper(request)
+            with core._jvm_thread():
+                response = core.license_validate_helper(request)
             httpstatus, _, result = utils.get_json_response_data(response)
-            jpype.JClass('java.lang.Thread').detach()
             returnstatus = utils.get_return_code(httpstatus)
             uploaded_file_obj = request.FILES.get("file") or request.data.get("file")
             query = ValidateFileUpload.objects.create(
@@ -112,8 +111,8 @@ def convert(request):
         serializer = ConvertSerializer(data=request.data)
         if serializer.is_valid():
             core.initialise_jpype()
-            response = core.license_convert_helper(request)
-            jpype.JClass('java.lang.Thread').detach()
+            with core._jvm_thread():
+                response = core.license_convert_helper(request)
             httpstatus, result, message = utils.get_json_response_data(response)
             returnstatus = utils.get_return_code(httpstatus)
             
@@ -163,9 +162,9 @@ def compare(request):
             file2 = request.data.get('file2')
             files = [file1, file2]
             request.FILES.setlist('files', files)
-            response = core.license_compare_helper(request)
+            with core._jvm_thread():
+                response = core.license_compare_helper(request)
             httpstatus, result, message = utils.get_json_response_data(response)
-            jpype.JClass('java.lang.Thread').detach()
             returnstatus = utils.get_return_code(httpstatus)
 
             if httpstatus != 200:
@@ -202,8 +201,8 @@ def check_license(request):
         serializer.is_valid(raise_exception=True)
         license_text = serializer.validated_data['file'].read().decode('utf8')
         core.initialise_jpype()
-        matching_id, matching_type, all_matches = check_spdx_license(license_text)
-        jpype.JClass('java.lang.Thread').detach()
+        with core._jvm_thread():
+            matching_id, matching_type, all_matches = check_spdx_license(license_text)
         response = {
             "matched_license": matching_id,
             "match_type": matching_type,

--- a/src/app/context_processors.py
+++ b/src/app/context_processors.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any
 
 import redis
 
-from app.core import initialise_jpype
 from src.secret import getRedisHost
 from src.version import (
     java_tools_version,

--- a/src/app/core.py
+++ b/src/app/core.py
@@ -5,12 +5,14 @@
 """This file contains the core logic used in the SPDX Online Tools' APP and API"""
 
 import os
+from contextlib import contextmanager
 from json import dumps
 from time import time
 from traceback import format_exc
 from urllib.parse import urljoin
 
 import jpype
+import jpype.imports  # noqa: F401 - required for Java package imports
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage
 from django.utils.datastructures import MultiValueDictKeyError
@@ -21,33 +23,41 @@ import app.utils as utils
 
 
 def initialise_jpype():
-    """Start JVM if not already started, attach a Thread and start processing the request
+    """Start JVM if not already started.
 
     The SPDX Online Tools must control the lifecycle of the JVM itself,
-    since the CLASSPATH must be set to include the tool.jar file in a specifc
+    since the CLASSPATH must be set to include the tool.jar file in a specific
     location (JAR_ABSOLUTE_PATH in settings).
     If we let libraries, like spdx_license_matcher, start the JVM, they may not
     include the correct tool.jar in the CLASSPATH.
     """
-
-    # Check is the JVM is already running or not. If not, start JVM.
     if not jpype.isJVMStarted():
         jpype.startJVM(
             "-ea", "-Djava.awt.headless=true", classpath=settings.JAR_ABSOLUTE_PATH
         )
-    # Attach a thread to JVM and start processing
-    jpype.JClass('java.lang.Thread').attach()
-    jpype.JPackage("org.spdx.library").SpdxModelFactory.init()
+        from org.spdx.library import SpdxModelFactory
+        SpdxModelFactory.init()
+
+
+@contextmanager
+def _jvm_thread():
+    """Attach current thread to JVM as daemon; detach on exit."""
+    JThread = jpype.JClass("java.lang.Thread")
+    JThread.attachAsDaemon()
+    try:
+        yield
+    finally:
+        JThread.detach()
 
 
 def license_compare_helper(request):
     """
     A helper function to compare two given licenses.
     """
-    package = jpype.JPackage("org.spdx.tools")
-    verifyclass = package.Verify
-    compareclass = package.CompareSpdxDocs
-    helperclass = package.SpdxToolsHelper
+    from org.spdx.tools import CompareSpdxDocs, SpdxToolsHelper, Verify
+    verifyclass = Verify
+    compareclass = CompareSpdxDocs
+    helperclass = SpdxToolsHelper
     ajaxdict = dict()
     filelist = list()
     errorlist = list()
@@ -96,7 +106,7 @@ def license_compare_helper(request):
                     except jpype.JException as ex:
                         # Error raised by verifyclass.verifyRDFFile without exiting the application
                         filelist.append(myfile.name)
-                        errorlist.append(jpype.JException.message(ex))
+                        errorlist.append(str(ex))
                     except Exception:
                         # Other Exceptions
                         erroroccurred = True
@@ -315,8 +325,7 @@ def license_validate_helper(request):
     """
     A helper function to validate the given license file in various formats.
     """
-    package = jpype.JPackage("org.spdx.tools")
-    verifyclass = package.Verify
+    from org.spdx.tools import Verify as verifyclass
     ajaxdict = dict()
     context_dict = {}
     result = {}
@@ -381,12 +390,12 @@ def license_validate_helper(request):
         if utils.is_ajax(request):
             ajaxdict = dict()
             ajaxdict["type"] = "error"
-            ajaxdict["data"] = jpype.JException.message(ex)
+            ajaxdict["data"] = str(ex)
             response = dumps(ajaxdict)
             result['response'] = response
             result['status'] = 400
             return result
-        context_dict["error"] = jpype.JException.message(ex)
+        context_dict["error"] = str(ex)
         result['context'] = context_dict
         result['status'] = 400
         return result
@@ -462,12 +471,12 @@ def license_check_helper(request):
         # Java exception raised without exiting the application
         if utils.is_ajax(request):
             ajaxdict = dict()
-            ajaxdict["data"] = jpype.JException.message(ex)
+            ajaxdict["data"] = str(ex)
             response = dumps(ajaxdict)
             result['response'] = response
             result['status'] = 404
             return result
-        context_dict["error"] = jpype.JException.message(ex)
+        context_dict["error"] = str(ex)
         result['context'] = context_dict
         result['status'] = 404
         return result
@@ -490,10 +499,8 @@ def license_convert_helper(request):
     """
     A helper function to help in conversion of the license from one format to another.
     """
-    package = jpype.JPackage("org.spdx.tools")
+    from org.spdx.tools import SpdxConverter as spdxConverter, Verify as verifyclass
     serFileTypeEnum = jpype.JClass("org.spdx.tools.SpdxToolsHelper$SerFileType")
-    spdxConverter = package.SpdxConverter
-    verifyclass = package.Verify
     ajaxdict = dict()
     result = {}
     context_dict = {}
@@ -564,13 +571,13 @@ def license_convert_helper(request):
         # Java exception raised without exiting the application
         if utils.is_ajax(request):
             ajaxdict["type"] = "error"
-            ajaxdict["data"] = jpype.JException.message(ex)
+            ajaxdict["data"] = str(ex)
             response = dumps(ajaxdict)
             result['response'] = response
             result['status'] = 400
             return result
         context_dict["type"] = "error"
-        context_dict["error"] = jpype.JException.message(ex)
+        context_dict["error"] = str(ex)
         result['context'] = context_dict
         result['status'] = 400
         return result
@@ -634,12 +641,12 @@ def license_diff_helper(request):
         # Java exception raised without exiting the application
         if utils.is_ajax(request):
             ajaxdict = dict()
-            ajaxdict["data"] = jpype.JException.message(ex)
+            ajaxdict["data"] = str(ex)
             response = dumps(ajaxdict)
             data['response'] = response
             data['status'] = 404
             return data
-        data["error"] = jpype.JException.message(ex)
+        data["error"] = str(ex)
         data['context'] = data
         data['status'] = 404
         return data

--- a/src/app/core.py
+++ b/src/app/core.py
@@ -36,7 +36,7 @@ def initialise_jpype():
             "-ea", "-Djava.awt.headless=true", classpath=settings.JAR_ABSOLUTE_PATH
         )
     # Attach a thread to JVM and start processing
-    jpype.attachThreadToJVM()
+    jpype.JClass('java.lang.Thread').attach()
     jpype.JPackage("org.spdx.library").SpdxModelFactory.init()
 
 

--- a/src/app/core.py
+++ b/src/app/core.py
@@ -41,13 +41,19 @@ def initialise_jpype():
 
 @contextmanager
 def _jvm_thread():
-    """Attach current thread to JVM as daemon; detach on exit."""
+    """Attach current thread to JVM as daemon; detach on exit.
+
+    Guards the detach with isAttached() because spdx_license_matcher (v2.8)
+    calls detachThreadFromJVM() internally, which can leave the thread already
+    detached by the time the finally block runs.
+    """
     JThread = jpype.JClass("java.lang.Thread")
     JThread.attachAsDaemon()
     try:
         yield
     finally:
-        JThread.detach()
+        if JThread.isAttached():
+            JThread.detach()
 
 
 def license_compare_helper(request):

--- a/src/app/core.py
+++ b/src/app/core.py
@@ -40,7 +40,7 @@ def initialise_jpype():
 
 
 @contextmanager
-def _jvm_thread():
+def jvm_thread():
     """Attach current thread to JVM as daemon; detach on exit.
 
     Guards the detach with isAttached() because spdx_license_matcher (v2.8)

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -15,7 +15,6 @@ from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 
 import codecs
-import jpype
 import requests
 from lxml import etree
 import os
@@ -463,8 +462,8 @@ def validate(request):
         context_dict={}
         if request.method == 'POST':
             core.initialise_jpype()
-            result = core.license_validate_helper(request)
-            jpype.JClass('java.lang.Thread').detach()
+            with core._jvm_thread():
+                result = core.license_validate_helper(request)
             context_dict = result.get('context', None)
             status = result.get('status', None)
             response = result.get('response', None)
@@ -572,8 +571,8 @@ def compare(request):
         context_dict = {}
         if request.method == 'POST':
             core.initialise_jpype()
-            result = core.license_compare_helper(request)
-            jpype.JClass('java.lang.Thread').detach()
+            with core._jvm_thread():
+                result = core.license_compare_helper(request)
             context_dict = result.get('context', None)
             status = result.get('status', None)
             response = result.get('response', None)
@@ -600,8 +599,8 @@ def convert(request):
         context_dict={}
         if request.method == 'POST':
             core.initialise_jpype()
-            result = core.license_convert_helper(request)
-            jpype.JClass('java.lang.Thread').detach()
+            with core._jvm_thread():
+                result = core.license_convert_helper(request)
             context_dict = result.get('context', None)
             status = result.get('status', None)
             response = result.get('response', None)
@@ -631,11 +630,8 @@ def check_license(request):
             # If we do not initialise JPype here, spdx_license_matcher will
             # start its own JVM with its own CLASSPATH which may cause issues.
             core.initialise_jpype()
-            result = core.license_check_helper(request)
-            try:
-                jpype.JClass('java.lang.Thread').detach()
-            except Exception:
-                pass
+            with core._jvm_thread():
+                result = core.license_check_helper(request)
             context_dict = result.get('context', None)
             status = result.get('status', None)
             response = result.get('response', None)
@@ -667,11 +663,8 @@ def license_diff(request):
             # If we do not initialise JPype here, spdx_license_matcher will
             # start its own JVM with its own CLASSPATH which may cause issues.
             core.initialise_jpype()
-            result = core.license_diff_helper(request)
-            try:
-                jpype.JClass('java.lang.Thread').detach()
-            except Exception:
-                pass
+            with core._jvm_thread():
+                result = core.license_diff_helper(request)
             return JsonResponse(result)
         else:
             return render(request,

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -462,7 +462,7 @@ def validate(request):
         context_dict={}
         if request.method == 'POST':
             core.initialise_jpype()
-            with core._jvm_thread():
+            with core.jvm_thread():
                 result = core.license_validate_helper(request)
             context_dict = result.get('context', None)
             status = result.get('status', None)
@@ -571,7 +571,7 @@ def compare(request):
         context_dict = {}
         if request.method == 'POST':
             core.initialise_jpype()
-            with core._jvm_thread():
+            with core.jvm_thread():
                 result = core.license_compare_helper(request)
             context_dict = result.get('context', None)
             status = result.get('status', None)
@@ -599,7 +599,7 @@ def convert(request):
         context_dict={}
         if request.method == 'POST':
             core.initialise_jpype()
-            with core._jvm_thread():
+            with core.jvm_thread():
                 result = core.license_convert_helper(request)
             context_dict = result.get('context', None)
             status = result.get('status', None)
@@ -630,7 +630,7 @@ def check_license(request):
             # If we do not initialise JPype here, spdx_license_matcher will
             # start its own JVM with its own CLASSPATH which may cause issues.
             core.initialise_jpype()
-            with core._jvm_thread():
+            with core.jvm_thread():
                 result = core.license_check_helper(request)
             context_dict = result.get('context', None)
             status = result.get('status', None)
@@ -663,7 +663,7 @@ def license_diff(request):
             # If we do not initialise JPype here, spdx_license_matcher will
             # start its own JVM with its own CLASSPATH which may cause issues.
             core.initialise_jpype()
-            with core._jvm_thread():
+            with core.jvm_thread():
                 result = core.license_diff_helper(request)
             return JsonResponse(result)
         else:

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -482,7 +482,7 @@ def validate(request):
         if request.method == 'POST':
             core.initialise_jpype()
             result = core.license_validate_helper(request)
-            jpype.detachThreadFromJVM()
+            jpype.JClass('java.lang.Thread').detach()
             context_dict = result.get('context', None)
             status = result.get('status', None)
             response = result.get('response', None)
@@ -591,7 +591,7 @@ def compare(request):
         if request.method == 'POST':
             core.initialise_jpype()
             result = core.license_compare_helper(request)
-            jpype.detachThreadFromJVM()
+            jpype.JClass('java.lang.Thread').detach()
             context_dict = result.get('context', None)
             status = result.get('status', None)
             response = result.get('response', None)
@@ -619,7 +619,7 @@ def convert(request):
         if request.method == 'POST':
             core.initialise_jpype()
             result = core.license_convert_helper(request)
-            jpype.detachThreadFromJVM()
+            jpype.JClass('java.lang.Thread').detach()
             context_dict = result.get('context', None)
             status = result.get('status', None)
             response = result.get('response', None)
@@ -651,7 +651,7 @@ def check_license(request):
             core.initialise_jpype()
             result = core.license_check_helper(request)
             try:
-                jpype.detachThreadFromJVM()
+                jpype.JClass('java.lang.Thread').detach()
             except Exception:
                 pass
             context_dict = result.get('context', None)
@@ -687,7 +687,7 @@ def license_diff(request):
             core.initialise_jpype()
             result = core.license_diff_helper(request)
             try:
-                jpype.detachThreadFromJVM()
+                jpype.JClass('java.lang.Thread').detach()
             except Exception:
                 pass
             return JsonResponse(result)


### PR DESCRIPTION
- Update JPype to 1.7.0
- Use context manager for JVM attach/detach, to ensure that thread will always get detached.

--

- [x] Works locally with validate, convert, compare (tools-java)
- [x] Works locally with license check (spdx-license-matcher)

To resolve #634 