### PR TITLE
Add tool/version info to each tab + "Get involved" info to About

### DIFF
--- a/src/app/context_processors.py
+++ b/src/app/context_processors.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2026-present SPDX Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import jpype
+
+from app.core import initialise_jpype
+from src.version import (
+    java_tools_version,
+    jpype_version,
+    ntia_conformance_checker_version,
+    python_tools_version,
+    python_version,
+    spdx_license_list_version,
+    spdx_license_matcher_version,
+    spdx_online_tools_version,
+    spdx_python_model_version,
+)
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
+
+
+def _get_java_version() -> str:
+    """Query Java version thru JPype"""
+    try:
+        initialise_jpype()
+        System = jpype.java.lang.System
+        vendor_ver = str(System.getProperty("java.vendor.version") or "")
+        java_ver = str(System.getProperty("java.version") or "Unknown")
+        if vendor_ver:
+            # "Temurin-25.0.2+10" -> "Temurin 25.0.2"
+            # "GraalVM CE 21.0.1+12.1" -> "GraalVM CE 21.0.1"
+            clean = vendor_ver.rsplit("+", 1)[0].replace("-", " ", 1)
+            return clean
+        # Fallback: use vm.vendor + version
+        vm_vendor = str(System.getProperty("java.vm.vendor") or "")
+        return f"{vm_vendor} {java_ver}".strip()
+    except Exception:
+        return "Unknown"
+
+
+def tool_versions(request: HttpRequest) -> dict[str, Any]:
+    return {
+        "java_tools_version": java_tools_version,
+        "java_version": _get_java_version(),
+        "jpype_version": jpype_version,
+        "python_version": python_version,
+        "ntia_conformance_checker_version": ntia_conformance_checker_version,
+        "python_tools_version": python_tools_version,
+        "spdx_license_list_version": spdx_license_list_version,
+        "spdx_license_matcher_version": spdx_license_matcher_version,
+        "spdx_online_tools_version": spdx_online_tools_version,
+        "spdx_python_model_version": spdx_python_model_version,
+    }

--- a/src/app/context_processors.py
+++ b/src/app/context_processors.py
@@ -12,7 +12,6 @@ from app.core import initialise_jpype
 from src.secret import getRedisHost
 from src.version import (
     java_tools_version,
-    jpype_version,
     ntia_conformance_checker_version,
     python_tools_version,
     spdx_license_matcher_version,
@@ -63,7 +62,6 @@ def _get_license_metadata() -> dict[str, str]:
 def tool_versions(request: HttpRequest) -> dict[str, Any]:
     return {
         "java_tools_version": java_tools_version,
-        "jpype_version": jpype_version,
         "ntia_conformance_checker_version": ntia_conformance_checker_version,
         "python_tools_version": python_tools_version,
         "spdx_license_matcher_version": spdx_license_matcher_version,

--- a/src/app/context_processors.py
+++ b/src/app/context_processors.py
@@ -3,18 +3,20 @@
 
 from __future__ import annotations
 
+import datetime
 from typing import TYPE_CHECKING, Any
 
 import jpype
+import redis
 
 from app.core import initialise_jpype
+from src.secret import getRedisHost
 from src.version import (
     java_tools_version,
     jpype_version,
     ntia_conformance_checker_version,
     python_tools_version,
     python_version,
-    spdx_license_list_version,
     spdx_license_matcher_version,
     spdx_online_tools_version,
     spdx_python_model_version,
@@ -24,35 +26,74 @@ if TYPE_CHECKING:
     from django.http import HttpRequest
 
 
-def _get_java_version() -> str:
-    """Query Java version thru JPype"""
+def _compute_java_version() -> str:
     try:
         initialise_jpype()
         System = jpype.java.lang.System
         vendor_ver = str(System.getProperty("java.vendor.version") or "")
         java_ver = str(System.getProperty("java.version") or "Unknown")
         if vendor_ver:
-            # "Temurin-25.0.2+10" -> "Temurin 25.0.2"
-            # "GraalVM CE 21.0.1+12.1" -> "GraalVM CE 21.0.1"
-            clean = vendor_ver.rsplit("+", 1)[0].replace("-", " ", 1)
-            return clean
-        # Fallback: use vm.vendor + version
+            # "Temurin-25.0.2+10" -> "25.0.2 (Temurin)"
+            # "GraalVM CE 21.0.1+12.1" -> "21.0.1 (GraalVM CE)"
+            no_build = vendor_ver.rsplit("+", 1)[0].replace("-", " ", 1)
+            name, ver = no_build.rsplit(" ", 1)
+            return f"{ver} ({name})"
         vm_vendor = str(System.getProperty("java.vm.vendor") or "")
-        return f"{vm_vendor} {java_ver}".strip()
+        return f"{java_ver} ({vm_vendor})".strip()
     except Exception:
         return "Unknown"
+
+
+# Computed once at startup — Java version doesn't change while the server runs
+java_version: str = _compute_java_version()
+
+
+def _get_license_metadata() -> dict[str, str]:
+    """Fetch all license metadata keys in one Redis connection."""
+    keys = (
+        "license_list_version",
+        "license_list_release_date",
+        "license_db_last_updated",
+    )
+    try:
+        r = redis.StrictRedis(host=getRedisHost(), port=6379, db=1)
+        version_val, release_val, synced_val = r.mget(keys)
+
+        list_version = version_val.decode() if version_val else "Unknown"
+
+        if release_val:
+            dt_str = release_val.decode().replace("Z", "+00:00")
+            dt = datetime.datetime.fromisoformat(dt_str)
+            release_date = dt.strftime("%Y-%m-%d %H:%M:%S %Z").strip()
+        else:
+            release_date = "Unknown"
+
+        if synced_val:
+            dt = datetime.datetime.fromisoformat(synced_val.decode())
+            last_synced = dt.strftime("%Y-%m-%d %H:%M:%S %Z").strip()
+        else:
+            last_synced = "Unknown"
+
+    except Exception:
+        list_version = release_date = last_synced = "Unknown"
+
+    return {
+        "license_list_version": list_version,
+        "license_list_release_date": release_date,
+        "license_list_last_synced": last_synced,
+    }
 
 
 def tool_versions(request: HttpRequest) -> dict[str, Any]:
     return {
         "java_tools_version": java_tools_version,
-        "java_version": _get_java_version(),
+        "java_version": java_version,
         "jpype_version": jpype_version,
         "python_version": python_version,
         "ntia_conformance_checker_version": ntia_conformance_checker_version,
         "python_tools_version": python_tools_version,
-        "spdx_license_list_version": spdx_license_list_version,
         "spdx_license_matcher_version": spdx_license_matcher_version,
         "spdx_online_tools_version": spdx_online_tools_version,
         "spdx_python_model_version": spdx_python_model_version,
+        **_get_license_metadata(),
     }

--- a/src/app/context_processors.py
+++ b/src/app/context_processors.py
@@ -39,13 +39,13 @@ def _get_license_metadata() -> dict[str, str]:
         if release_val:
             dt_str = release_val.decode().replace("Z", "+00:00")
             dt = datetime.datetime.fromisoformat(dt_str)
-            release_date = dt.strftime("%Y-%m-%d %H:%M:%S %Z").strip()
+            release_date = dt.strftime("%Y-%m-%d").strip()
         else:
             release_date = "Unknown"
 
         if synced_val:
             dt = datetime.datetime.fromisoformat(synced_val.decode())
-            last_synced = dt.strftime("%Y-%m-%d %H:%M:%S %Z").strip()
+            last_synced = dt.strftime("%Y-%m-%d %H:%M %Z").strip()
         else:
             last_synced = "Unknown"
 

--- a/src/app/context_processors.py
+++ b/src/app/context_processors.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING, Any
 
-import jpype
 import redis
 
 from app.core import initialise_jpype
@@ -16,7 +15,6 @@ from src.version import (
     jpype_version,
     ntia_conformance_checker_version,
     python_tools_version,
-    python_version,
     spdx_license_matcher_version,
     spdx_online_tools_version,
     spdx_python_model_version,
@@ -24,28 +22,6 @@ from src.version import (
 
 if TYPE_CHECKING:
     from django.http import HttpRequest
-
-
-def _compute_java_version() -> str:
-    try:
-        initialise_jpype()
-        System = jpype.java.lang.System
-        vendor_ver = str(System.getProperty("java.vendor.version") or "")
-        java_ver = str(System.getProperty("java.version") or "Unknown")
-        if vendor_ver:
-            # "Temurin-25.0.2+10" -> "25.0.2 (Temurin)"
-            # "GraalVM CE 21.0.1+12.1" -> "21.0.1 (GraalVM CE)"
-            no_build = vendor_ver.rsplit("+", 1)[0].replace("-", " ", 1)
-            name, ver = no_build.rsplit(" ", 1)
-            return f"{ver} ({name})"
-        vm_vendor = str(System.getProperty("java.vm.vendor") or "")
-        return f"{java_ver} ({vm_vendor})".strip()
-    except Exception:
-        return "Unknown"
-
-
-# Computed once at startup — Java version doesn't change while the server runs
-java_version: str = _compute_java_version()
 
 
 def _get_license_metadata() -> dict[str, str]:
@@ -87,9 +63,7 @@ def _get_license_metadata() -> dict[str, str]:
 def tool_versions(request: HttpRequest) -> dict[str, Any]:
     return {
         "java_tools_version": java_tools_version,
-        "java_version": java_version,
         "jpype_version": jpype_version,
-        "python_version": python_version,
         "ntia_conformance_checker_version": ntia_conformance_checker_version,
         "python_tools_version": python_tools_version,
         "spdx_license_matcher_version": spdx_license_matcher_version,

--- a/src/app/templates/app/_tool_versions.html
+++ b/src/app/templates/app/_tool_versions.html
@@ -1,0 +1,19 @@
+<div style="font-size:0.8em; color:#666; margin-top:1.2em; border-top:1px solid #e0e0e0; padding-top:0.6em; padding-left:5px;">
+  Component versions used by this tool:
+  <ul style="list-style:none; padding:0; margin:0.3em 0 0 0;">
+    {% if show_java_tools %}
+    <li><a href="https://github.com/spdx/tools-java">SPDX Java Tools</a>: <span style="color:#0097c4;">{{ java_tools_version }}</span> (via JPype <span style="color:#0097c4;">{{ jpype_version }}</span>)</li>
+    {% endif %}
+    {% if show_python_tools %}
+    <li><a href="https://github.com/spdx/tools-python">SPDX Python Tools</a>: <span style="color:#0097c4;">{{ python_tools_version }}</span></li>
+    <li><a href="https://github.com/spdx/spdx-python-model">SPDX Python Model</a>: <span style="color:#0097c4;">{{ spdx_python_model_version }}</span></li>
+    {% endif %}
+    {% if show_ntia %}
+    <li><a href="https://github.com/spdx/ntia-conformance-checker">NTIA Conformance Checker</a>: <span style="color:#0097c4;">{{ ntia_conformance_checker_version }}</span></li>
+    {% endif %}
+    {% if show_license_matcher %}
+    <li><a href="https://github.com/spdx/spdx-license-matcher">SPDX License Matcher</a>: <span style="color:#0097c4;">{{ spdx_license_matcher_version }}</span></li>
+    <li><a href="https://github.com/spdx/license-list-XML">SPDX License List</a>: <span style="color:#0097c4;">{{ spdx_license_list_version }}</span></li>
+    {% endif %}
+  </ul>
+</div>

--- a/src/app/templates/app/_tool_versions.html
+++ b/src/app/templates/app/_tool_versions.html
@@ -2,7 +2,7 @@
   Component versions used by this tool:
   <ul style="list-style:none; padding:0; margin:0.3em 0 0 0;">
     {% if show_java_tools %}
-    <li><a href="https://github.com/spdx/tools-java">SPDX Java Tools</a>: <span style="color:#0097c4;">{{ java_tools_version }}</span> (via JPype <span style="color:#0097c4;">{{ jpype_version }}</span>)</li>
+    <li><a href="https://github.com/spdx/tools-java">SPDX Java Tools</a>: <span style="color:#0097c4;">{{ java_tools_version }}</span></li>
     {% endif %}
     {% if show_python_tools %}
     <li><a href="https://github.com/spdx/tools-python">SPDX Python Tools</a>: <span style="color:#0097c4;">{{ python_tools_version }}</span></li>

--- a/src/app/templates/app/about.html
+++ b/src/app/templates/app/about.html
@@ -113,10 +113,10 @@
         associated with a software package.</p>
 
       <h3 class="about-section-title">What is SPDX Online Tools?</h3>
-      <p>A portal for SPDX SBOM utilities and license management.
-        Validate, check conformance, compare, and convert SPDX documents.
-        Identify SPDX License IDs from text and submit new entries to the <a href="https://spdx.org/licenses/">SPDX
-          License List</a>.</p>
+      <p>A portal for SPDX SBOM and license management.
+        Validate, convert, compare, and edit SPDX documents.
+        Identify an SPDX License ID from license text and a submit new license to the        
+        <a href="https://spdx.org/licenses/">SPDX License List</a>.</p>
 
       <h3 class="about-section-title">Get involved</h3>
       <ul class="about-links">

--- a/src/app/templates/app/about.html
+++ b/src/app/templates/app/about.html
@@ -113,7 +113,7 @@
         associated with a software package.</p>
 
       <h3 class="about-section-title">What is SPDX Online Tools?</h3>
-      <p>A centralized portal for SPDX document and license management.
+      <p>A portal for SPDX SBOM utilities and license management.
         Validate, check conformance, compare, and convert SPDX documents.
         Identify SPDX License IDs from text and submit new entries to the <a href="https://spdx.org/licenses/">SPDX
           License List</a>.</p>

--- a/src/app/templates/app/about.html
+++ b/src/app/templates/app/about.html
@@ -233,24 +233,29 @@
         </tbody>
       </table>
       <p class="about-note">
-        The SPDX 3 visual editor (<a href="https://github.com/condots/dots/">dots</a>) is an external tool hosted by
-        Ilan Schifter at
-        <a href="https://condots.duckdns.org">condots.duckdns.org</a>.
+        The SPDX 3 visual editor (<a href="https://github.com/condots/dots/">dots</a>)
+        is an external tool hosted by Ilan Schifter at
+        <a href="https://condots.duckdns.org" target="_blank" rel="noreferrer">condots.duckdns.org</a>.
       </p>
-      <h3 class="about-section-title">System information</h3>
+      <p class="about-note">
+        <a href="https://github.com/spdx/spdx-license-diff">SPDX License Diff</a>,
+        a Chrome/Firefox browser extension to compare text against licenses in SPDX License List,
+        uses an API endpoint provided by SPDX Online Tools.
+      </p>
+      <h3 class="about-section-title">SPDX License List</h3>
       <table class="version-table">
         <tbody>
           <tr>
-            <td><a href="https://github.com/spdx/license-list-XML">SPDX License List</a> (in db)</td>
+            <td><a href="https://github.com/spdx/license-list-XML/releases">License list version</a></td>
             <td>{{ license_list_version }}</td>
-          </tr>
-          <tr>
-            <td>License list last synced (in db)</td>
-            <td>{{ license_list_last_synced }}</td>
           </tr>
           <tr>
             <td>License list release date</td>
             <td>{{ license_list_release_date }}</td>
+          </tr>
+          <tr>
+            <td>License list last synced to db</td>
+            <td>{{ license_list_last_synced }}</td>
           </tr>
         </tbody>
       </table>

--- a/src/app/templates/app/about.html
+++ b/src/app/templates/app/about.html
@@ -117,65 +117,17 @@
         Validate, check conformance, compare, and convert SPDX documents.
         Identify SPDX License IDs from text and submit new entries to the <a href="https://spdx.org/licenses/">SPDX
           License List</a>.</p>
-    </div>
 
-    <div class="about-col-side">
-      <h3 class="about-section-title">Core components</h3>
-      <p style="font-size:0.88em;">Versions deployed here and links to upstream source code.</p>
-      <table class="version-table">
-        <tbody>
-          <tr>
-            <td><a href="https://github.com/spdx/spdx-online-tools">SPDX Online Tools</a></td>
-            <td>{{ spdx_online_tools_version }}</td>
-          </tr>
-          <tr>
-            <td><a href="https://github.com/spdx/license-list-XML">SPDX License List</a></td>
-            <td>{{ spdx_license_list_version }}</td>
-          </tr>
-          <tr>
-            <td><a href="https://github.com/spdx/tools-java">SPDX Java Tools</a></td>
-            <td>{{ java_tools_version }}</td>
-          </tr>
-          <tr>
-            <td><a href="https://github.com/spdx/tools-python">SPDX Python Tools</a></td>
-            <td>{{ python_tools_version }}</td>
-          </tr>
-          <tr>
-            <td><a href="https://github.com/spdx/spdx-python-model">SPDX Python Model</a></td>
-            <td>{{ spdx_python_model_version }}</td>
-          </tr>
-          <tr>
-            <td><a href="https://github.com/spdx/spdx-license-matcher">SPDX License Matcher</a></td>
-            <td>{{ spdx_license_matcher_version }}</td>
-          </tr>
-          <tr>
-            <td><a href="https://github.com/spdx/ntia-conformance-checker">NTIA Conformance Checker</a></td>
-            <td>{{ ntia_conformance_checker_version }}</td>
-          </tr>
-        </tbody>
-      </table>
-      <p class="about-note">
-        The SPDX 3 visual editor (<a href="https://github.com/condots/dots/">dots</a>) is an external tool hosted by
-        Ilan Schifter at
-        <a href="https://condots.duckdns.org">condots.duckdns.org</a>.
-      </p>
-      <h3 class="about-section-title">System information</h3>
-      <table class="version-table">
-        <tbody>
-          <tr>
-            <td>Java</td>
-            <td>{{ java_version }}</td>
-          </tr>
-          <tr>
-            <td><a href="https://github.com/nicktindall/jpype">JPype</a></td>
-            <td>{{ jpype_version }}</td>
-          </tr>
-          <tr>
-            <td>Python</td>
-            <td>{{ python_version }}</td>
-          </tr>
-        </tbody>
-      </table>
+      <h3 class="about-section-title">Get involved</h3>
+      <ul class="about-links">
+        <li><a href="https://github.com/spdx/spdx-online-tools/blob/main/CONTRIBUTING.md">Read the contributing
+            guide</a></li>
+        <li><a href="https://github.com/spdx/spdx-online-tools/issues">Report a bug or request a feature</a></li>
+        <li><a href="https://github.com/spdx/spdx-online-tools/issues?q=state%3Aopen%20label%3Agood-first-issue">Pick up
+            a good first issue</a></li>
+        <li><a href="https://lists.spdx.org/g/spdx-implementers">Join the mailing list</a></li>
+        <li><a href="https://github.com/spdx/meetings#implementers">Join the SPDX Implementers call</a></li>
+      </ul>
     </div>
 
     <div class="about-col-side">
@@ -247,19 +199,65 @@
           </tr>
         </tbody>
       </table>
+    </div>
 
-      </ul>
-
-      <h3 class="about-section-title">Get involved</h3>
-      <ul class="about-links">
-        <li><a href="https://github.com/spdx/spdx-online-tools/blob/main/CONTRIBUTING.md">Read the contributing
-            guide</a></li>
-        <li><a href="https://github.com/spdx/spdx-online-tools/issues">Report a bug or request a feature</a></li>
-        <li><a href="https://github.com/spdx/spdx-online-tools/issues?q=state%3Aopen%20label%3Agood-first-issue">Pick up
-            a good first issue</a></li>
-        <li><a href="https://lists.spdx.org/g/spdx-implementers">Join the mailing list</a></li>
-        <li><a href="https://github.com/spdx/meetings#implementers">Join the SPDX Implementers call</a></li>
-      </ul>
+    <div class="about-col-side">
+      <h3 class="about-section-title">Core components</h3>
+      <p style="font-size:0.88em;">Versions deployed here and links to upstream source code.</p>
+      <table class="version-table">
+        <tbody>
+          <tr>
+            <td><a href="https://github.com/spdx/spdx-online-tools">SPDX Online Tools</a></td>
+            <td>{{ spdx_online_tools_version }}</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/spdx/license-list-XML">SPDX License List</a></td>
+            <td>{{ spdx_license_list_version }}</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/spdx/tools-java">SPDX Java Tools</a></td>
+            <td>{{ java_tools_version }}</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/spdx/tools-python">SPDX Python Tools</a></td>
+            <td>{{ python_tools_version }}</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/spdx/spdx-python-model">SPDX Python Model</a></td>
+            <td>{{ spdx_python_model_version }}</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/spdx/spdx-license-matcher">SPDX License Matcher</a></td>
+            <td>{{ spdx_license_matcher_version }}</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/spdx/ntia-conformance-checker">NTIA Conformance Checker</a></td>
+            <td>{{ ntia_conformance_checker_version }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="about-note">
+        The SPDX 3 visual editor (<a href="https://github.com/condots/dots/">dots</a>) is an external tool hosted by
+        Ilan Schifter at
+        <a href="https://condots.duckdns.org">condots.duckdns.org</a>.
+      </p>
+      <h3 class="about-section-title">System information</h3>
+      <table class="version-table">
+        <tbody>
+          <tr>
+            <td>Java</td>
+            <td>{{ java_version }}</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/nicktindall/jpype">JPype</a></td>
+            <td>{{ jpype_version }}</td>
+          </tr>
+          <tr>
+            <td>Python</td>
+            <td>{{ python_version }}</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
 
   </div>

--- a/src/app/templates/app/about.html
+++ b/src/app/templates/app/about.html
@@ -211,10 +211,6 @@
             <td>{{ spdx_online_tools_version }}</td>
           </tr>
           <tr>
-            <td><a href="https://github.com/spdx/license-list-XML">SPDX License List</a></td>
-            <td>{{ spdx_license_list_version }}</td>
-          </tr>
-          <tr>
             <td><a href="https://github.com/spdx/tools-java">SPDX Java Tools</a></td>
             <td>{{ java_tools_version }}</td>
           </tr>
@@ -255,6 +251,18 @@
           <tr>
             <td>Python</td>
             <td>{{ python_version }}</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/spdx/license-list-XML">SPDX License List</a> (in db)</td>
+            <td>{{ license_list_version }}</td>
+          </tr>
+          <tr>
+            <td>License list last synced (in db)</td>
+            <td>{{ license_list_last_synced }}</td>
+          </tr>
+          <tr>
+            <td>License list release date</td>
+            <td>{{ license_list_release_date }}</td>
           </tr>
         </tbody>
       </table>

--- a/src/app/templates/app/about.html
+++ b/src/app/templates/app/about.html
@@ -241,18 +241,6 @@
       <table class="version-table">
         <tbody>
           <tr>
-            <td>Java</td>
-            <td>{{ java_version }}</td>
-          </tr>
-          <tr>
-            <td><a href="https://github.com/nicktindall/jpype">JPype</a></td>
-            <td>{{ jpype_version }}</td>
-          </tr>
-          <tr>
-            <td>Python</td>
-            <td>{{ python_version }}</td>
-          </tr>
-          <tr>
             <td><a href="https://github.com/spdx/license-list-XML">SPDX License List</a> (in db)</td>
             <td>{{ license_list_version }}</td>
           </tr>

--- a/src/app/templates/app/about.html
+++ b/src/app/templates/app/about.html
@@ -2,97 +2,273 @@
 {% load static %}
 {% block head_block %}
 <style>
+  .about-wrap {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 0 8px;
+  }
+
+  .about-logos {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2.5em;
+    flex-wrap: wrap;
+    margin-bottom: 1.8em;
+  }
+
+  .about-logos img {
+    max-height: 56px;
+    width: auto;
+  }
+
   @media (min-width: 768px) {
-    .logo-vcenter {
+    .about-cols {
       display: flex;
-      align-items: center;
+      gap: 2em;
+      align-items: flex-start;
     }
+
+    .about-col-main {
+      flex: 1.2;
+    }
+
+    .about-col-side {
+      flex: 1;
+    }
+  }
+
+  .about-section-title {
+    color: #0097c4;
+    font-size: 1em;
+    font-weight: 600;
+    margin-top: 1.2em;
+    margin-bottom: 0.4em;
+  }
+
+  .about-contributors {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-size: 0.9em;
+    text-align: left;
+  }
+
+  .about-links {
+    padding-left: 1.2em;
+    margin: 0;
+    font-size: 0.9em;
+    text-align: left;
+  }
+
+  .version-table {
+    width: auto;
+    border-collapse: collapse;
+    font-size: 0.88em;
+  }
+
+  .version-table td {
+    padding: 3px 16px 3px 0;
+    vertical-align: top;
+    border-bottom: 1px solid #f0f0f0;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  .version-table td:last-child {
+    color: #0097c4;
+    padding-right: 0;
+  }
+
+  .version-table tr:last-child td {
+    border-bottom: none;
+  }
+
+  .about-note {
+    font-size: 0.82em;
+    color: #666;
+    margin-top: 0.8em;
   }
 </style>
 {% endblock %}
+
 {% block body1 %}
-<div class="container">
-  <div class="row text-center logo-vcenter">
-    <div class="col-sm-6">
-      <a href="https://spdx.dev/" id="spdxhome" target="_blank" title="SPDX"><img
-          src="{% static 'img/spdx.png' %}" alt="SPDX logo" class="img-responsive center-block" /></a>
-    </div>
-    <div class="col-sm-6">
-      <a href="https://summerofcode.withgoogle.com/" id="gsochome" target="_blank" title="Google Summer of Code"><img
-          src="{% static 'img/gsoc-h.png' %}" alt="Google Summer of Code logo"
-          class="img-responsive center-block" /></a>
-    </div>
+<div class="about-wrap">
+
+  <div class="about-logos">
+    <a href="https://spdx.dev/" target="_blank" title="SPDX">
+      <img src="{% static 'img/spdx.png' %}" alt="SPDX logo" class="img-responsive" />
+    </a>
+    <a href="https://summerofcode.withgoogle.com/" target="_blank" title="Google Summer of Code">
+      <img src="{% static 'img/gsoc-h.png' %}" alt="Google Summer of Code logo" class="img-responsive" />
+    </a>
   </div>
-</div>
 
-<div class="row">
-  <div class="col-md-8 col-md-offset-2">
-    <h3 class="lead" style="color:#0097c4;">What is SPDX?</h3>
-    <p>The <a href="https://spdx.dev/">System Package Data Exchange (SPDX)</a> (formerly "Software Package Data Exchange") specification is a standard
-      format for communicating the components, licenses and copyrights associated with a software package.</p>
+  <div class="about-cols">
 
-    <h3 class="lead" style="color:#0097c4;">What is this about?</h3>
-    <p>Providing an all-in-one portal to upload and parse SPDX documents for
-      validation, conformance check, comparison, conversion and SPDX License List search.</p>
+    <div class="about-col-main">
+      <h3 class="about-section-title">What is SPDX?</h3>
+      <p><a href="https://spdx.dev/">System Package Data Exchange (SPDX)</a> is a standard
+        format for communicating the components, licenses, and copyrights
+        associated with a software package.</p>
 
-    <h3 class="lead" style="color:#0097c4;">Contributors</h3>
-    <ul class="list-unstyled">
-      <li>Rohit Lodha, GSoC 2017</li>
-      <li>Tushar Mittal, GSoC 2018</li>
-      <li>Galo Castillo, GSoC 2018</li>
-      <li>Umang Taneja, GSoC 2019</li>
-      <li>Tanjong Agbor Smith, GSoC 2019</li>
-      <li>Joshua Lin, GSoC 2022</li>
-      <li>Arthit Suriyawongkul, GSoC 2025</li>
-      <li>Sujal Bhor, GSoC 2025</li>
-      <li>Ilan Schifter</li>
-      <li>Gary O'Neall</li>
-      <li>and <a href="https://github.com/spdx/">SPDX contributors</a></li>
-    </ul>
+      <h3 class="about-section-title">What is SPDX Online Tools?</h3>
+      <p>A centralized portal for SPDX document and license management.
+        Validate, check conformance, compare, and convert SPDX documents.
+        Identify SPDX License IDs from text and submit new entries to the <a href="https://spdx.org/licenses/">SPDX
+          License List</a>.</p>
+    </div>
 
-    <h3 class="lead" style="color:#0097c4;">Version information</h3>
-    <p>SPDX Online Tools is built using several components. The version information of these components is as follows:</p>
-    <ul class="list-unstyled">
-      <li>
-        <a href="https://github.com/spdx/spdx-online-tools">SPDX Online Tools</a>:
-        <span style="color:#0097c4;">{{ spdx_online_tools_version }}</span>
-      </li>
-      <li>
-        <a href="https://github.com/spdx/license-list-XML">SPDX License List</a>:
-        <span style="color:#0097c4;">{{ spdx_license_list_version }}</span>
-      </li>
-      <li>
-        <a href="https://github.com/spdx/tools-java">SPDX Java Tools</a>:
-        <span style="color:#0097c4;">{{ java_tools_version }}</span>
-      </li>
-      <li>
-        <a href="https://github.com/spdx/tools-python">SPDX Python Tools</a>:
-        <span style="color:#0097c4;">{{ python_tools_version }}</span>
-      </li>
-      <li>
-        <a href="https://github.com/spdx/spdx-python-model">SPDX Python Model</a>:
-        <span style="color:#0097c4;">{{ spdx_python_model_version }}</span>
-      </li>
-      <li>
-        <a href=https://github.com/spdx/spdx-license-matcher>SPDX License Matcher</a>:
-        <span style="color:#0097c4;">{{ spdx_license_matcher_version }}</span>
-      </li>
-      <li>
-        <a href="https://github.com/spdx/ntia-conformance-checker">NTIA Conformance Checker</a>:
-        <span style="color:#0097c4;">{{ ntia_conformance_checker_version }}</span>
-      </li>
-      <li>
-        The SPDX 3 visual editor (dots) is an external tool hosted by Ilan Schifter at<br />
-        <a href="https://condots.duckdns.org">https://condots.duckdns.org</a>.
-      </li>
-    </ul>
+    <div class="about-col-side">
+      <h3 class="about-section-title">Core components</h3>
+      <p style="font-size:0.88em;">Versions deployed here and links to upstream source code.</p>
+      <table class="version-table">
+        <tbody>
+          <tr>
+            <td><a href="https://github.com/spdx/spdx-online-tools">SPDX Online Tools</a></td>
+            <td>{{ spdx_online_tools_version }}</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/spdx/license-list-XML">SPDX License List</a></td>
+            <td>{{ spdx_license_list_version }}</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/spdx/tools-java">SPDX Java Tools</a></td>
+            <td>{{ java_tools_version }}</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/spdx/tools-python">SPDX Python Tools</a></td>
+            <td>{{ python_tools_version }}</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/spdx/spdx-python-model">SPDX Python Model</a></td>
+            <td>{{ spdx_python_model_version }}</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/spdx/spdx-license-matcher">SPDX License Matcher</a></td>
+            <td>{{ spdx_license_matcher_version }}</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/spdx/ntia-conformance-checker">NTIA Conformance Checker</a></td>
+            <td>{{ ntia_conformance_checker_version }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="about-note">
+        The SPDX 3 visual editor (<a href="https://github.com/condots/dots/">dots</a>) is an external tool hosted by
+        Ilan Schifter at
+        <a href="https://condots.duckdns.org">condots.duckdns.org</a>.
+      </p>
+      <h3 class="about-section-title">System information</h3>
+      <table class="version-table">
+        <tbody>
+          <tr>
+            <td>Java</td>
+            <td>{{ java_version }}</td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/nicktindall/jpype">JPype</a></td>
+            <td>{{ jpype_version }}</td>
+          </tr>
+          <tr>
+            <td>Python</td>
+            <td>{{ python_version }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="about-col-side">
+      <h3 class="about-section-title">Contributors</h3>
+      <table class="version-table">
+        <tbody>
+          <tr>
+            <td><a href="https://github.com/rtgdk">Rohit Lodha</a></td>
+            <td><a
+                href="https://github.com/spdx/spdx-online-tools/wiki/Online-SPDX-Tool%2C-Google-Summer-of-Code-2017">GSoC
+                2017</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/gaalocastillo">Galo Castillo</a></td>
+            <td><a
+                href="https://github.com/spdx/spdx-online-tools/wiki/Online-SPDX-New-License-Requests-Submittal%2C-Google-Summer-of-Code-2018">GSoC
+                2018</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/techytushar">Tushar Mittal</a></td>
+            <td><a
+                href="https://github.com/spdx/spdx-online-tools/wiki/Online-XML-Editor-for-SPDX-Licenses%2C-Google-Summer-of-Code-2018">GSoC
+                2018</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/tjasmith">Tanjong Agbor Smith</a></td>
+            <td><a
+                href="https://github.com/spdx/spdx-online-tools/wiki/Registry-and-repository-of-License-List-Namespaces%3A-GSOC-2019">GSoC
+                2019</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/Ugtan">Umang Taneja</a></td>
+            <td><a
+                href="https://github.com/spdx/spdx-online-tools/wiki/Enhance-the-workflow-of-License-Submittal-feature%2C-Google-Summer-of-Code-2019">GSoC
+                2019</a>, <a
+                href="https://github.com/spdx/spdx-online-tools/wiki/Migrate-online-tools-to-Django-3-and-add-additional-features-to-python3-branch">2021</a>
+            </td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/linynjosh">Joshua Lin</a></td>
+            <td><a href="https://github.com/spdx/ntia-conformance-checker/wiki/Project-Origin">GSoC 2022</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/BassCoder2808">Vedant Jolly</a></td>
+            <td><a
+                href="https://github.com/spdx/spdx-online-tools/wiki/Enhancing-the-SPDX-License-Submission-Online-Tool%3A-Improving-Streamlined-License-Compliance%2C-Google-Summer-of-Code-2023">GSoC
+                2023</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/bact">Arthit Suriyawongkul</a></td>
+            <td><a href="https://github.com/spdx/ntia-conformance-checker/wiki/Adding-SPDX-3.0-Support">GSoC 2025</a>
+            </td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/bhorsujal">Sujal Bhor</a></td>
+            <td><a href="https://summerofcode.withgoogle.com/archive/2025/projects/TwtGeZ4X">GSoC 2025</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/ilans">Ilan Schifter</a></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/goneall">Gary O'Neall</a></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>and <a href="https://github.com/spdx/">SPDX contributors</a></td>
+            <td></td>
+          </tr>
+        </tbody>
+      </table>
+
+      </ul>
+
+      <h3 class="about-section-title">Get involved</h3>
+      <ul class="about-links">
+        <li><a href="https://github.com/spdx/spdx-online-tools/blob/main/CONTRIBUTING.md">Read the contributing
+            guide</a></li>
+        <li><a href="https://github.com/spdx/spdx-online-tools/issues">Report a bug or request a feature</a></li>
+        <li><a href="https://github.com/spdx/spdx-online-tools/issues?q=state%3Aopen%20label%3Agood-first-issue">Pick up
+            a good first issue</a></li>
+        <li><a href="https://lists.spdx.org/g/spdx-implementers">Join the mailing list</a></li>
+        <li><a href="https://github.com/spdx/meetings#implementers">Join the SPDX Implementers call</a></li>
+      </ul>
+    </div>
+
   </div>
 </div>
 {% endblock %}
 
 {% block script_block %}
 <script type="text/javascript">
-$(document).ready(function () {
+  $(document).ready(function () {
     $("#aboutpage").addClass('linkactive');
   });
 </script>

--- a/src/app/templates/app/check_license.html
+++ b/src/app/templates/app/check_license.html
@@ -21,6 +21,7 @@
     {% include "app/modal.html" %}
   </div>
 </div>
+{% include "app/_tool_versions.html" with show_license_matcher=True %}
 {% endblock %}
 {% block script_block %}
 <script type="text/javascript">

--- a/src/app/templates/app/compare.html
+++ b/src/app/templates/app/compare.html
@@ -41,6 +41,7 @@
 </div>
 </div>
 {% include "app/modal.html" %}
+{% include "app/_tool_versions.html" with show_java_tools=True %}
 {% endblock %}
 
 {% block script_block %}

--- a/src/app/templates/app/convert.html
+++ b/src/app/templates/app/convert.html
@@ -77,6 +77,7 @@
 </div>
 </div>
 {% include "app/modal.html" %}
+{% include "app/_tool_versions.html" with show_java_tools=True %}
 {% endblock %}
 
 {% block script_block %}

--- a/src/app/templates/app/ntia_conformance_checker.html
+++ b/src/app/templates/app/ntia_conformance_checker.html
@@ -174,6 +174,8 @@
   <button id="checkbutton" name="checkbutton" class="btn btn-md btn-info" type="submit" disabled="true">Check minimum elements</button>
   {% include "app/modal.html" %}
 </div>
+</div>
+{% include "app/_tool_versions.html" with show_python_tools=True show_ntia=True %}
 
 {% endblock %}
 

--- a/src/app/templates/app/validate.html
+++ b/src/app/templates/app/validate.html
@@ -39,11 +39,13 @@
     </form>
 <hr>
     <button id="validatebutton" name="validatebutton" class="btn btn-md btn-info" type="submit" disabled="true">Validate</button>
-  {% include "app/modal.html" %} 
+  {% include "app/modal.html" %}
   <!--
   <output id="list"></output>
   -->
 </div>
+</div>
+{% include "app/_tool_versions.html" with show_java_tools=True %}
 
 {% endblock %}
 

--- a/src/app/templates/app/xml_upload.html
+++ b/src/app/templates/app/xml_upload.html
@@ -64,9 +64,10 @@
           </form>
         </div>
   </div>
-  {% include "app/modal.html" %} 
+  {% include "app/modal.html" %}
   </div>
 </div>
+{% include "app/_tool_versions.html" with show_java_tools=True %}
 {% endblock %}
 
 {% block script_block %}

--- a/src/app/utils.py
+++ b/src/app/utils.py
@@ -1,8 +1,9 @@
 # SPDX-FileCopyrightText: 2018 Tushar Mittal
-# SPDX-FileCopyrightText: 2025 SPDX Contributors
+# SPDX-FileCopyrightText: 2025-present SPDX Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import base64
+import datetime
 import json
 import logging
 import re
@@ -404,6 +405,7 @@ def postToGithub(message, encodedContent, filename):
 def removeSpecialCharacters(filename):
     return re.sub(r'[#%&{}<>*?/$!\'":@+`|=]', "-", filename)
 
+
 def parseXmlString(xmlString):
     """ View for generating a spdx license xml
     returns a dictionary with the xmlString license fields values
@@ -573,14 +575,88 @@ def check_new_licenses_and_rejected_licenses(inputLicenseText, urlType):
     return matches, issueUrl
 
 
+def _fetch_remote_license_info() -> tuple[str, str]:
+    """Download licenses.json from spdx.org. Return (licenseListVersion, releaseDate)."""
+    try:
+        resp = requests.get("https://spdx.org/licenses/licenses.json", timeout=30)
+        data = resp.json()
+        return str(data.get("licenseListVersion", "")), str(data.get("releaseDate", ""))
+    except Exception:
+        return "", ""
+
+
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Parse a version string into a tuple of integers."""
+    try:
+        return tuple(int(x) for x in v.split("."))
+    except Exception:
+        return (0,)
+
+
+def _write_license_db_metadata(
+    r_meta: "redis.StrictRedis[bytes]", version: str, release_date: str
+) -> None:
+    """Writes license list metadata to the database to track data freshness."""
+    r_meta.set(
+        "license_db_last_updated",
+        datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    )
+    if version:
+        r_meta.set("license_list_version", version)
+    if release_date:
+        r_meta.set("license_list_release_date", release_date)
+
+
+def _ensure_license_db_current(
+    r: "redis.StrictRedis[bytes]", r_meta: "redis.StrictRedis[bytes]"
+) -> None:
+    """Rebuild the license db when needed and keep metadata in sync."""
+    metadata_complete = (
+        r_meta.get("license_list_version")
+        and r_meta.get("license_list_release_date")
+        and r_meta.get("license_db_last_updated")
+    )
+
+    if not r.keys('*') or not metadata_complete:
+        remote_version, remote_release_date = _fetch_remote_license_info()
+        build_spdx_licenses()
+        _write_license_db_metadata(r_meta, remote_version, remote_release_date)
+        return
+
+    # Periodic upstream version check (at most once per week)
+    needs_check = False
+    last_checked_val = r_meta.get("license_db_last_checked")
+    if not last_checked_val:
+        needs_check = True
+    else:
+        try:
+            last_checked = datetime.datetime.fromisoformat(last_checked_val.decode())
+            if datetime.datetime.now(datetime.timezone.utc) - last_checked >= datetime.timedelta(weeks=1):
+                needs_check = True
+        except Exception:
+            needs_check = True
+
+    if needs_check:
+        r_meta.set(
+            "license_db_last_checked",
+            datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        )
+        remote_version, remote_release_date = _fetch_remote_license_info()
+        if remote_version:
+            stored_val = r_meta.get("license_list_version")
+            stored_version = stored_val.decode() if stored_val else ""
+            if _parse_version(remote_version) > _parse_version(stored_version):
+                build_spdx_licenses()
+                _write_license_db_metadata(r_meta, remote_version, remote_release_date)
+
+
 def check_spdx_license(licenseText):
     """Check the license text against the SPDX License List.
     """
     r = redis.StrictRedis(host=getRedisHost(), port=6379, db=0)
-    
-    # if redis is empty build the SPDX License List in the redis database
-    if r.keys('*') == []:
-        build_spdx_licenses()
+    r_meta = redis.StrictRedis(host=getRedisHost(), port=6379, db=1)
+    _ensure_license_db_current(r, r_meta)
+
     spdxLicenseIds = list(r.keys())
     spdxLicenseTexts = r.mget(spdxLicenseIds)
     licenseData = dict(list(zip(spdxLicenseIds, spdxLicenseTexts)))

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: 2017 Rohit Lodha
-# SPDX-FileCopyrightText: 2025 SPDX Contributors
+# SPDX-FileCopyrightText: 2025-present SPDX Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from django.shortcuts import render
@@ -13,15 +13,6 @@ from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
-from src.version import (
-    java_tools_version,
-    ntia_conformance_checker_version,
-    python_tools_version,
-    spdx_license_list_version,
-    spdx_license_matcher_version,
-    spdx_online_tools_version,
-    spdx_python_model_version,
-)
 
 import codecs
 import jpype
@@ -76,16 +67,7 @@ def about(request):
     """ View for about
     returns about.html template
     """
-    context_dict = {
-        "java_tools_version": java_tools_version,
-        "ntia_conformance_checker_version": ntia_conformance_checker_version,
-        "python_tools_version": python_tools_version,
-        "spdx_license_list_version": spdx_license_list_version,
-        "spdx_license_matcher_version": spdx_license_matcher_version,
-        "spdx_online_tools_version": spdx_online_tools_version,
-        "spdx_python_model_version": spdx_python_model_version,
-    }
-    return render(request, "app/about.html", context_dict)
+    return render(request, "app/about.html", {})
 
 
 def submitNewLicense(request):

--- a/src/src/settings.py
+++ b/src/src/settings.py
@@ -115,6 +115,7 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'social_django.context_processors.backends',
                 'social_django.context_processors.login_redirect',
+                'app.context_processors.tool_versions',
             ],
         },
     },

--- a/src/src/version.py
+++ b/src/src/version.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020-2025 SPDX Contributors
+# SPDX-FileCopyrightText: 2020-present SPDX Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """
@@ -7,6 +7,7 @@ the tools and online-tools repositories.
 """
 
 import json
+import platform
 from importlib.metadata import version
 from os.path import abspath, dirname, exists, join
 from re import search
@@ -62,6 +63,9 @@ def get_spdx_license_list_version() -> str:
 
 
 spdx_online_tools_version = "1.3.3"  # Update this when releasing new version
+
+jpype_version = version("jpype1")
+python_version = f"{platform.python_implementation()} {platform.python_version()}"
 
 java_tools_version = get_tools_version("tool.jar")
 ntia_conformance_checker_version = version("ntia-conformance-checker")

--- a/src/src/version.py
+++ b/src/src/version.py
@@ -6,15 +6,11 @@ Version file for displaying the respective version of
 the tools and online-tools repositories.
 """
 
-import json
 import platform
 from importlib.metadata import version
-from os.path import abspath, dirname, exists, join
+from os.path import abspath, dirname, join
 from re import search
 from subprocess import PIPE, run
-from typing import Any, Dict, cast
-
-from .settings import LICENSE_ROOT
 
 
 def get_tools_version(jar_name: str) -> str:
@@ -38,38 +34,13 @@ def get_tools_version(jar_name: str) -> str:
     return "Unknown"
 
 
-def get_spdx_license_list_version() -> str:
-    """
-    Determine license list version from a local copy of licenses.json if available.
-
-    Returns:
-        string -- SPDX License List version
-    """
-    paths = [
-        join(LICENSE_ROOT, "licenses.json"),
-    ]
-    for p in paths:
-        try:
-            if not exists(p):
-                continue
-            with open(p, "r", encoding="utf-8") as fh:
-                data = json.load(fh)
-            if isinstance(data, dict) and "licenseListVersion" in data:
-                data_dict = cast(Dict[str, Any], data)
-                return data_dict.get("licenseListVersion", "Unknown")
-        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-            continue
-    return "Unknown"
-
-
 spdx_online_tools_version = "1.3.3"  # Update this when releasing new version
 
 jpype_version = version("jpype1")
-python_version = f"{platform.python_implementation()} {platform.python_version()}"
+python_version = f"{platform.python_version()} ({platform.python_implementation()})"
 
 java_tools_version = get_tools_version("tool.jar")
 ntia_conformance_checker_version = version("ntia-conformance-checker")
 python_tools_version = version("spdx-tools")
-spdx_license_list_version = get_spdx_license_list_version()
 spdx_license_matcher_version = version("spdx-license-matcher")
 spdx_python_model_version = version("spdx-python-model")

--- a/src/src/version.py
+++ b/src/src/version.py
@@ -6,7 +6,6 @@ Version file for displaying the respective version of
 the tools and online-tools repositories.
 """
 
-import platform
 from importlib.metadata import version
 from os.path import abspath, dirname, join
 from re import search
@@ -35,8 +34,6 @@ def get_tools_version(jar_name: str) -> str:
 
 
 spdx_online_tools_version = "1.3.3"  # Update this when releasing new version
-
-jpype_version = version("jpype1")
 
 java_tools_version = get_tools_version("tool.jar")
 ntia_conformance_checker_version = version("ntia-conformance-checker")

--- a/src/src/version.py
+++ b/src/src/version.py
@@ -37,7 +37,6 @@ def get_tools_version(jar_name: str) -> str:
 spdx_online_tools_version = "1.3.3"  # Update this when releasing new version
 
 jpype_version = version("jpype1")
-python_version = f"{platform.python_version()} ({platform.python_implementation()})"
 
 java_tools_version = get_tools_version("tool.jar")
 ntia_conformance_checker_version = version("ntia-conformance-checker")


### PR DESCRIPTION
Add info about current system status. Version info to make it easier to identify issues. Links to tools encourage contributions to those projects.

- Each app (each tab): Add tool version info to bottom of page
  - Fix #620
- <s>About page: Add Java, JPype, and Python version info for easier debugging</s>
- About page: Update logic to check SPDX License List version from actual data in the Redis db.
  - This information allows us to rebuild the license list database when needed, and eventually...
  - Fix #629
  - Fix #632
- About page: Add @BassCoder2808 (GSoC 2023) to contributors list
- About page: Add "Get involved" block with links to GitHub issue, mailing list, and SPDX Implementers meeting

The layout is dynamic, will adjust to the width of window.

In wider window:

<img width="998" height="504" src="https://github.com/user-attachments/assets/df5cbaf9-7fcb-4e5b-921c-71bef1fb83a3" />

In narrower window:

<img width="548" height="403" src="https://github.com/user-attachments/assets/46f93908-e4e3-4e6b-8af3-8a4d977ed565" />
