### PR TITLE
ntia: Fix error popup

### DIFF
--- a/src/app/templates/app/ntia_conformance_checker.html
+++ b/src/app/templates/app/ntia_conformance_checker.html
@@ -258,7 +258,7 @@ function checkform() {
 
   function renderConformanceData(data) {
     if (typeof data !== "object" || data === null) {
-      return escapeHtml(String(data));
+      return String(data);  // data is HTML
     }
 
     var html = "<div class='res-container'>";


### PR DESCRIPTION
Error messages from NTIA Conformance Checker should be rendered, not being displayed as raw HTML tags.

Currently it shows HTML tags:

<img width="707" height="688" src="https://github.com/user-attachments/assets/c8ec549c-94e4-48e3-b899-7dd9d8863d54" />

With fix from this PR:

<img width="712" height="687" src="https://github.com/user-attachments/assets/044f2578-4d02-4147-ba16-950dba3b2dfd" />
