### PR TITLE
Front page redesign - big buttons

### DIFF
--- a/src/app/static/css/dragdrop.css
+++ b/src/app/static/css/dragdrop.css
@@ -1,48 +1,57 @@
 #drop-area {
-    border: 2px dashed rgb(221, 221, 221);
-    border-radius: 20px;
-    width: 90%;
-    min-height: 220px;
-    font-family: sans-serif;
-    margin: 30px auto;
-    padding: 20px 0;
-    transition: box-shadow 0.2s;
-    overflow: hidden;
+    border: 2px dashed #a8c8d8;
+    border-radius: 10px;
+    width: 100%;
+    max-width: 600px;
+    min-height: 150px;
+    margin: 16px auto;
+    padding: 24px 20px 16px;
+    text-align: center;
+    background: #f4fafd;
+    transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
+    box-sizing: border-box;
+}
+#drop-area:focus-within {
+    border-color: #0097c4;
+    background: #eaf5fb;
 }
 #drop-area.highlight {
-    -webkit-box-shadow: 0 0 12px 1px grey inset;
-    -moz-box-shadow: 0 0 12px 1px grey inset;
-    box-shadow: 0 0 12px 1px grey inset;
+    border-color: #0097c4;
+    background: #e2f1f8;
+    box-shadow: 0 0 0 3px rgba(0,151,196,0.15);
 }
-.my-form {
-    margin-bottom: 10px;
+#drop-area h4,
+#drop-area p {
+    font-size: 0.92em;
+    color: #555;
+    margin-bottom: 14px;
 }
-.file-name{
-    margin-top:10px;
-}
-.success{
-    color:green;
-}
-.fail{
-    color:red;
+.file-name {
+    margin-top: 12px;
+    font-size: 0.88em;
+    color: #444;
+    min-height: 1.4em;
 }
 .button {
     display: inline-block;
-    padding: 8px;
-    background: #ccc;
+    padding: 7px 18px;
+    background: #0097c4;
+    color: #fff;
     cursor: pointer;
     border-radius: 5px;
-    border: 1px solid #ccc;
+    border: none;
+    font-size: 0.9em;
+    font-weight: 600;
+    transition: background 0.12s;
+    margin: 2px 4px;
 }
-.button:hover {
-    background: #ddd;
+.button:hover { background: #007aa0; color: #fff; }
+.button:focus { outline: 3px solid rgba(0,151,196,0.40); outline-offset: 2px; }
+.reset {
+    background: #b71c1c !important;
+    color: #fff;
 }
-.reset{
-    background: rgb(255, 62, 62) !important;
-}
-.reset:hover{
-    background: rgb(252, 98, 98) !important;
-}
-#file {
-    display: none;
-}
+.reset:hover { background: #8b1010 !important; }
+#file { display: none; }
+.success { color: #2e7d32; font-weight: 600; }
+.fail    { color: #c62828; font-weight: 600; }

--- a/src/app/static/css/editor/editor.css
+++ b/src/app/static/css/editor/editor.css
@@ -1,5 +1,5 @@
-.container-fluid{
-    margin-top:-60px;
+.editor-container {
+    margin-top: 0;
 }
 .CodeMirror{
     border:1px solid rgb(211, 211, 211);

--- a/src/app/static/css/starter-template.css
+++ b/src/app/static/css/starter-template.css
@@ -2,7 +2,7 @@ body {
   padding-top: 50px;
 }
 .starter-template {
-  padding: 40px 15px;
+  padding: 10px 15px;
   text-align: center;
 }
 .combo {

--- a/src/app/templates/app/about.html
+++ b/src/app/templates/app/about.html
@@ -84,6 +84,11 @@
     border-bottom: none;
   }
 
+  .about-section-title + p,
+  .about-note {
+    text-align: left;
+  }
+
   .about-note {
     font-size: 0.82em;
     color: #666;

--- a/src/app/templates/app/archive_requests.html
+++ b/src/app/templates/app/archive_requests.html
@@ -6,9 +6,9 @@
 
 <div id="messages" class="messages">
 </div>
-<p class ="lead"> {{ error }}</p>
+<p class ="lead">{{ error }}</p>
 <div class="panel panel-default">
-<div class="panel-heading"> <p class="lead">Archive License Requests List</p> </div>
+<div class="panel-heading"> <p class="lead">Archived License Requests List</p> </div>
 <div class="panel-body" style= "overflow: scroll;">
     <table id="requests_table" class="display dataTable">
       <thead>

--- a/src/app/templates/app/archive_requests.html
+++ b/src/app/templates/app/archive_requests.html
@@ -4,9 +4,8 @@
 
 <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.16/css/jquery.dataTables.css">
 
-<div id="messages" class="messages">
-</div>
-<p class ="lead">{{ error }}</p>
+<div id="messages" class="messages"></div>
+{% if error %}<p class="lead">{{ error }}</p>{% endif %}
 <div class="panel panel-default">
 <div class="panel-heading"> <p class="lead">Archived License Requests List</p> </div>
 <div class="panel-body" style= "overflow: scroll;">

--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -3,19 +3,16 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="An easy all-in-one portal to upload and parse SPDX documents for validation, conformance check, comparison, conversion and SPDX License List search.">
     <meta name="keywords" content="SPDX, SBOM, validation, conformance, license, licence, compare, convert, SPDX License List, open source, free software, online tools, software bill of materials, supply chain security, NTIA, CISA, compliance">
     <meta name="author" content="SPDX">
     <link rel="icon" type="image/png" href="{% static 'img/spdx-icon.png' %}">
-    <link rel="icon" type="image/x-icon" href="{% static 'img/favicon.ico' %}">
-    <link rel="shortcut icon" type="image/x-icon" href="{% static 'img/favicon.ico' %}">
-    <title >SPDX Online Tools {% block title %}{% endblock %}</title>
-    <link href="{% static 'css/bootstrap.min.css' %}" rel="stylesheet" type="text/css">
-    <link href="{% static 'css/starter-template.css' %}" rel="stylesheet" type="text/css">
+    <link rel="icon" href="{% static 'img/favicon.ico' %}">
+    <title>SPDX Online Tools {% block title %}{% endblock %}</title>
+    <link href="{% static 'css/bootstrap.min.css' %}" rel="stylesheet">
+    <link href="{% static 'css/starter-template.css' %}" rel="stylesheet">
     {% block head_block %}{% endblock %}
-	</head>
 <style>
 /* ── Navbar ──────────────────────────────────────────────── */
 .navbar-inverse {
@@ -221,6 +218,7 @@ div p {
   white-space: pre-wrap;
 }
 </style>
+  </head>
   <body>
 
     <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation" aria-label="Main navigation">

--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -81,12 +81,40 @@
 @media (max-width: 767px) {
     .nav-sep { display: none !important; }
     .navbar-inverse .navbar-nav > li > a {
-        padding: 10px 14px;
+        padding: 12px 16px;
         border-radius: 0;
     }
+    /* login button looks like a plain nav item inside collapsed menu */
     .nav-login > a {
-        margin: 6px 10px !important;
+        margin: 0 !important;
+        padding: 12px 16px !important;
+        border: none !important;
+        border-radius: 0 !important;
+        display: block !important;
+        line-height: inherit !important;
     }
+    .nav-login > a:hover,
+    .nav-login > a:focus {
+        background: rgba(255,255,255,0.12) !important;
+        border: none !important;
+    }
+    /* reduce top gap on inner pages */
+    .starter-template { padding-top: 14px; }
+    /* collapsed dropdown items: white text to match nav links */
+    .navbar-collapse .dropdown-menu > li > a {
+        color: rgba(255,255,255,0.88) !important;
+        padding: 8px 16px 8px 28px;
+    }
+    .navbar-collapse .dropdown-menu > li > a:hover,
+    .navbar-collapse .dropdown-menu > li > a:focus {
+        color: #fff !important;
+        background: rgba(255,255,255,0.12) !important;
+    }
+}
+/* on very small screens, hide "Online Tools" text to save brand space */
+@media (max-width: 380px) {
+    .brand-sep,
+    .brand-title { display: none !important; }
 }
 
 /* login / user account button */
@@ -105,14 +133,15 @@
     border-color: rgba(255,255,255,0.80) !important;
 }
 
-/* dropdowns */
+/* dropdowns — desktop floating menu */
 .dropdown-menu {
     font-size: 13px;
     border-radius: 4px;
     box-shadow: 0 3px 10px rgba(0,0,0,0.14);
 }
 .dropdown-menu > li > a { color: #0097c4; }
-.dropdown-menu > li > a:hover {
+.dropdown-menu > li > a:hover,
+.dropdown-menu > li > a:focus {
     background-color: #e6f5fb;
     color: #005f7d;
 }
@@ -134,12 +163,6 @@
 }
 .yellow-modal{
     background-color: #ffcc00;
-}
-.dropdown-menu {
-    font-size: 18px;
-}
-.dropdown-menu > li > a {
-    color: #0097C4;
 }
 .left-align {
   text-align: left;

--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -272,6 +272,7 @@ a:focus { outline: 2px solid #0097c4; outline-offset: 2px; border-radius: 2px; }
 .btn-space   { margin-right: 1em; }
 .error-log   { font-size: 0.6em; text-align: left; white-space: pre-wrap; }
 .messages    { margin-bottom: 8px; }
+.messages:empty { margin-bottom: 0; }
 
 /* tables */
 tbody tr  { cursor: pointer; }

--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -220,6 +220,7 @@ div p {
           <ul class="nav navbar-nav">
             <!-- Home -->
             <li><a href="/app/" id="homepage" title="Home" aria-label="Home"><span class="glyphicon glyphicon-home"></span></a></li>
+            <li class="nav-sep" role="separator" aria-hidden="true"><span></span></li>
             <!-- SBOM tools -->
             <li><a href="/app/validate/"     id="validatepage">Validate</a></li>
             <li><a href="/app/convert/"      id="convertpage">Convert</a></li>
@@ -243,15 +244,14 @@ div p {
             <li class="nav-sep" role="separator" aria-hidden="true"><span></span></li>
             <!-- About -->
             <li><a href="/app/about/" id="aboutpage">About</a></li>
-          </ul>
-
-          <ul class="nav navbar-nav navbar-right">
+            <li class="nav-sep" role="separator" aria-hidden="true"><span></span></li>
+            <!-- Account -->
             {% if user.is_authenticated %}
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
                 {{user}} <span class="caret"></span>
               </a>
-              <ul class="dropdown-menu dropdown-menu-right">
+              <ul class="dropdown-menu">
                 <li><a href="/app/logout/"><span class="glyphicon glyphicon-log-out"></span> Logout</a></li>
               </ul>
             </li>

--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -75,8 +75,35 @@
     background: rgba(255,255,255,0.28);
     margin: 15px 5px;
 }
+
+/* category labels */
+.nav-cat {
+    padding: 15px 1px 13px 7px !important;
+    pointer-events: none;
+    user-select: none;
+    white-space: nowrap;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.10em;
+    color: rgba(255,255,255,0.46);
+    line-height: 1;
+}
+
 @media (max-width: 767px) {
-    .nav-sep { display: none !important; }
+    .nav-sep {
+        display: block !important;
+        height: 0 !important;
+        padding: 0 !important;
+        margin: 4px 0 !important;
+        border-top: 1px solid rgba(255,255,255,0.15);
+    }
+    .nav-sep > span { display: none; }
+    .nav-cat {
+        display: block;
+        padding: 8px 16px 2px !important;
+        font-size: 9px;
+    }
     .navbar-inverse .navbar-nav > li > a {
         padding: 12px 16px;
         border-radius: 0;
@@ -243,23 +270,25 @@ div p {
             <li><a href="/app/" id="homepage" title="Home" aria-label="Home"><span class="glyphicon glyphicon-home"></span></a></li>
             <li class="nav-sep" role="separator" aria-hidden="true"><span></span></li>
             <!-- SBOM tools -->
+            <li class="nav-cat" aria-hidden="true">SBOM</li>
             <li><a href="/app/validate/"     id="validatepage">Validate</a></li>
             <li><a href="/app/convert/"      id="convertpage">Convert</a></li>
             <li><a href="/app/compare/"      id="comparepage">Compare</a></li>
             <li><a href="/app/ntia_checker/" id="checkerpage">Conformance</a></li>
-            <li><a href="/app/dots/"         id="dots">Visual Editor</a></li>
+            <li><a href="/app/dots/"         id="dots">Edit</a></li>
             <li class="nav-sep" role="separator" aria-hidden="true"><span></span></li>
             <!-- License tools -->
-            <li><a href="/app/check_license/" id="checklicensepage">License Check</a></li>
-            <li><a href="/app/xml_upload/"    id="license-xml-editor">XML Editor</a></li>
+            <li class="nav-cat" aria-hidden="true">License</li>
+            <li><a href="/app/check_license/" id="checklicensepage">Check</a></li>
+            <li><a href="/app/xml_upload/"    id="license-xml-editor">Edit</a></li>
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="licenserequest" role="button" aria-haspopup="true" aria-expanded="false">
-                License Requests <span class="caret"></span>
+                Request <span class="caret"></span>
               </a>
               <ul class="dropdown-menu">
                 <li><a href="/app/submit_new_license/" id="submitnewlicensepage">Submit New License</a></li>
-                <li><a href="/app/license_requests/"   id="licenserequestspage">License Requests</a></li>
-                <li><a href="/app/archive_requests/"   id="archiverequestspage">Archive Requests</a></li>
+                <li><a href="/app/license_requests/"   id="licenserequestspage">Request List</a></li>
+                <li><a href="/app/archive_requests/"   id="archiverequestspage">Request Archive</a></li>
               </ul>
             </li>
             <li class="nav-sep" role="separator" aria-hidden="true"><span></span></li>

--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="An easy all-in-one portal to upload and parse SPDX documents for validation, conformance check, comparison, conversion and SPDX License List search.">
+    <meta name="description" content="Validate, convert, compare, and edit SPDX documents. Identify an SPDX License ID from license text and submit new entries to the SPDX License List.">
     <meta name="keywords" content="SPDX, SBOM, validation, conformance, license, licence, compare, convert, SPDX License List, open source, free software, online tools, software bill of materials, supply chain security, NTIA, CISA, compliance">
     <meta name="author" content="SPDX">
     <link rel="icon" type="image/png" href="{% static 'img/spdx-icon.png' %}">
@@ -170,80 +170,124 @@
     color: #005f7d;
 }
 
-/* ── rest of page ─────────────────────────────────────────── */
+/* ── Content / shared components ─────────────────────────── */
+
+/* panels → card */
+.panel {
+    border: none;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+    margin-bottom: 24px;
+}
+.panel-default { border: none; }
 .panel-default > .panel-heading {
+    background: #f7f9fa;
+    border-bottom: 3px solid #0097c4;
+    border-radius: 8px 8px 0 0;
+    padding: 14px 20px;
+    color: #1a1a1a;
+}
+.panel-title,
+.panel-heading .lead,
+.panel-heading p.lead {
+    margin: 0;
+    font-size: 1.05em;
+    font-weight: 700;
+    color: #1a1a1a;
+    text-align: left;
+    line-height: 1.3;
+}
+.panel-body { padding: 20px 24px; }
+
+/* form controls */
+select,
+input[type="text"],
+input[type="email"],
+input[type="password"] {
+    border: 1px solid #c8d0d4;
+    border-radius: 5px;
+    padding: 6px 10px;
+    font-size: 0.94em;
+    transition: border-color 0.15s, box-shadow 0.15s;
+    outline: none;
+    background: #fff;
     color: #333;
-    background-color: #f5f5f5;
+    height: auto;
+}
+textarea {
+    border: 1px solid #c8d0d4;
+    border-radius: 5px;
+    padding: 8px 10px;
+    font-size: 0.94em;
+    transition: border-color 0.15s, box-shadow 0.15s;
+    outline: none;
+    background: #fff;
+    color: #333;
+    resize: vertical;
+}
+select:focus,
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="password"]:focus,
+textarea:focus {
     border-color: #0097c4;
+    box-shadow: 0 0 0 3px rgba(0,151,196,0.18);
 }
-.panel-default {
-    border-color: #0097c4;
-}
-.green-modal {
-    background-color: #04dd2f;
-}
-.red-modal{
-    background-color: #ea2300;
-}
-.yellow-modal{
-    background-color: #ffcc00;
-}
-.left-align {
-  text-align: left;
-}
-tbody tr {
-  cursor: pointer;
-}
-th {
-  text-align: center;
-}
-tbody tr:hover {
-  background-color: #ddd!important;
-}
-tbody tr:hover > .sorting_1 {
-  background-color: #ddd!important;
-}
-.ui-autocomplete {
-  background: white;
-}
-.ui-menu .ui-menu-item{
-  border-radius: 0px;
-  border: 1px solid #dcdcdc;
-}
-.ui-state-active {
-  background-color: gray;
-  font-weight: bold;
-  color:white;
-}
-.licenseField {
-  float: left;
-  margin-top: 1.5em;
-}
-.fieldName {
-  font-size: 1.4em;
-  color: #3197c4;
-}
-div p {
-  text-align: left;
-}
-.lead {
-  text-align: center;
-}
-.btn-info {
-  background-color: #3197c4;
-  border: none;
-}
-.btn-info:hover {
-  background-color: RoyalBlue;
-}
-.btn-space {
-  margin-right: 1em;
-}
-.error-log {
-  font-size: 0.6em;
-  text-align: left;
-  white-space: pre-wrap;
-}
+label.control-label { font-weight: 600; color: #444; font-size: 0.92em; }
+
+/* buttons */
+.btn { border-radius: 5px; font-weight: 600; transition: background 0.12s, box-shadow 0.12s; }
+.btn:focus,
+.btn:active:focus { outline: 3px solid rgba(0,151,196,0.35); outline-offset: 2px; }
+.btn-info { background-color: #0097c4; border: none; padding: 8px 20px; }
+.btn-info:hover,
+.btn-info:focus { background-color: #007aa0; color: #fff; }
+.btn-default { padding: 7px 16px; }
+.btn-default:focus { outline: 3px solid rgba(0,0,0,0.18); outline-offset: 2px; }
+
+/* modal */
+.modal-dialog { max-width: 860px; margin: 40px auto; }
+.modal-header { padding: 14px 20px; border-radius: 4px 4px 0 0; }
+.modal-footer { padding: 12px 20px; border-top: 1px solid #e9ecef; }
+.green-modal  { background: #2e7d32; }
+.red-modal    { background: #c62828; }
+.yellow-modal { background: #e65100; }
+.green-modal .modal-title,
+.red-modal   .modal-title,
+.yellow-modal .modal-title { color: #fff; }
+.green-modal .close,
+.red-modal   .close,
+.yellow-modal .close { color: #fff; opacity: 0.8; }
+
+/* alerts */
+.alert { border-radius: 6px; border: none; }
+.alert-danger  { background: #fff5f5; color: #8b1a1a; border-left: 4px solid #dc2626; }
+.alert-success { background: #f0faf0; color: #1a5c1a; border-left: 4px solid #2e7d32; }
+
+/* accessible focus for links */
+a:focus { outline: 2px solid #0097c4; outline-offset: 2px; border-radius: 2px; }
+
+/* utilities */
+.left-align  { text-align: left; }
+.btn-space   { margin-right: 1em; }
+.error-log   { font-size: 0.6em; text-align: left; white-space: pre-wrap; }
+.messages    { margin-bottom: 8px; }
+
+/* tables */
+tbody tr  { cursor: pointer; }
+th        { text-align: center; }
+tbody tr:hover              { background-color: #e8f4f8 !important; }
+tbody tr:hover > .sorting_1 { background-color: #e8f4f8 !important; }
+
+/* jQuery UI autocomplete */
+.ui-autocomplete { background: white; box-shadow: 0 3px 10px rgba(0,0,0,0.12); border-radius: 4px; }
+.ui-menu .ui-menu-item { border-radius: 0; border: 1px solid #e0e0e0; }
+.ui-state-active { background-color: #0097c4; font-weight: 600; color: white; }
+
+/* license tools */
+.licenseField { float: left; margin-top: 1.5em; }
+.fieldName    { font-size: 1.4em; color: #0097c4; }
+.btn-space    { margin-right: 1em; }
 </style>
   </head>
   <body>

--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -17,30 +17,107 @@
     {% block head_block %}{% endblock %}
 	</head>
 <style>
+/* ── Navbar ──────────────────────────────────────────────── */
 .navbar-inverse {
     background-color: #0097c4;
-    border-color: #0097c4;
+    border: none;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.18);
+    min-height: 48px;
 }
-.navbar-inverse .navbar-nav > li > a:hover, .navbar-inverse .navbar-nav > li > a:focus {
-    color: #fff;
-    background-color: transparent;
-    border-bottom: 3px solid;
+.navbar-brand {
+    display: flex !important;
+    align-items: center;
+    padding: 8px 12px;
+    height: 48px;
+    color: #fff !important;
 }
+.navbar-brand img { display: block; }
+.brand-sep {
+    display: inline-block;
+    width: 1px;
+    height: 16px;
+    background: rgba(255,255,255,0.38);
+    margin: 0 9px;
+    flex-shrink: 0;
+}
+.brand-title {
+    font-size: 0.86em;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    opacity: 0.88;
+    white-space: nowrap;
+}
+.navbar-inverse .navbar-brand:hover,
+.navbar-inverse .navbar-brand:focus { background: transparent; }
+
 .navbar-inverse .navbar-nav > li > a {
+    color: rgba(255,255,255,0.90);
+    font-size: 14px;
+    padding: 14px 9px;
+    border-radius: 3px;
+    transition: background 0.1s, color 0.1s;
+}
+.navbar-inverse .navbar-nav > li > a:hover,
+.navbar-inverse .navbar-nav > li > a:focus {
     color: #fff;
+    background: rgba(255,255,255,0.12);
 }
-.navbar-inverse .navbar-brand:hover, .navbar-inverse .navbar-brand:focus {
-    color: black;
-    background-color: transparent;
-}
-.navbar-inverse .navbar-brand {
+.navbar-inverse .navbar-nav .linkactive > a,
+.navbar-inverse .navbar-nav > li > a.linkactive {
     color: #fff;
+    background: rgba(0,0,0,0.14);
+    font-weight: 600;
 }
-.navbar-inverse .navbar-nav .linkactive {
-    color: black;
-    background-color: transparent;
-    border-bottom: 3px solid;
+
+/* category separators */
+.nav-sep { padding: 0 !important; pointer-events: none; }
+.nav-sep > span {
+    display: block;
+    width: 1px;
+    height: 18px;
+    background: rgba(255,255,255,0.28);
+    margin: 15px 5px;
 }
+@media (max-width: 767px) {
+    .nav-sep { display: none !important; }
+    .navbar-inverse .navbar-nav > li > a {
+        padding: 10px 14px;
+        border-radius: 0;
+    }
+    .nav-login > a {
+        margin: 6px 10px !important;
+    }
+}
+
+/* login / user account button */
+.nav-login > a {
+    display: inline-block;
+    margin: 9px 4px 9px 8px !important;
+    padding: 4px 12px !important;
+    border: 1px solid rgba(255,255,255,0.48) !important;
+    border-radius: 4px !important;
+    line-height: 1.6 !important;
+    font-size: 14px !important;
+}
+.nav-login > a:hover,
+.nav-login > a:focus {
+    background: rgba(255,255,255,0.13) !important;
+    border-color: rgba(255,255,255,0.80) !important;
+}
+
+/* dropdowns */
+.dropdown-menu {
+    font-size: 13px;
+    border-radius: 4px;
+    box-shadow: 0 3px 10px rgba(0,0,0,0.14);
+}
+.dropdown-menu > li > a { color: #0097c4; }
+.dropdown-menu > li > a:hover {
+    background-color: #e6f5fb;
+    color: #005f7d;
+}
+
+/* ── rest of page ─────────────────────────────────────────── */
 .panel-default > .panel-heading {
     color: #333;
     background-color: #f5f5f5;
@@ -123,69 +200,70 @@ div p {
 </style>
   <body>
 
-    <nav class="navbar navbar-inverse navbar-fixed-top">
-      <div class="navbar-header">
-        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-          <span class="sr-only">Toggle navigation</span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-        </button>
-        <a class="navbar-brand navbar-left" id="indexpage" href="/app/">SPDX Online Tools</a>
-      </div>
-      <div id="navbar" class="collapse navbar-collapse" >
-        <ul class="nav navbar-nav" style="font-size: 12px;">
-            <li><a href="/app/about/" id="aboutpage">About</a></li>
-            <li><a href="/app/validate/" id="validatepage">Validate</a></li>
-            <li><a href="/app/compare/" id="comparepage">Compare</a></li>
-            <li><a href="/app/convert/" id="convertpage">Convert</a></li>
-            <li><a href="/app/check_license/" id="checklicensepage">License Check</a></li>
-            <!-- <li><a href="/app/diff/" id="licensediffpage">License Diff</a></li> -->
-            <li><a href="/app/xml_upload/" id="license-xml-editor">License XML Editor</a></li>
-            <li><a href="/app/ntia_checker/" id="checkerpage">Conformance Checker</a></li>
-            <li><a href="/app/dots/" id="dots">Visual Editor</a></li>
-            <li>
-              <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="licenserequest">License Requests
-                <span class="caret"></span>
-              </a>
-              <ul class="dropdown-menu" style="font-size: 12px;">
-                <li><a href="/app/submit_new_license/" id="submitnewlicensepage">Submit New License</a></li>
-                <li><a href="/app/license_requests/" id="licenserequestspage">License Requests</a></li>
-                <li><a href="/app/archive_requests/" id="archiverequestspage">Archive Requests</a></li>
-              </ul>
-            </li>
-            <!-- Remove the namespace menu until we decide on the specific functionality
-			<li>
-              <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="licensenamespace">License namespaces
-                <span class="caret"></span>
-              </a>
-              <ul class="dropdown-menu" style="font-size: 12px;">
-                <li><a href="/app/submit_new_license_namespace/" id="submitnewlicensenamespacepage">Submit namespace</a></li>
-                <li><a href="/app/license_namespace_requests/" id="licensenamespacerequests">License namespaces</a></li>
-                <li><a href="/app/archive_namespace_requests/" id="archivenamespacerequestspage">Archived namespaces</a></li>
-              </ul>
-            </li> 
-			-->
-		  </ul>
-		  <ul class="nav navbar-nav navbar-right" style="margin-right: 25px;font-size: 12px;">
-        <div class="navbar-left" style="margin-top: 14px; ">
-          <a href="https://spdx.dev/" id="spdxhome" target="_blank">
-            <img class="starting-logo dark-version skip-lazy" width="80" height="20" alt="Software Package Data Exchange (SPDX)" src="{% static 'img/spdx-white.svg' %}">
+    <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation" aria-label="Main navigation">
+      <div class="container-fluid">
+        <div class="navbar-header">
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class="navbar-brand" href="/app/" id="indexpage">
+            <img src="{% static 'img/spdx-white.svg' %}" width="62" height="16" alt="SPDX">
+            <span class="brand-sep" aria-hidden="true"></span>
+            <span class="brand-title">Online Tools</span>
           </a>
         </div>
-        {% if user.is_authenticated %}
-        <!--<li><a href="/app/profile/" id="profilepage">Profile</a></li>-->
-        <li><a class="dropdown-toggle" data-toggle="dropdown" href="#">{{user}} <span class="caret"></span></a>
-          <ul class="dropdown-menu">
-            <li><a href="/app/logout/"><span class="glyphicon glyphicon-log-out"></span> Logout</a></li>
+
+        <div id="navbar" class="collapse navbar-collapse">
+          <ul class="nav navbar-nav">
+            <!-- Home -->
+            <li><a href="/app/" id="homepage" title="Home" aria-label="Home"><span class="glyphicon glyphicon-home"></span></a></li>
+            <!-- SBOM tools -->
+            <li><a href="/app/validate/"     id="validatepage">Validate</a></li>
+            <li><a href="/app/convert/"      id="convertpage">Convert</a></li>
+            <li><a href="/app/compare/"      id="comparepage">Compare</a></li>
+            <li><a href="/app/ntia_checker/" id="checkerpage">Conformance</a></li>
+            <li><a href="/app/dots/"         id="dots">Visual Editor</a></li>
+            <li class="nav-sep" role="separator" aria-hidden="true"><span></span></li>
+            <!-- License tools -->
+            <li><a href="/app/check_license/" id="checklicensepage">License Check</a></li>
+            <li><a href="/app/xml_upload/"    id="license-xml-editor">XML Editor</a></li>
+            <li class="dropdown">
+              <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="licenserequest" role="button" aria-haspopup="true" aria-expanded="false">
+                License Requests <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu">
+                <li><a href="/app/submit_new_license/" id="submitnewlicensepage">Submit New License</a></li>
+                <li><a href="/app/license_requests/"   id="licenserequestspage">License Requests</a></li>
+                <li><a href="/app/archive_requests/"   id="archiverequestspage">Archive Requests</a></li>
+              </ul>
+            </li>
+            <li class="nav-sep" role="separator" aria-hidden="true"><span></span></li>
+            <!-- About -->
+            <li><a href="/app/about/" id="aboutpage">About</a></li>
           </ul>
-        </li>
-        {% else %}
-        <li><a href="/app/login/" id="loginpage"><span class="glyphicon glyphicon-log-in"></span> Login</a></li>
-        {% endif %}
-      </ul>
-    </div><!--/.nav-collapse -->
-  </nav>
+
+          <ul class="nav navbar-nav navbar-right">
+            {% if user.is_authenticated %}
+            <li class="dropdown">
+              <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+                {{user}} <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu dropdown-menu-right">
+                <li><a href="/app/logout/"><span class="glyphicon glyphicon-log-out"></span> Logout</a></li>
+              </ul>
+            </li>
+            {% else %}
+            <li class="nav-login">
+              <a href="/app/login/" id="loginpage"><span class="glyphicon glyphicon-log-in"></span> Login</a>
+            </li>
+            {% endif %}
+          </ul>
+        </div>
+      </div>
+    </nav>
 
   <div class="container body1">
 

--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -82,11 +82,11 @@
     pointer-events: none;
     user-select: none;
     white-space: nowrap;
-    font-size: 10px;
+    font-size: 11px;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.10em;
-    color: rgba(255,255,255,0.46);
+    color: rgba(255,255,255,0.72);
     line-height: 1;
 }
 
@@ -102,7 +102,7 @@
     .nav-cat {
         display: block;
         padding: 8px 16px 2px !important;
-        font-size: 9px;
+        font-size: 10px;
     }
     .navbar-inverse .navbar-nav > li > a {
         padding: 12px 16px;

--- a/src/app/templates/app/check_license.html
+++ b/src/app/templates/app/check_license.html
@@ -1,9 +1,8 @@
 {% extends 'app/base.html' %}
 {% load static %}
 {% block body1 %}
-<div id="messages" class="messages">
-</div>
-<p class="lead">{{ error }}</p>
+<div id="messages" class="messages"></div>
+{% if error %}<p class="lead">{{ error }}</p>{% endif %}
 <div class="panel panel-default">
   <div class="panel-heading">
     <p class="lead">Check license</p>

--- a/src/app/templates/app/compare.html
+++ b/src/app/templates/app/compare.html
@@ -6,10 +6,9 @@
 {% endblock %}
 
 {% block body1 %}
-<div id="messages" class="messages">
-</div>
-<p class ="lead"> {{ medialink }}</p>
-<p class ="lead"> {{ error }}</p>
+<div id="messages" class="messages"></div>
+{% if medialink %}<p class="lead">{{ medialink }}</p>{% endif %}
+{% if error %}<p class="lead">{{ error }}</p>{% endif %}
 <div class="panel panel-default">
 <div class="panel-heading">
 	<p class="lead">Compare SPDX 2.X documents</p>

--- a/src/app/templates/app/convert.html
+++ b/src/app/templates/app/convert.html
@@ -6,10 +6,9 @@
 {% endblock %}
 
 {% block body1 %}
-<div id="messages" class="messages">
-</div>
-<p class ="lead">{{ medialink }}</p>
-<p class ="lead">{{ error }}</p>
+<div id="messages" class="messages"></div>
+{% if medialink %}<p class="lead">{{ medialink }}</p>{% endif %}
+{% if error %}<p class="lead">{{ error }}</p>{% endif %}
 <div class="panel panel-default">
 <div class="panel-heading">
     <p class="lead">Convert to other SPDX format</p>

--- a/src/app/templates/app/editor.html
+++ b/src/app/templates/app/editor.html
@@ -9,6 +9,7 @@
     <link href="{% static 'css/editor/foldgutter.css' %}" rel="stylesheet" type="text/css">
     <link href="{% static 'css/editor/treeview.css' %}" rel="stylesheet" type="text/css">
     <link href="{% static 'css/editor/diffview.css' %}" rel="stylesheet" type="text/css">
+    <style>.starter-template { padding: 0; }</style>
 {% endblock %}
 
 {% block body1 %}
@@ -16,7 +17,7 @@
 {% endblock %}
 
 {% block body2 %}
-    <div class="container-fluid">
+    <div class="container-fluid editor-container">
         <input type="hidden" id="xmlText" value="{{xml_text}}">
         <ul class="nav nav-tabs">
             <li class="active"><a href="#text" id="tabTextEditor">Text editor</a></li>

--- a/src/app/templates/app/index.html
+++ b/src/app/templates/app/index.html
@@ -38,7 +38,6 @@
 }
 .cat-sbom   { color: #00728e; }
 .cat-lic    { color: #2e7d32; }
-.cat-about  { color: #5d5d5d; }
 
 .tool-grid {
     display: grid;
@@ -93,8 +92,6 @@
 .btn-lic-xml     { background-color: #2e7d32; }
 .btn-lic-req     { background-color: #1b5e20; }
 
-/* About */
-.btn-about       { background-color: #616161; }
 
 .tool-icon {
     font-size: 2.0em;
@@ -131,13 +128,50 @@
     .tool-btn { min-height: 60px; padding: 12px 10px 22px 12px; }
     .home-tagline { font-size: 1.05em; }
 }
+.home-footer {
+    margin-top: 28px;
+    padding-top: 16px;
+    border-top: 1px solid #dde5e8;
+    color: #666;
+    font-size: 0.88em;
+    line-height: 1.6;
+}
+.home-footer p { margin: 0 0 6px; }
+.home-footer a { color: #0097c4; }
+.home-footer-links {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+.home-footer-links a {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    color: #555;
+    text-decoration: none;
+    transition: color 0.1s;
+}
+.home-footer-links a:hover,
+.home-footer-links a:focus { color: #0097c4; }
+.home-footer-links svg { display: block; fill: currentColor; }
+.home-footer-bottom {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+.home-footer-copy {
+    margin: 0;
+    font-size: 0.92em;
+    color: #999;
+}
 </style>
 {% endblock %}
 
 {% block body1 %}
 <div class="home-wrap">
-
-    <p class="home-tagline">Validate, convert, compare, and check SPDX documents and licenses.</p>
 
     <!-- SBOM Tools -->
     <div class="cat-section">
@@ -203,19 +237,23 @@
         </div>
     </div>
 
-    <!-- About -->
-    <div class="cat-section">
-        <div class="cat-label cat-about">About</div>
-        <div class="tool-grid">
-
-            <a href="/app/about/" class="tool-btn btn-about">
-                <span class="tool-icon glyphicon glyphicon-info-sign"></span>
-                <span class="tool-name">About SPDX Online Tools</span>
-                <span class="tool-versions"></span>
-            </a>
-
+    <!-- Footer -->
+    <footer class="home-footer">
+        <div class="home-footer-bottom">
+            <div class="home-footer-links">
+                <a href="https://github.com/spdx/spdx-online-tools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                    <svg height="15" width="15" viewBox="0 0 16 16" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+                    GitHub
+                </a>
+                <a href="https://lists.spdx.org/g/spdx-implementers" target="_blank" rel="noopener">
+                    <span class="glyphicon glyphicon-envelope" aria-hidden="true"></span>
+                    Mailing list
+                </a>
+                <a href="/app/about/">About</a>
+            </div>
+            <p class="home-footer-copy">&copy; {% now "Y" %} SPDX contributors &middot; <a href="https://spdx.org/licenses/Apache-2.0.html" target="_blank" rel="noopener">Apache-2.0</a></p>
         </div>
-    </div>
+    </footer>
 
 </div>
 {% endblock %}

--- a/src/app/templates/app/index.html
+++ b/src/app/templates/app/index.html
@@ -3,16 +3,23 @@
 
 {% block head_block %}
 <style>
+.starter-template {
+    padding-top: 6px;
+}
 .home-wrap {
     max-width: 900px;
     margin: 0 auto;
-    padding: 16px 12px 40px;
+    padding: 4px 12px 40px;
 }
 .home-tagline {
-    color: #0097c4;
-    font-weight: 600;
-    margin-bottom: 28px;
-    font-size: 1.0em;
+    color: #3d3d3d;
+    font-weight: 400;
+    font-size: 1.15em;
+    margin: 0 0 28px 2px;
+    line-height: 1.5;
+    letter-spacing: 0.01em;
+    border-left: 3px solid #0097c4;
+    padding-left: 12px;
 }
 .cat-section {
     margin-bottom: 20px;
@@ -128,9 +135,7 @@
 
     <!-- SBOM Tools -->
     <div class="cat-section">
-        <div class="cat-label cat-sbom">
-            <span class="glyphicon glyphicon-hdd"></span> SBOM Tools
-        </div>
+        <div class="cat-label cat-sbom">SBOM Tools</div>
         <div class="tool-grid">
 
             <a href="/app/validate/" class="tool-btn btn-validate">
@@ -168,9 +173,7 @@
 
     <!-- License Tools -->
     <div class="cat-section">
-        <div class="cat-label cat-lic">
-            <span class="glyphicon glyphicon-scale"></span> License Tools
-        </div>
+        <div class="cat-label cat-lic">License Tools</div>
         <div class="tool-grid">
 
             <a href="/app/check_license/" class="tool-btn btn-lic-check">
@@ -196,9 +199,7 @@
 
     <!-- About -->
     <div class="cat-section">
-        <div class="cat-label cat-about">
-            <span class="glyphicon glyphicon-info-sign"></span> About
-        </div>
+        <div class="cat-label cat-about">About</div>
         <div class="tool-grid">
 
             <a href="/app/about/" class="tool-btn btn-about">

--- a/src/app/templates/app/index.html
+++ b/src/app/templates/app/index.html
@@ -121,9 +121,15 @@
 }
 
 @media (max-width: 767px) {
-    .tool-btn { min-height: 72px; padding: 12px 12px 24px 14px; }
-    .tool-icon { font-size: 1.65em; }
-    .tool-name { font-size: 0.92em; }
+    .home-wrap { padding-left: 10px; padding-right: 10px; }
+    .tool-grid { gap: 8px; }
+    .tool-btn { min-height: 72px; padding: 12px 10px 24px 12px; gap: 10px; }
+    .tool-icon { font-size: 1.6em; }
+    .tool-name { font-size: 0.91em; }
+}
+@media (max-width: 479px) {
+    .tool-btn { min-height: 60px; padding: 12px 10px 22px 12px; }
+    .home-tagline { font-size: 1.05em; }
 }
 </style>
 {% endblock %}

--- a/src/app/templates/app/index.html
+++ b/src/app/templates/app/index.html
@@ -158,7 +158,7 @@
             </a>
 
             <a href="/app/dots/" class="tool-btn btn-visual">
-                <span class="tool-icon glyphicon glyphicon-th-large"></span>
+                <span class="tool-icon glyphicon glyphicon-hand-up"></span>
                 <span class="tool-name">Visual Editor</span>
                 <span class="tool-versions">SPDX 3</span>
             </a>

--- a/src/app/templates/app/index.html
+++ b/src/app/templates/app/index.html
@@ -1,23 +1,214 @@
 {% extends 'app/base.html' %}
 {% load static %}
+
+{% block head_block %}
+<style>
+.home-wrap {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 16px 12px 40px;
+}
+.home-tagline {
+    color: #0097c4;
+    font-weight: 600;
+    margin-bottom: 28px;
+    font-size: 1.0em;
+}
+.cat-section {
+    margin-bottom: 20px;
+}
+.cat-label {
+    font-size: 0.78em;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.10em;
+    margin: 0 0 8px 4px;
+    padding-bottom: 4px;
+    border-bottom: 2px solid currentColor;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+.cat-sbom   { color: #00728e; }
+.cat-lic    { color: #2e7d32; }
+.cat-about  { color: #5d5d5d; }
+
+.tool-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 10px;
+}
+@media (max-width: 767px) {
+    .tool-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 479px) {
+    .tool-grid { grid-template-columns: 1fr; }
+}
+
+.tool-btn {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 16px 14px 28px 16px;
+    border-radius: 10px;
+    text-decoration: none;
+    color: #fff;
+    min-height: 88px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.18);
+    transition: transform 0.08s ease, box-shadow 0.08s ease, filter 0.08s ease;
+    cursor: pointer;
+    border: none;
+    outline: none;
+}
+.tool-btn:hover, .tool-btn:focus {
+    text-decoration: none;
+    color: #fff;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(0,0,0,0.24);
+    filter: brightness(1.08);
+}
+.tool-btn:active {
+    transform: translateY(0);
+    box-shadow: 0 2px 5px rgba(0,0,0,0.16);
+    filter: brightness(0.94);
+}
+
+/* SBOM palette — shades of SPDX blue */
+.btn-validate    { background-color: #0097c4; }
+.btn-convert     { background-color: #007aa0; }
+.btn-compare     { background-color: #005f7d; }
+.btn-conformance { background-color: #00495e; }
+.btn-visual      { background-color: #016b91; }
+
+/* License palette — greens */
+.btn-lic-check   { background-color: #388e3c; }
+.btn-lic-xml     { background-color: #2e7d32; }
+.btn-lic-req     { background-color: #1b5e20; }
+
+/* About */
+.btn-about       { background-color: #616161; }
+
+.tool-icon {
+    font-size: 2.0em;
+    flex-shrink: 0;
+    opacity: 0.90;
+    width: 1.2em;
+    text-align: center;
+}
+.tool-name {
+    font-size: 0.98em;
+    font-weight: 600;
+    line-height: 1.3;
+    flex: 1;
+}
+.tool-versions {
+    position: absolute;
+    bottom: 7px;
+    right: 10px;
+    font-size: 0.63em;
+    font-weight: 700;
+    opacity: 0.72;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+@media (max-width: 767px) {
+    .tool-btn { min-height: 72px; padding: 12px 12px 24px 14px; }
+    .tool-icon { font-size: 1.65em; }
+    .tool-name { font-size: 0.92em; }
+}
+</style>
+{% endblock %}
+
 {% block body1 %}
-<div class="container">
-    <div class="row text-center">
-        <div class="col-sm-12">
-            <img src="{% static 'img/spdx.png' %}" alt="SPDX logo" class="img-responsive center-block" />
+<div class="home-wrap">
+
+    <p class="home-tagline">Validate, convert, compare, and check SPDX documents and licenses.</p>
+
+    <!-- SBOM Tools -->
+    <div class="cat-section">
+        <div class="cat-label cat-sbom">
+            <span class="glyphicon glyphicon-hdd"></span> SBOM Tools
+        </div>
+        <div class="tool-grid">
+
+            <a href="/app/validate/" class="tool-btn btn-validate">
+                <span class="tool-icon glyphicon glyphicon-ok-sign"></span>
+                <span class="tool-name">Validate</span>
+                <span class="tool-versions">SPDX 2 &middot; 3</span>
+            </a>
+
+            <a href="/app/convert/" class="tool-btn btn-convert">
+                <span class="tool-icon glyphicon glyphicon-transfer"></span>
+                <span class="tool-name">Convert</span>
+                <span class="tool-versions">SPDX 2 &rarr; 2 / 3</span>
+            </a>
+
+            <a href="/app/compare/" class="tool-btn btn-compare">
+                <span class="tool-icon glyphicon glyphicon-random"></span>
+                <span class="tool-name">Compare</span>
+                <span class="tool-versions">SPDX 2</span>
+            </a>
+
+            <a href="/app/ntia_checker/" class="tool-btn btn-conformance">
+                <span class="tool-icon glyphicon glyphicon-list-alt"></span>
+                <span class="tool-name">Conformance Check</span>
+                <span class="tool-versions">SPDX 2 &middot; 3</span>
+            </a>
+
+            <a href="/app/dots/" class="tool-btn btn-visual">
+                <span class="tool-icon glyphicon glyphicon-edit"></span>
+                <span class="tool-name">Visual Editor</span>
+                <span class="tool-versions">SPDX 3</span>
+            </a>
+
         </div>
     </div>
-    <div class="row text-center">
-        <div class="col-sm-12">
-            <p class="lead" style="color:#0097c4;">
-                <strong>SPDX Online Tools -
-                    an all-in-one portal to upload and parse SPDX documents
-                    for validation, conformance check, comparison, conversion
-                    and SPDX License List search.</strong>
-            </p>
-            <p class="lead">Select the tool by clicking on the tool name on
-                the menu bar.</p>
+
+    <!-- License Tools -->
+    <div class="cat-section">
+        <div class="cat-label cat-lic">
+            <span class="glyphicon glyphicon-scale"></span> License Tools
+        </div>
+        <div class="tool-grid">
+
+            <a href="/app/check_license/" class="tool-btn btn-lic-check">
+                <span class="tool-icon glyphicon glyphicon-search"></span>
+                <span class="tool-name">License Check</span>
+                <span class="tool-versions">SPDX License List</span>
+            </a>
+
+            <a href="/app/xml_upload/" class="tool-btn btn-lic-xml">
+                <span class="tool-icon glyphicon glyphicon-text-background"></span>
+                <span class="tool-name">License XML Editor</span>
+                <span class="tool-versions"></span>
+            </a>
+
+            <a href="/app/submit_new_license/" class="tool-btn btn-lic-req">
+                <span class="tool-icon glyphicon glyphicon-send"></span>
+                <span class="tool-name">License Requests</span>
+                <span class="tool-versions"></span>
+            </a>
+
         </div>
     </div>
+
+    <!-- About -->
+    <div class="cat-section">
+        <div class="cat-label cat-about">
+            <span class="glyphicon glyphicon-info-sign"></span> About
+        </div>
+        <div class="tool-grid">
+
+            <a href="/app/about/" class="tool-btn btn-about">
+                <span class="tool-icon glyphicon glyphicon-info-sign"></span>
+                <span class="tool-name">About SPDX Online Tools</span>
+                <span class="tool-versions"></span>
+            </a>
+
+        </div>
+    </div>
+
 </div>
 {% endblock %}

--- a/src/app/templates/app/index.html
+++ b/src/app/templates/app/index.html
@@ -104,7 +104,7 @@
     text-align: center;
 }
 .tool-name {
-    font-size: 0.98em;
+    font-size: 1.08em;
     font-weight: 600;
     line-height: 1.3;
     flex: 1;

--- a/src/app/templates/app/index.html
+++ b/src/app/templates/app/index.html
@@ -146,7 +146,7 @@
             </a>
 
             <a href="/app/compare/" class="tool-btn btn-compare">
-                <span class="tool-icon glyphicon glyphicon-random"></span>
+                <span class="tool-icon glyphicon glyphicon-adjust"></span>
                 <span class="tool-name">Compare</span>
                 <span class="tool-versions">SPDX 2</span>
             </a>
@@ -158,7 +158,7 @@
             </a>
 
             <a href="/app/dots/" class="tool-btn btn-visual">
-                <span class="tool-icon glyphicon glyphicon-edit"></span>
+                <span class="tool-icon glyphicon glyphicon-th-large"></span>
                 <span class="tool-name">Visual Editor</span>
                 <span class="tool-versions">SPDX 3</span>
             </a>
@@ -180,7 +180,7 @@
             </a>
 
             <a href="/app/xml_upload/" class="tool-btn btn-lic-xml">
-                <span class="tool-icon glyphicon glyphicon-text-background"></span>
+                <span class="tool-icon glyphicon glyphicon-pencil"></span>
                 <span class="tool-name">License XML Editor</span>
                 <span class="tool-versions"></span>
             </a>

--- a/src/app/templates/app/index.html
+++ b/src/app/templates/app/index.html
@@ -4,7 +4,7 @@
 {% block head_block %}
 <style>
 .starter-template {
-    padding-top: 6px;
+    padding-top: 10px;
 }
 .home-wrap {
     max-width: 900px;

--- a/src/app/templates/app/license_requests.html
+++ b/src/app/templates/app/license_requests.html
@@ -4,9 +4,8 @@
 
 <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.16/css/jquery.dataTables.css">
 
-<div id="messages" class="messages">
-</div>
-<p class ="lead"> {{ error }}</p>
+<div id="messages" class="messages"></div>
+{% if error %}<p class="lead">{{ error }}</p>{% endif %}
 <div class="panel panel-default">
 <div class="panel-heading"> <p class="lead">License Requests List</p> </div>
 <div class="panel-body" style="overflow: scroll;">

--- a/src/app/templates/app/ntia_conformance_checker.html
+++ b/src/app/templates/app/ntia_conformance_checker.html
@@ -138,9 +138,8 @@
 {% endblock %}
 
 {% block body1 %}
-<div id="messages" class="messages">
-</div>
-<p class ="lead">{{ error }}</p>
+<div id="messages" class="messages"></div>
+{% if error %}<p class="lead">{{ error }}</p>{% endif %}
 <div class="panel panel-default">
 <div class="panel-heading">
   <p class="lead">Check conformance</p>

--- a/src/app/templates/app/submit_new_license.html
+++ b/src/app/templates/app/submit_new_license.html
@@ -4,14 +4,9 @@
 {% block head_block %}
     <link href="{% static 'css/editor/editor.css' %}" rel="stylesheet" type="text/css">
     <link href="{% static 'css/editor/diffview.css' %}" rel="stylesheet" type="text/css">
-    <style>
-      .body1 {
-        display: none;
-      }
-    </style>
 {% endblock %}
 
-{% block body2 %}
+{% block body1 %}
 {% include "app/modal.html" %}
 <form style="display:none" id="form">
   {% csrf_token %}
@@ -57,7 +52,6 @@
 {% else %}
 <p id="githubLogin" hidden>False</p>
 {% endif %}
-</div>
 <div class="panel panel-default">
 <div class="panel-heading">
   <p class="lead">Submit a new license to the SPDX License List</p>
@@ -175,7 +169,6 @@ Once you have submitted a license, please follow the <a href="https://github.com
 </form>
 </div>
 </div>
-{% include "app/modal.html" %}
 {% endblock %}
 
 {% block script_block %}

--- a/src/app/templates/app/validate.html
+++ b/src/app/templates/app/validate.html
@@ -6,9 +6,8 @@
 {% endblock %}
 
 {% block body1 %}
-<div id="messages" class="messages">
-</div>
-<p class ="lead"> {{ error }}</p>
+<div id="messages" class="messages"></div>
+{% if error %}<p class="lead">{{ error }}</p>{% endif %}
 <div class="panel panel-default">
 <div class="panel-heading">
   <p class="lead">Validate SPDX document</p>

--- a/src/app/templates/app/xml_upload.html
+++ b/src/app/templates/app/xml_upload.html
@@ -7,8 +7,8 @@
 {% endblock %}
 
 {% block body1 %}
-<div id="messages" class="messages"> </div>
-<p class ="lead"> {{ error }} </p>
+<div id="messages" class="messages"></div>
+{% if error %}<p class="lead">{{ error }}</p>{% endif %}
 
 <div class="panel panel-default">
   <div class="panel-heading">


### PR DESCRIPTION
- Make the front page more functional by providing buttons to apps immediately
- Buttons will flow and stack by the screen width
- Redesign the top pane, order the tab logically by category (SBOM tools, license tools, about)
- Make sure all the apps (in each tab) are being displayed in a consistent way

On wider screen:

<img width="1103" height="520" src="https://github.com/user-attachments/assets/93a19334-4e82-4edd-aa9b-ecdd186b1a1c" />


On narrower screen:

<img width="490" height="626" src="https://github.com/user-attachments/assets/87c6ce9b-f78f-4968-a979-2ae84a49056c" />


