### PR TITLE
test: Use GitHub Actions to setup Firefox driver + use Chrome as fallback

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,31 +56,13 @@ jobs:
           distribution: temurin
           java-version: "17"
       - name: Install Firefox
-        # Make sure to install the latest version of Firefox to avoid compatibility issues with geckodriver
+        # Use PPA to install non-snap Firefox, which is more reliable for Selenium on Ubuntu runners
         run: |
           sudo snap remove --purge firefox || true
           sudo add-apt-repository ppa:mozillateam/ppa -y
           printf 'Package: firefox*\nPin: release o=LP-PPA-mozillateam\nPin-Priority: 1001\n' | sudo tee /etc/apt/preferences.d/mozilla-firefox
           sudo apt-get update
           sudo apt-get install -y firefox
-      - name: Prepare geckodriver path
-        run: |
-          mkdir -p "$HOME/.local/geckodriver"
-          echo "$HOME/.local/geckodriver" >> "$GITHUB_PATH"
-      - name: Cache geckodriver
-        # Cache geckodriver to speed up subsequent runs and avoid rate limits.
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: ~/.local/geckodriver/geckodriver
-          key: geckodriver-v0.36.0-${{ runner.os }}-x64
-      - name: Install geckodriver
-        run: |
-          if [ ! -x "$HOME/.local/geckodriver/geckodriver" ]; then
-            wget -q https://github.com/mozilla/geckodriver/releases/download/v0.36.0/geckodriver-v0.36.0-linux64.tar.gz -O geckodriver.tar.gz
-            tar xzf geckodriver.tar.gz -C "$HOME/.local/geckodriver"
-            chmod +x "$HOME/.local/geckodriver/geckodriver"
-          fi
-          geckodriver --version
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,14 +55,8 @@ jobs:
         with:
           distribution: temurin
           java-version: "17"
-      - name: Install Firefox
-        # Use PPA to install non-snap Firefox, which is more reliable for Selenium on Ubuntu runners
-        run: |
-          sudo snap remove --purge firefox || true
-          sudo add-apt-repository ppa:mozillateam/ppa -y
-          printf 'Package: firefox*\nPin: release o=LP-PPA-mozillateam\nPin-Priority: 1001\n' | sudo tee /etc/apt/preferences.d/mozilla-firefox
-          sudo apt-get update
-          sudo apt-get install -y firefox
+      - name: Set up Firefox
+        uses: browser-actions/setup-firefox@fcf821c621167805dd63a29662bd7cb5676c81a8 # v1.7.1
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/src/app/tests.py
+++ b/src/app/tests.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime
+import logging
 import os
 import shutil
 from unittest import skipIf
@@ -42,7 +43,7 @@ def _init_selenium():
         if driver_path and os.path.isfile(driver_path) and os.access(driver_path, os.X_OK):
             return "firefox", driver_path
     except Exception as e:
-        print(f"Firefox initialization failed or geckodriver not found: {e}")
+        logging.warning(f"Firefox initialization failed or geckodriver not found: {e}")
 
     # Attempt Chrome
     try:
@@ -50,7 +51,7 @@ def _init_selenium():
         if driver_path and os.path.isfile(driver_path) and os.access(driver_path, os.X_OK):
             return "chrome", driver_path
     except Exception as e:
-        print(f"Chrome initialization failed or chromedriver not found: {e}")
+        logging.warning(f"Chrome initialization failed or chromedriver not found: {e}")
 
     return None, None
 
@@ -741,6 +742,8 @@ class BaseSeleniumTestCase(StaticLiveServerTestCase):
         super(BaseSeleniumTestCase, self).tearDown()
 
 
+# @skipIf is intentionally kept alongside the BaseSeleniumTestCase.setUp check to skip
+# the class before any fixtures are set up, which is faster.
 @skipIf(not SELENIUM_AVAILABLE, "Selenium not available (Firefox or Chrome required)")
 class LicenseXMLEditorTestCase(BaseSeleniumTestCase):
 
@@ -1268,6 +1271,8 @@ class ArchiveLicenseRequestsViewsTestCase(TestCase):
         self.assertEqual(resp.resolver_match.func.__name__,"licenseInformation")
 
 
+# @skipIf is intentionally kept alongside the BaseSeleniumTestCase.setUp check to skip
+# the class before any fixtures are set up, which is faster.
 @skipIf(not SELENIUM_AVAILABLE, "Selenium not available (Firefox or Chrome required)")
 class ArchiveLicenseRequestsSeleniumTestCase(BaseSeleniumTestCase):
 
@@ -1427,6 +1432,8 @@ class LicenseNamespaceViewsTestCase(TestCase):
         self.assertEqual(resp.resolver_match.func.__name__,"licenseNamespaceRequests")
 
 
+# @skipIf is intentionally kept alongside the BaseSeleniumTestCase.setUp check to skip
+# the class before any fixtures are set up, which is faster.
 @skipIf(not SELENIUM_AVAILABLE, "Selenium not available (Firefox or Chrome required)")
 class PromoteLicenseNamespaceViewsTestCase(BaseSeleniumTestCase):
 
@@ -1494,6 +1501,8 @@ class ArchiveLicenseNamespaceViewsTestCase(TestCase):
         self.assertEqual(resp.resolver_match.func.__name__,"licenseNamespaceInformation")
 
 
+# @skipIf is intentionally kept alongside the BaseSeleniumTestCase.setUp check to skip
+# the class before any fixtures are set up, which is faster.
 @skipIf(not SELENIUM_AVAILABLE, "Selenium not available (Firefox or Chrome required)")
 class ArchiveLicenseNamespaceSeleniumTestCase(BaseSeleniumTestCase):
 

--- a/src/app/tests.py
+++ b/src/app/tests.py
@@ -17,12 +17,15 @@ from django.test import TestCase
 from django.urls import reverse
 from selenium import webdriver
 from selenium.webdriver.common.by import By
-from selenium.webdriver.firefox.options import Options
-from selenium.webdriver.firefox.service import Service
+from selenium.webdriver.firefox.options import Options as FirefoxOptions
+from selenium.webdriver.firefox.service import Service as FirefoxService
+from selenium.webdriver.chrome.options import Options as ChromeOptions
+from selenium.webdriver.chrome.service import Service as ChromeService
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 from social_django.models import UserSocialAuth
 from webdriver_manager.firefox import GeckoDriverManager
+from webdriver_manager.chrome import ChromeDriverManager
 
 from app.generateXml import generateLicenseXml
 from app.models import LicenseNamespace, LicenseRequest, UserID
@@ -33,15 +36,26 @@ os.environ.setdefault('WDM_PROGRESS_BAR', '0')
 os.environ.setdefault('WDM_LOG', '0')
 
 def _init_selenium():
+    # Attempt Firefox
     try:
         driver_path = shutil.which("geckodriver") or GeckoDriverManager().install()
         if driver_path and os.path.isfile(driver_path) and os.access(driver_path, os.X_OK):
-            return True, Service(driver_path)
-        return False, None
-    except Exception:
-        return False, None
+            return "firefox", driver_path
+    except Exception as e:
+        print(f"Firefox initialization failed or geckodriver not found: {e}")
 
-SELENIUM_AVAILABLE, service = _init_selenium()
+    # Attempt Chrome
+    try:
+        driver_path = shutil.which("chromedriver") or ChromeDriverManager().install()
+        if driver_path and os.path.isfile(driver_path) and os.access(driver_path, os.X_OK):
+            return "chrome", driver_path
+    except Exception as e:
+        print(f"Chrome initialization failed or chromedriver not found: {e}")
+
+    return None, None
+
+DRIVER_TYPE, DRIVER_PATH = _init_selenium()
+SELENIUM_AVAILABLE = DRIVER_TYPE is not None
 
 def getExamplePath(filename):
     return os.path.join(settings.EXAMPLES_DIR, filename)
@@ -686,24 +700,42 @@ class ValidateXMLViewsTestCase(TestCase):
         self.client.logout()
 
 
-@skipIf(not SELENIUM_AVAILABLE, "geckodriver not available or not working")
-class LicenseXMLEditorTestCase(StaticLiveServerTestCase):
-
+class BaseSeleniumTestCase(StaticLiveServerTestCase):
     def setUp(self):
-        options = Options()
-        options.add_argument('-headless')
+        if not SELENIUM_AVAILABLE:
+            self.skipTest("No supported webdriver (Firefox or Chrome) available")
+
         try:
-            self.selenium = webdriver.Firefox(service=service, options=options)
+            if DRIVER_TYPE == "firefox":
+                options = FirefoxOptions()
+                options.add_argument('-headless')
+                self.selenium = webdriver.Firefox(service=FirefoxService(DRIVER_PATH), options=options)
+            elif DRIVER_TYPE == "chrome":
+                options = ChromeOptions()
+                options.add_argument('--headless')
+                options.add_argument('--no-sandbox')
+                options.add_argument('--disable-dev-shm-usage')
+                self.selenium = webdriver.Chrome(service=ChromeService(DRIVER_PATH), options=options)
+            
+            self.selenium.set_window_size(1920, 1080)
         except Exception as e:
-            self.skipTest(f"geckodriver not available or not working: {e}")
-        self.selenium.set_window_size(1920, 1080)
-        self.initialXML = '<?xml version="1.0" encoding="UTF-8"?>\n<SPDXLicenseCollection xmlns="http://www.spdx.org/license">\n   <license>\n   </license>\n</SPDXLicenseCollection>'
-        self.invalidXML = '<?xml version="1.0" encoding="UTF-8"?><SPDXLicenseCollection xmlns="http://www.spdx.org/license"><license></license>'
-        super(LicenseXMLEditorTestCase, self).setUp()
+            self.skipTest(f"Failed to initialize {DRIVER_TYPE} driver: {e}")
+        
+        super(BaseSeleniumTestCase, self).setUp()
 
     def tearDown(self):
-        self.selenium.quit()
-        super(LicenseXMLEditorTestCase, self).tearDown()
+        if hasattr(self, 'selenium'):
+            self.selenium.quit()
+        super(BaseSeleniumTestCase, self).tearDown()
+
+
+@skipIf(not SELENIUM_AVAILABLE, "Selenium not available (Firefox or Chrome required)")
+class LicenseXMLEditorTestCase(BaseSeleniumTestCase):
+
+    def setUp(self):
+        super(LicenseXMLEditorTestCase, self).setUp()
+        self.initialXML = '<?xml version="1.0" encoding="UTF-8"?>\n<SPDXLicenseCollection xmlns="http://www.spdx.org/license">\n   <license>\n   </license>\n</SPDXLicenseCollection>'
+        self.invalidXML = '<?xml version="1.0" encoding="UTF-8"?><SPDXLicenseCollection xmlns="http://www.spdx.org/license"><license></license>'
 
     def test_tree_editor_attributes(self):
         """ Test for adding, editing and deleting attributes using tree editor """
@@ -1224,21 +1256,8 @@ class ArchiveLicenseRequestsViewsTestCase(TestCase):
         self.assertEqual(resp.resolver_match.func.__name__,"licenseInformation")
 
 
-@skipIf(not SELENIUM_AVAILABLE, "geckodriver not available or not working")
-class ArchiveLicenseRequestsSeleniumTestCase(StaticLiveServerTestCase):
-
-    def setUp(self):
-        options = Options()
-        options.add_argument('-headless')
-        try:
-            self.selenium = webdriver.Firefox(service=service, options=options)
-        except Exception as e:
-            self.skipTest(f"geckodriver not available or not working: {e}")
-        super(ArchiveLicenseRequestsSeleniumTestCase, self).setUp()
-
-    def tearDown(self):
-        self.selenium.quit()
-        super(ArchiveLicenseRequestsSeleniumTestCase, self).tearDown()
+@skipIf(not SELENIUM_AVAILABLE, "Selenium not available (Firefox or Chrome required)")
+class ArchiveLicenseRequestsSeleniumTestCase(BaseSeleniumTestCase):
 
     @skipIf(not getAccessToken() or not getGithubUserId() or not getGithubUserName(), "You need to set GitHub parameters in the secret.py file for this test to be executed properly.")
     def test_archive_license_requests_feature(self):
@@ -1396,23 +1415,13 @@ class LicenseNamespaceViewsTestCase(TestCase):
         self.assertEqual(resp.resolver_match.func.__name__,"licenseNamespaceRequests")
 
 
-@skipIf(not SELENIUM_AVAILABLE, "geckodriver not available or not working")
-class PromoteLicenseNamespaceViewsTestCase(StaticLiveServerTestCase):
+@skipIf(not SELENIUM_AVAILABLE, "Selenium not available (Firefox or Chrome required)")
+class PromoteLicenseNamespaceViewsTestCase(BaseSeleniumTestCase):
 
     def setUp(self):
-        options = Options()
-        options.add_argument('-headless')
-        try:
-            self.selenium = webdriver.Firefox(service=service, options=options)
-        except Exception as e:
-            self.skipTest(f"geckodriver not available or not working: {e}")
+        super(PromoteLicenseNamespaceViewsTestCase, self).setUp()
         login = TestUtil.gitHubLogin(self)
         self.assertTrue(login)
-        super(PromoteLicenseNamespaceViewsTestCase, self).setUp()
-
-    def tearDown(self):
-        self.selenium.quit()
-        super(PromoteLicenseNamespaceViewsTestCase, self).tearDown()
 
 
     @skipIf(not getAccessToken() or not getGithubUserId() or not getGithubUserName(), "You need to set GitHub parameters in the secret.py file for this test to be executed properly.")
@@ -1473,22 +1482,8 @@ class ArchiveLicenseNamespaceViewsTestCase(TestCase):
         self.assertEqual(resp.resolver_match.func.__name__,"licenseNamespaceInformation")
 
 
-@skipIf(not SELENIUM_AVAILABLE, "geckodriver not available or not working")
-class ArchiveLicenseNamespaceSeleniumTestCase(StaticLiveServerTestCase):
-
-    def setUp(self):
-        options = Options()
-        options.add_argument('-headless')
-        try:
-            self.selenium = webdriver.Firefox(service=service, options=options)
-        except Exception as e:
-            self.skipTest(f"geckodriver not available or not working: {e}")
-        self.selenium.set_window_size(1920, 1080)
-        super(ArchiveLicenseNamespaceSeleniumTestCase, self).setUp()
-
-    def tearDown(self):
-        self.selenium.quit()
-        super(ArchiveLicenseNamespaceSeleniumTestCase, self).tearDown()
+@skipIf(not SELENIUM_AVAILABLE, "Selenium not available (Firefox or Chrome required)")
+class ArchiveLicenseNamespaceSeleniumTestCase(BaseSeleniumTestCase):
 
     def test_archive_license_namespace_feature(self):
         """Check if the license namespace is shifted to archive namespace when archive button is pressed"""

--- a/src/app/tests.py
+++ b/src/app/tests.py
@@ -16,16 +16,16 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.urls import reverse
 from selenium import webdriver
+from selenium.webdriver.chrome.options import Options as ChromeOptions
+from selenium.webdriver.chrome.service import Service as ChromeService
 from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
 from selenium.webdriver.firefox.service import Service as FirefoxService
-from selenium.webdriver.chrome.options import Options as ChromeOptions
-from selenium.webdriver.chrome.service import Service as ChromeService
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 from social_django.models import UserSocialAuth
-from webdriver_manager.firefox import GeckoDriverManager
 from webdriver_manager.chrome import ChromeDriverManager
+from webdriver_manager.firefox import GeckoDriverManager
 
 from app.generateXml import generateLicenseXml
 from app.models import LicenseNamespace, LicenseRequest, UserID
@@ -137,8 +137,10 @@ class LoginViewsTestCase(TestCase):
     def test_postlogin(self):
         """POST Request for index with different user types."""
         self.initialise()
-        resp = self.client.post(reverse("login"),self.credentials,follow=True,secure=True)
-        self.assertEqual(resp.status_code,200)
+        resp = self.client.post(
+            reverse("login"), self.credentials, follow=True, secure=True
+        )
+        self.assertEqual(resp.status_code, 200)
         self.assertNotEqual(resp.redirect_chain,[])
         self.assertIn(settings.LOGIN_REDIRECT_URL, (i[0] for i in resp.redirect_chain))
         self.assertTrue(resp.context['user'].is_active)
@@ -146,8 +148,10 @@ class LoginViewsTestCase(TestCase):
         self.assertFalse(resp.context['user'].is_superuser)
         self.client.get(reverse("logout"))
 
-        resp2 = self.client.post(reverse("login"),self.credentials2,follow=True,secure=True)
-        self.assertEqual(resp2.status_code,403)
+        resp2 = self.client.post(
+            reverse("login"), self.credentials2, follow=True, secure=True
+        )
+        self.assertEqual(resp2.status_code, 403)
         self.assertEqual(resp2.redirect_chain,[])
         self.assertFalse(resp2.context['user'].is_active)
         self.assertFalse(resp2.context['user'].is_staff)
@@ -156,8 +160,10 @@ class LoginViewsTestCase(TestCase):
         self.assertIn("app/login.html",(i.name for i in resp2.templates))
         self.client.get(reverse("logout"))
 
-        resp3 = self.client.post(reverse("login"),self.credentials3,follow=True,secure=True)
-        self.assertEqual(resp3.status_code,403)
+        resp3 = self.client.post(
+            reverse("login"), self.credentials3, follow=True, secure=True
+        )
+        self.assertEqual(resp3.status_code, 403)
         self.assertEqual(resp3.redirect_chain,[])
         self.assertFalse(resp3.context['user'].is_active)
         self.assertFalse(resp3.context['user'].is_staff)
@@ -170,10 +176,16 @@ class RegisterViewsTestCase(TestCase):
 
     def initialise(self):
         self.username = "testuser4"
-        self.password ="testpass4"
-        self.data = {"first_name": "test","last_name" : "test" ,
-            "email" : "test@spdx.org","username":self.username,
-            "password":self.password,"confirm_password":self.password,"organisation":"spdx"}
+        self.password = "testpass4"
+        self.data = {
+            "first_name": "test",
+            "last_name": "test",
+            "email": "test@spdx.org",
+            "username": self.username,
+            "password": self.password,
+            "confirm_password": self.password,
+            "organisation": "spdx",
+        }
 
     def test_register(self):
         """GET Request for register"""


### PR DESCRIPTION
- Use [browser-actions/setup-firefox](https://github.com/browser-actions/setup-firefox) to setup Firefox - much faster
- If Firefox is not available for test, try Chrome (already included in default GitHub runner)