### PR TITLE
Remove Unicode/encoding code from Python 2

### DIFF
--- a/src/api/admin.py
+++ b/src/api/admin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
 # SPDX-License-Identifier: Apache-2.0

--- a/src/api/apps.py
+++ b/src/api/apps.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
 # SPDX-License-Identifier: Apache-2.0

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
 # SPDX-License-Identifier: Apache-2.0

--- a/src/api/oauth.py
+++ b/src/api/oauth.py
@@ -24,8 +24,7 @@ def generate_github_access_token(github_client_id, github_client_secret, github_
         }),
         headers={'content-type': 'application/json'}
     )
-    auth_response_content = auth_response.content
-    auth_response_content = auth_response_content.decode('utf-8') if not isinstance(auth_response_content, str) else auth_response_content
+    auth_response_content = auth_response.content.decode('utf-8')
     token = re.search(r'access_token=([a-zA-Z0-9]+)', auth_response_content)
     if token is None:
         raise PermissionDenied(auth_response)

--- a/src/api/serializers.py
+++ b/src/api/serializers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
 # SPDX-License-Identifier: Apache-2.0

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
 # SPDX-License-Identifier: Apache-2.0

--- a/src/api/utils.py
+++ b/src/api/utils.py
@@ -1,8 +1,8 @@
-# -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
 # SPDX-License-Identifier: Apache-2.0
 
+import re
 from rest_framework import status
 
 

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: 2017 Rohit Lodha
 # SPDX-FileCopyrightText: 2025 SPDX Contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/src/app/admin.py
+++ b/src/app/admin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
 # SPDX-License-Identifier: Apache-2.0

--- a/src/app/apps.py
+++ b/src/app/apps.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
 # SPDX-License-Identifier: Apache-2.0

--- a/src/app/formatxml.py
+++ b/src/app/formatxml.py
@@ -219,7 +219,7 @@ def singlespaceline(txt):
 if NAMESPACE:
     full_TAGS_inline = list(NAMESPACE+e for e in TAGS_inline)
     full_TAGS_block = list(NAMESPACE+e for e in TAGS_block)
-    full_ATTRS_SEQ = dict((NAMESPACE+k, v) for k,v in list(ATTRS_SEQ.items()))
+    full_ATTRS_SEQ = dict((NAMESPACE+k, v) for k,v in ATTRS_SEQ.items())
 
 if __name__ == '__main__':
 

--- a/src/app/forms.py
+++ b/src/app/forms.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
 # SPDX-License-Identifier: Apache-2.0

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
 # SPDX-License-Identifier: Apache-2.0
@@ -34,10 +33,8 @@ class License(models.Model):
 
 class LicenseRequest(License):
 
-    def __unicode__(self):
-        return "%s" % (self.fullname)
     def __str__(self):
-        return "%s" % (self.fullname)
+        return self.fullname
 
     class Meta:
         verbose_name = "LicenseRequest"
@@ -47,9 +44,6 @@ class LicenseRequest(License):
 class OrganisationName(models.Model):
     name = models.CharField(max_length=250)
     orgId = models.CharField(max_length=25)
-
-    def __unicode__(self):
-        return "%s" % (self.name)
 
     def __str__(self):
         return "{0} [{1}]".format(self.name, self.orgId)
@@ -70,11 +64,8 @@ class LicenseNamespace(License):
     promoted = models.BooleanField(default=False)
     license_request = models.ForeignKey(LicenseRequest, null=True, blank=True, on_delete=models.CASCADE)
 
-    def __unicode__(self):
-        return "%s" % (self.namespace)
-
     def __str__(self):
-        return "%s" % (self.namespace)
+        return self.namespace
 
     class Meta:
         verbose_name = "LicenseNamespace"

--- a/src/app/urls.py
+++ b/src/app/urls.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: 2017 Rohit Lodha
 # Copyright (c) 2017 Rohit Lodha
 # SPDX-License-Identifier: Apache-2.0

--- a/src/app/utils.py
+++ b/src/app/utils.py
@@ -187,9 +187,9 @@ def makePullRequest(username, token, branchName, updateUpstream, fileName, commi
     else:
         commit_url = "{0}repos/{1}/{2}/contents/src/{3}".format(url, username, settings.NAMESPACE_REPO_NAME if is_ns else settings.LICENSE_REPO_NAME, fileName)        
     text_commit_url = "{0}repos/{1}/{2}/contents/test/simpleTestForGenerator/{3}".format(url, username, settings.NAMESPACE_REPO_NAME if is_ns else settings.LICENSE_REPO_NAME, textFileName)
-    xmlText = xmlText.encode('utf-8') if isinstance(xmlText, str) else xmlText
+    xmlText = xmlText.encode('utf-8')
     fileContent = base64.b64encode(xmlText).decode()
-    plainText = plainText.encode('utf-8') if isinstance(plainText, str) else plainText
+    plainText = plainText.encode('utf-8')
     textFileContent = base64.b64encode(plainText).decode()
     body = {
         "path":"src/"+fileName,
@@ -536,7 +536,6 @@ def get_license_data(issues):
                     licenseIdentifier = re.search(r'(?im)short identifier:\s([a-zA-Z0-9|.|-]+)', licenseInfo).group(1)
                     dbId = re.search(r'License Request Url:.+/app/license_requests/([0-9]+)', licenseInfo).group(1)
                     licenseXml = LicenseRequest.objects.get(id=dbId, shortIdentifier=licenseIdentifier).xml
-                    licenseXml = licenseXml.decode('utf-8') if not isinstance(licenseXml, str) else licenseXml
                     licenseText = parseXmlString(licenseXml)['text']
                     licenseTexts.append(clean(licenseText))
                     licenseIds.append(licenseIdentifier)
@@ -544,7 +543,7 @@ def get_license_data(issues):
                     pass
                 except AttributeError:
                     pass
-    licenseData = dict(list(zip(licenseIds, licenseTexts)))
+    licenseData = dict(zip(licenseIds, licenseTexts))
     return licenseData
 
 
@@ -659,7 +658,7 @@ def check_spdx_license(licenseText):
 
     spdxLicenseIds = list(r.keys())
     spdxLicenseTexts = r.mget(spdxLicenseIds)
-    licenseData = dict(list(zip(spdxLicenseIds, spdxLicenseTexts)))
+    licenseData = dict(zip(spdxLicenseIds, spdxLicenseTexts))
     matches = get_close_matches(licenseText, licenseData)
     if not matches:
         matchedLicenseIds = None

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: 2017 Rohit Lodha
 # SPDX-FileCopyrightText: 2025-present SPDX Contributors
 # SPDX-License-Identifier: Apache-2.0
@@ -14,7 +13,6 @@ from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 
-import codecs
 import jpype
 import requests
 from lxml import etree
@@ -494,8 +492,7 @@ def validate_xml(request):
             try :
                 if "xmlText" in request.POST:
                     # Saving file to the media directory
-                    xmlText = request.POST['xmlText']
-                    xmlText = xmlText.encode('utf-8') if isinstance(xmlText, str) else xmlText
+                    xmlText = request.POST['xmlText'].encode('utf-8')
                     folder = f"{request.user}/{int(time())}"
                     folder_path = os.path.join(settings.MEDIA_ROOT, folder)
                     if not os.path.isdir(folder_path):
@@ -511,11 +508,11 @@ def validate_xml(request):
                         xmlschema_doc = etree.fromstring(schema_text.encode('utf-8'))
                     except:
                         schema_url = settings.BASE_DIR + "/examples/xml-schema.xsd"
-                        with open(schema_url) as f:
+                        with open(schema_url, 'rb') as f:
                             xmlschema_doc = etree.parse(f)
                     # Using the lxml etree functions
                     xmlschema = etree.XMLSchema(xmlschema_doc)
-                    with open(uploaded_file_url) as f:
+                    with open(uploaded_file_url, 'rb') as f:
                         xml_input = etree.parse(f)
 
                     try:
@@ -1123,7 +1120,8 @@ def beautify(request):
                     f.close()
                 commandRun = subprocess.call([sys.executable, _FORMATXML_SCRIPT, "test.xml", "-i", "3"])
                 if commandRun == 0:
-                    data = codecs.open("test.xml", 'r', encoding='utf-8').read()
+                    with open("test.xml", 'r', encoding='utf-8') as f:
+                        data = f.read()
                     os.remove('test.xml')
                     if (utils.is_ajax(request)):
                         ajaxdict["type"] = "success"


### PR DESCRIPTION
Python 3 supports Unicode natively.

- Remove legacy encoding code that was necessary at the time but no longer now.
- Remove unnecessary `list()` for object that is already a list in Python 3.
- Specify 'rb' (read, binary) when sent text to XML processor.