### PR TITLE
Use .spdx3.json extension in Convert

### DIFF
--- a/src/app/templates/app/compare.html
+++ b/src/app/templates/app/compare.html
@@ -24,10 +24,10 @@
       <div class="file-name">No file selected</div>
 		</div>
 		<br>
-		<div class = "form-group">
-			<div class="col-sm-12">
-			<label class="control-label col-sm-3">Result file name</label>
-				<div class="col-sm-6"> 
+		<div style="max-width: 600px; margin: 0 auto;">
+			<div class="form-group">
+				<label class="control-label col-sm-5">Result file name</label>
+				<div class="col-sm-7"> 
 					<input type="text" id="rfilename" name="rfilename">
 					<label class="control-label" id="convertdoclabel">.xlsx</label>
 				</div>

--- a/src/app/templates/app/convert.html
+++ b/src/app/templates/app/convert.html
@@ -16,8 +16,9 @@
 <div class="panel-body">
 <form id="convertform" enctype="multipart/form-data" class="form-horizontal" method="post">
 		{% csrf_token %}
-		<div class="form-group">
-      From &nbsp;
+		<div style="max-width: 600px; margin: 0 auto;">
+			<div class="form-group">
+				From &nbsp;
 			<select name="from_format" id="from_format">
 			 	  <option value="0" selected="">-</option>
 				  <option value="TAG">V2 Tag/Value</option>
@@ -32,7 +33,7 @@
 			&nbsp; to &nbsp;
 			<select name="to_format" id="to_format">
 			 	  <option value="0" data-value="INGORE" data-ext="" selected="">-</option>
-				  <option value="JSONLD" data-value="JSONLD" data-ext=".jsonld.json">V3 JSON-LD</option>
+			 	  <option value="JSONLD" data-value="JSONLD" data-ext=".spdx3.json">V3 JSON-LD</option>
 				  <option value="TAG" data-value="TAG" data-ext=".spdx">V2 Tag/Value</option>
 				  <option value="RDFXML" data-value="RDFXML" data-ext=".rdf.xml">V2 RDF/XML</option>
 				  <option value="RDFTTL" data-value="RDFTTL" data-ext=".rdf.ttl">V2 RDF/TTL</option>
@@ -42,7 +43,8 @@
 				  <option value="XML" data-value="XML" data-ext=".xml">V2 XML</option>
 				  <option value="YAML" data-value="YAML" data-ext=".yaml">V2 YAML</option>
       </select>
-    </div>
+	    </div>
+		</div>
     <div id="drop-area" class="container">
       <h4 id="doclabel">Upload SPDX document using the button or by dragging and dropping onto the dashed region</h4>
       <input type="file" id="file" onchange="handleFiles(this.files)">
@@ -59,14 +61,14 @@
 			</div>	
     </div>
     -->
-		<div class = "form-group">
-			<div class="col-sm-12">
-			<label class="control-label col-sm-3">Converted file name</label>
-				<div class="col-sm-3"> 
+		<div style="max-width: 600px; margin: 0 auto;">
+			<div class="form-group">
+				<label class="control-label col-sm-5">Converted file name</label>
+				<div class="col-sm-7"> 
 				  <input type="text" id="cfilename" name="cfilename">
 				  <label class="control-label" id="convertdoclabel"></label>
 				</div>
-			</div>	
+			</div>
 		</div>
     <hr>
 		<input type="hidden" id="cfileformat" name="cfileformat" value="">

--- a/src/app/templates/app/ntia_conformance_checker.html
+++ b/src/app/templates/app/ntia_conformance_checker.html
@@ -148,7 +148,7 @@
   <form id="checkform" enctype="multipart/form-data" class="form-horizontal" method="post">
     {% csrf_token %}
     <div class = "form-group">
-      File Format &nbsp;
+      File format &nbsp;
       <select name="format" id="format">
         <option value="0" data-value="0" selected="">-</option>
         <option value="JSON">V2 JSON</option>

--- a/src/app/templates/app/validate.html
+++ b/src/app/templates/app/validate.html
@@ -16,7 +16,7 @@
 	<form id="validateform" enctype="multipart/form-data" class="form-horizontal" method="post">
 	  {% csrf_token %}
 	  <div class = "form-group">
-			File Type &nbsp;
+			File type &nbsp;
 				<select name="format" id="format">
 					  <option value="0" data-value="0" selected="">-</option>
 					  <option value="JSONLD">V3 JSON-LD</option>


### PR DESCRIPTION
- Change SPDX 3 JSON file extension from `.jsonld.json` to `.spdx3.json`
  - Aligned with the new agreed file extension (as submitted to IANA).
- Fix layout when display the long file extension (like .spdx3.json), keep it in the same line as the filename.
- Fix layout of Compare page to be consistent with new file label margin in Convert page

Tested the conversion. The converted file now has the `.spdx3.json` extension.

---

Before the fix:

File extension (.jsonld.json) goes below filename

<img width="745" height="400" src="https://github.com/user-attachments/assets/e8d221a5-4526-4213-9c70-3235b0f70756" />

After the fix:

File extension (.spdx3.json) stays the same line with filename

<img width="648" height="371" src="https://github.com/user-attachments/assets/bf4aaa52-6fce-44b2-99d0-40451d0ffd5e" />

