### PR TITLE
Update spdx-license-matcher to version 2.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ social-auth-app-django>=5.0,<6.0
 social-auth-core>=4.3,<5.0
 spdx-python-model>=0.0.4,<1.0.0
 spdx-tools>=0.8.5,<1.0.0
-https://github.com/spdx/spdx-license-matcher/archive/refs/tags/v2.8.tar.gz#egg=spdx-license-matcher
+https://github.com/spdx/spdx-license-matcher/archive/refs/tags/v2.9.tar.gz#egg=spdx-license-matcher

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Django>=4.2,<4.3
 djangorestframework>=3.14.0,<4.0.0
 gevent>=26.4.0,<27.0.0
 gunicorn>=25.3.0,<26.0.0
-jpype1==1.6.0
+jpype1==1.7.0
 lxml>=5.4.0,<6.0.0
 ntia-conformance-checker>=5.0.2,<6.0.0
 python-dotenv>=1.0.1


### PR DESCRIPTION
This includes updates to JPype which is a dependency for PR #637