### PR TITLE
License tools: replace modal popups with inline result section

### DIFF
--- a/src/app/static/js/editor/script.js
+++ b/src/app/static/js/editor/script.js
@@ -708,7 +708,7 @@ function display_message(message){
     });
     setTimeout(function() {
         $(".close").click();
-    }, 2000);
+    }, 15000);
     $(".close").click(function(){
         editor.focus();
     })

--- a/src/app/static/js/editor/script.js
+++ b/src/app/static/js/editor/script.js
@@ -401,10 +401,10 @@ $(document).ready(function(){
             data: form,
             success: function (data) {
                 if(data.type=="valid"){
-                    displayModal("<h3>"+data.data+"</h3>","success");
+                    displayModal("<p>"+data.data+"</p>","success");
                 }
                 else{
-                    displayModal("<h3>"+data.data+"</h3>","alert");
+                    displayModal("<p>"+data.data+"</p>","alert");
                 }
                 $("#validateXML").text("Validate");
                 $("#validateXML").prop('disabled', false);
@@ -432,7 +432,7 @@ $(document).ready(function(){
         var githubLogin = $("#githubLogin").text();
         $("#modal-body").removeClass("diff-modal-body");
         $(".modal-dialog").removeClass("diff-modal-dialog");
-        $("#modal-title").html("SPDX License XML Editor");
+        $("#modal-title").html("License XML editor");
         $('button.close').remove();
         /* if user not authenticated using GitHub, display modal with login button */
         if(githubLogin == "False"){
@@ -596,7 +596,7 @@ function makePR(data=null){
         data: form,
         success: function (data) {
             if(data.type=="success"){
-                displayModal('<h3>Your Pull Request was created successfully <a href="'+data.data+'">here</a></h3>',"success");
+                displayModal('<p>Your Pull Request was created successfully <a href="'+data.data+'">here</a></p>',"success");
             }
             $("#prOk").html('<span class="glyphicon glyphicon-ok"></span> Confirm');
             $("#prCancel").html('<span class="glyphicon glyphicon-remove"></span> Cancel');
@@ -696,8 +696,8 @@ function display_message(message){
     $("#modal-header").removeClass("red-modal");
     $("#modal-header").removeClass("yellow-modal");
     $("#modal-header").addClass("green-modal");
-    $("#modal-title").html("SPDX License XML Editor");
-    $("#modal-body").html("<h3>"+message+"</h3>");
+    $("#modal-title").html("License XML editor");
+    $("#modal-body").html("<p>"+message+"</p>");
     $('button.close').remove();
     $('<button type="button" class="close" data-dismiss="modal">&times;</button>').insertBefore($("h4.modal-title"));
     $(".modal-footer").html('<button class="btn btn-default" data-dismiss="modal">OK</button>')

--- a/src/app/static/js/utils.js
+++ b/src/app/static/js/utils.js
@@ -9,76 +9,67 @@ function findLicenseMatch(request) {
       var matchType = data.matchType;
       var matchIds = data.matchIds;
       if (matchType == "Close match") {
-        $("#modal-header").addClass("yellow-modal");
         var inputLicenseText = data.inputLicenseText.replace(/\r\n/g, "\n");
         var originalLicenseText = data.originalLicenseText;
         var matchingGuidelinesUrl =
           "https://spdx.org/spdx-license-list/matching-guidelines";
-        var message = `Close match found! The license closely matches with the license ID(s): <strong>${matchIds}</strong> based on the SPDX Matching guidelines. Press show differences to continue.`;
-        $("#modal-header").removeClass("red-modal green-modal");
-        $("#modal-header").addClass("yellow-modal");
-        $(".modal-footer").html(
-          `<a href=${matchingGuidelinesUrl} target="_blank"><button class="btn btn-success btn-space" id="matchingguidelines"><span class="glyphicon glyphicon-link"></span> SPDX Matching Guidelines</button></a><button class="btn btn-success btn-space" id="showDiff"><span class="glyphicon glyphicon-link"></span> Show differences</button>`
-        );
-        $("#modal-body").html(message);
-        $("#myModal").modal({
-          backdrop: "static",
-          keyboard: true,
-          show: true,
-        });
-        $(document).on("click", "button#ok", function (event) {
-          $("#myModal").modal("hide");
-        });
-        $(document)
-          .off()
-          .on("click", "button#showDiff", function (event) {
-            generate_text_diff(
-              originalLicenseText.split("\n\n"),
-              inputLicenseText.split("\n\n")
-            );
+        var bodyHtml =
+          '<p>Close match found! The license closely matches with the license ID(s): ' +
+          '<strong>' + $('<span>').text(matchIds).html() + '</strong> ' +
+          'based on the SPDX Matching guidelines.</p>' +
+          '<div style="margin-top:12px;display:flex;gap:8px;flex-wrap:wrap;">' +
+          '<a href="' + matchingGuidelinesUrl + '" target="_blank" rel="noopener" ' +
+          '   class="btn btn-default">' +
+          '  <span class="glyphicon glyphicon-link" aria-hidden="true"></span>' +
+          '  SPDX Matching Guidelines</a>' +
+          '<button type="button" class="btn btn-default" id="showDiff">' +
+          '  <span class="glyphicon glyphicon-search" aria-hidden="true"></span>' +
+          '  Show differences</button>' +
+          '</div>';
+
+        showResult("warning", "Close match", bodyHtml);
+
+        // Store texts for the diff so the click handler can reach them
+        document.getElementById("showDiff")._baseText = originalLicenseText;
+        document.getElementById("showDiff")._inputText = inputLicenseText;
+
+        $(document).off("click.showDiff").on("click.showDiff", "#showDiff", function () {
+          var base = this._baseText.split("\n\n");
+          var newtxt = this._inputText.split("\n\n");
+          generate_text_diff(base, newtxt);
           });
       } else if (
         matchType == "Perfect match" ||
         matchType == "Standard License match"
       ) {
-        var message = `Perfect match found! The license matches with the license ID(s): <strong>${matchIds}</strong>`;
-        $("#modal-header").addClass("green-modal");
-        $("#modal-title").html("Found!");
-        $("#modal-body").html(message);
+        showResult(
+          "success",
+          "Match found",
+          '<p>Perfect match! The license matches with the license ID(s): ' +
+          '<strong>' + $('<span>').text(matchIds).html() + '</strong></p>'
+        );
       } else {
-        $("#modal-header").addClass("red-modal");
-        $("#modal-title").html("Not Found!");
-        var message = "The given license was not found in the SPDX database.";
-        $("#modal-body").html("<h3>" + message + "</h3>");
+        showResult(
+          "error",
+          "No match",
+          "<p>The given license was not found in the SPDX database.</p>"
+        );
       }
-      $("#myModal").modal({
-        backdrop: "static",
-        keyboard: true,
-        show: true,
-      });
       $("#licensediffbutton").text("License diff");
       $("#licensediffbutton").prop("disabled", false);
     },
     error: function (e) {
       console.log("ERROR : ", e);
-      $("#modal-header").removeClass("green-modal");
       try {
         var obj = JSON.parse(e.responseText);
-        $("#modal-header").addClass("red-modal");
-        $("#modal-title").html("Error!");
-        $("#modal-body").text(obj.data);
-      } catch (e) {
-        $("#modal-header").addClass("red-modal");
-        $("#modal-title").html("Error!");
-        $("#modal-body").text(
-          "The application could not be connected. Please try later."
+        showResult("error", "Error", '<p>' + $('<span>').text(obj.data).html() + '</p>');
+      } catch (_) {
+        showResult(
+          "error",
+          "Error",
+          "<p>The application could not be connected. Please try later.</p>"
         );
       }
-      $("#myModal").modal({
-        backdrop: "static",
-        keyboard: true,
-        show: true,
-      });
       $("#licensediffbutton").text("Check license");
       $("#licensediffbutton").prop("disabled", false);
     },

--- a/src/app/static/js/utils.js
+++ b/src/app/static/js/utils.js
@@ -1,7 +1,33 @@
 // SPDX-FileCopyrightText: 2025 SPDX Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-function findLicenseMatch(request) {
+/* Render a side-by-side diff inline in the result section */
+function generate_text_diff(base, newtxt) {
+  var sm = new difflib.SequenceMatcher(base, newtxt);
+  var opcodes = sm.get_opcodes();
+  var diffEl = diffview.buildView({
+    baseTextLines: base,
+    newTextLines: newtxt,
+    opcodes: opcodes,
+    baseTextName: "SPDX license text",
+    newTextName: "Your license text",
+    contextSize: null,
+    viewType: 1,
+  });
+  $(diffEl).find('thead').remove();
+  $(diffEl).find('th').remove();
+
+  var body = document.getElementById('result-body');
+  body.className = 'result-body diff-result-body';
+  body.innerHTML = '';
+  body.appendChild(diffEl);
+
+  var section = document.getElementById('result-section');
+  section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  section.focus();
+}
+
+function findLicenseMatch(request, onComplete) {
   $.ajax({
     ...request,
     success: function (data) {
@@ -12,7 +38,7 @@ function findLicenseMatch(request) {
         var inputLicenseText = data.inputLicenseText.replace(/\r\n/g, "\n");
         var originalLicenseText = data.originalLicenseText;
         var matchingGuidelinesUrl =
-          "https://spdx.org/spdx-license-list/matching-guidelines";
+          "https://spdx.github.io/spdx-spec/latest/annexes/license-matching-guidelines-and-templates/";
         var bodyHtml =
           '<p>Close match found! The license closely matches with the license ID(s): ' +
           '<strong>' + $('<span>').text(matchIds).html() + '</strong> ' +
@@ -57,6 +83,7 @@ function findLicenseMatch(request) {
       }
       $("#licensediffbutton").text("License diff");
       $("#licensediffbutton").prop("disabled", false);
+      if (onComplete) onComplete();
     },
     error: function (e) {
       console.log("ERROR : ", e);
@@ -72,6 +99,7 @@ function findLicenseMatch(request) {
       }
       $("#licensediffbutton").text("Check license");
       $("#licensediffbutton").prop("disabled", false);
+      if (onComplete) onComplete();
     },
   });
 }

--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -438,6 +438,11 @@ h4 { font-size: 1.2em !important; }
     clear: both;
 }
 
+.nav-tabs > li > a:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
 .btn-submit-center {
     display: block !important;
     width: -webkit-fit-content !important;

--- a/src/app/templates/app/check_license.html
+++ b/src/app/templates/app/check_license.html
@@ -1,23 +1,32 @@
 {% extends 'app/base.html' %}
 {% load static %}
 {% block body1 %}
-<div id="messages" class="messages"></div>
-{% if error %}<p class="lead">{{ error }}</p>{% endif %}
+<div id="messages" class="messages" role="status" aria-live="polite"></div>
+{% if error %}<p class="lead text-danger" role="alert">{{ error }}</p>{% endif %}
 <div class="panel panel-default">
   <div class="panel-heading">
     <p class="lead">Check license</p>
   </div>
-  <div class="panel-body" style="overflow:scroll;">
-    <form id="checklicenseform" enctype="multipart/form-data" class="form-horizontal" method="post">
+  <div class="panel-body">
+    <form id="checklicenseform" enctype="multipart/form-data" class="form-horizontal" method="post" aria-label="Check license text">
       {% csrf_token %}
       <p>Enter full license text in the text area below to check it against 
       <a href="https://spdx.org/licenses/">SPDX License List</a> and
       <a href="https://spdx.org/licenses/exceptions-index.html">License Exceptions</a>.</p>
-      <p>The result of the compare would be one of "Exact match", "Close match" or "No match".</p>
-      <textarea id="licensetext" name="licensetext" rows="18" style="width: 100%"></textarea>
-      <button id="checklicensebutton" class=" btn btn-md btn-info" type="submit">Check license</button>
+      <p>The result will be one of the following: <em>Perfect match</em>, <em>Standard License match</em>, <em>Close match</em>, or <em>Error (no match)</em>.</p>
+      <div class="form-group">
+        <label for="licensetext" class="sr-only">License text</label>
+        <textarea id="licensetext" name="licensetext" rows="12" style="width:100%; resize: vertical;" aria-required="true" placeholder="Paste the full license text here..."></textarea>
+      </div>
+      <button id="checklicensebutton" class="btn btn-md btn-info btn-submit-center" type="submit">Check license</button>
     </form>
-    {% include "app/modal.html" %}
+    <section id="result-section" class="result-section" role="region" aria-label="License check result" tabindex="-1" hidden>
+      <div id="result-header" class="result-header">
+        <h2 id="result-title" class="result-title"></h2>
+        <button type="button" class="result-close" aria-label="Close result" onclick="hideResult()">&times;</button>
+      </div>
+      <div id="result-body" class="result-body"></div>
+    </section>
   </div>
 </div>
 {% include "app/_tool_versions.html" with show_license_matcher=True %}
@@ -44,9 +53,9 @@ function checkform() {
     event.preventDefault();
     var check = checkform();
     if (check=="1"){
-      $("#checklicensebutton").text("Checking...");
-      $("#checklicensebutton").prop('disabled', true);
+      $("#checklicensebutton").text("Checking...").prop('disabled', true).attr('aria-disabled', 'true');
       $("#messages").html("");
+      hideResult();
       var form = new FormData($("#checklicenseform")[0]);
       $.ajax({
               type: "POST",
@@ -58,49 +67,44 @@ function checkform() {
               dataType: 'json',
               data: form,
               success: function (data) {
-                  console.log("SUCCESS : ", data);
-				  $("#modal-header").removeClass("red-modal");
-				  if (data["data"].toLowerCase().indexOf("perfect match") > -1 || data["data"].toLowerCase().indexOf("exact match") > -1) {
-                     $("#modal-header").addClass("green-modal");
-				  } else {
-				     $("#modal-header").addClass("yellow-modal");
-				  }
-                  $("#modal-title").html("Success!");
-                  $("#modal-body").html("<h3>"+data.data+"</h3>");
-                  $("#myModal").modal({
-                          backdrop: 'static',
-                          keyboard: true, 
-                          show: true
-                  });
-                  $("#checklicensebutton").text("Check license");
-                  $("#checklicensebutton").prop('disabled', false);
+                  var msg = data.data || '';
+                  var title = 'Result';
+                  var body = msg;
+        
+                  // Parse the standard "X found.<br />Y" format from the backend
+                  if (msg.indexOf(' found.<br />') > -1) {
+                    var parts = msg.split(' found.<br />');
+                    title = parts[0];
+                    body = parts[1];
+                  } else if (msg === "There are no matching SPDX listed licenses") {
+                    title = "No match";
+                  }
+        
+                  var lowerTitle = title.toLowerCase();
+                  var type = (lowerTitle.indexOf('perfect') > -1 || lowerTitle.indexOf('exact') > -1 || lowerTitle.indexOf('standard') > -1)
+                    ? 'success' : (title === 'No match' ? 'error' : 'warning');
+        
+                  showResult(type, title, '<p>' + body + '</p>');
+                  $('#checklicensebutton').text('Check license').prop('disabled', false).removeAttr('aria-disabled');
               },
               error: function (e) {
-                  console.log("ERROR : ", e);
-                  $("#modal-header").removeClass("green-modal");
                   try {
                     var obj = JSON.parse(e.responseText);
-                    $("#modal-header").addClass("red-modal");
-                    $("#modal-title").html("Error!");
-                    $("#modal-body").text(obj.data);
+                    showResult('error', 'Error', '<p>' + obj.data + '</p>');
                   }
-                  catch (e){
-                    $("#modal-header").addClass("red-modal");
-                    $("#modal-title").html("Error!");
-                    $("#modal-body").text("The application could not be connected. Please try later.");
+                  catch (_){
+                    showResult('error', 'Error',
+                               '<p>The application could not be connected. Please try later.</p>');
                   }
-                  $("#myModal").modal({
-                          backdrop: 'static',
-                          keyboard: true, 
-                          show: true
-                  });
-                  $("#checklicensebutton").text("Check license");
-                  $("#checklicensebutton").prop('disabled', false);
+                  $('#checklicensebutton').text('Check license').prop('disabled', false).removeAttr('aria-disabled');
               }
           });
     }
     else{
-      $("#messages").html('<div class="alert alert-danger alert-dismissable fade in"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a><strong>Error!</strong> '+check+'</div>');
+      $('#messages').html(
+        '<div class="alert alert-danger" role="alert"><strong>Error:</strong> ' +
+        $('<span>').text(check).html() + '</div>'
+      );
       setTimeout(function() {
         $("#messages").html("");
       }, 5000);

--- a/src/app/templates/app/check_license.html
+++ b/src/app/templates/app/check_license.html
@@ -1,5 +1,12 @@
 {% extends 'app/base.html' %}
 {% load static %}
+{% block head_block %}
+  <link href="{% static 'css/editor/diffview.css' %}" rel="stylesheet" type="text/css">
+  <style>
+    .diff-result-body { padding: 0; overflow-x: auto; }
+    .diff-result-body table { font-size: 0.82em; }
+  </style>
+{% endblock %}
 {% block body1 %}
 <div id="messages" class="messages" role="status" aria-live="polite"></div>
 {% if error %}<p class="lead text-danger" role="alert">{{ error }}</p>{% endif %}
@@ -32,84 +39,41 @@
 {% include "app/_tool_versions.html" with show_license_matcher=True %}
 {% endblock %}
 {% block script_block %}
+<script src="{% static 'js/utils.js' %}"></script>
+<script type="text/javascript" src="{% static 'js/editor/difflib.js' %}"></script>
+<script type="text/javascript" src="{% static 'js/editor/diffview.js' %}"></script>
 <script type="text/javascript">
 $(document).ready(function () {
     $("#checklicensepage").addClass('linkactive');
     });
 </script>
 <script type="text/javascript">
-function checkform() {
-  if ($('#licensetext').val() == "") {
+$('#checklicenseform').on('submit', function(event) {
+  event.preventDefault();
+  if ($('#licensetext').val() === '') {
     $('#licensetext').focus();
-    return ("No text entered.");
+    $('#messages').html(
+      '<div class="alert alert-danger" role="alert"><strong>Error:</strong> No text entered.</div>'
+    );
+    setTimeout(function() { $('#messages').html(''); }, 5000);
+    return;
   }
-  else {
-    return "1";
-  }
-}
-</script>
-<script type="text/javascript">
-  $('#checklicenseform').on('submit', function(event){
-    event.preventDefault();
-    var check = checkform();
-    if (check=="1"){
-      $("#checklicensebutton").text("Checking...").prop('disabled', true).attr('aria-disabled', 'true');
-      $("#messages").html("");
-      hideResult();
-      var form = new FormData($("#checklicenseform")[0]);
-      $.ajax({
-              type: "POST",
-              enctype: 'multipart/form-data',
-              url: "/app/check_license/",
-              processData: false,
-              contentType: false,
-              cache: false,
-              dataType: 'json',
-              data: form,
-              success: function (data) {
-                  var msg = data.data || '';
-                  var title = 'Result';
-                  var body = msg;
-        
-                  // Parse the standard "X found.<br />Y" format from the backend
-                  if (msg.indexOf(' found.<br />') > -1) {
-                    var parts = msg.split(' found.<br />');
-                    title = parts[0];
-                    body = parts[1];
-                  } else if (msg === "There are no matching SPDX listed licenses") {
-                    title = "No match";
-                  }
-        
-                  var lowerTitle = title.toLowerCase();
-                  var type = (lowerTitle.indexOf('perfect') > -1 || lowerTitle.indexOf('exact') > -1 || lowerTitle.indexOf('standard') > -1)
-                    ? 'success' : (title === 'No match' ? 'error' : 'warning');
-        
-                  showResult(type, title, '<p>' + body + '</p>');
-                  $('#checklicensebutton').text('Check license').prop('disabled', false).removeAttr('aria-disabled');
-              },
-              error: function (e) {
-                  try {
-                    var obj = JSON.parse(e.responseText);
-                    showResult('error', 'Error', '<p>' + obj.data + '</p>');
-                  }
-                  catch (_){
-                    showResult('error', 'Error',
-                               '<p>The application could not be connected. Please try later.</p>');
-                  }
-                  $('#checklicensebutton').text('Check license').prop('disabled', false).removeAttr('aria-disabled');
-              }
-          });
-    }
-    else{
-      $('#messages').html(
-        '<div class="alert alert-danger" role="alert"><strong>Error:</strong> ' +
-        $('<span>').text(check).html() + '</div>'
-      );
-      setTimeout(function() {
-        $("#messages").html("");
-      }, 5000);
-    }
+  $('#checklicensebutton').text('Checking...').prop('disabled', true).attr('aria-disabled', 'true');
+  $('#messages').html('');
+  hideResult();
+  var form = new FormData($('#checklicenseform')[0]);
+  findLicenseMatch({
+    type: 'POST',
+    enctype: 'multipart/form-data',
+    url: '/app/diff/',
+    processData: false,
+    contentType: false,
+    cache: false,
+    dataType: 'json',
+    data: form,
+  }, function() {
+    $('#checklicensebutton').text('Check license').prop('disabled', false).removeAttr('aria-disabled');
+  });
 });
-
 </script>
 {% endblock %}

--- a/src/app/templates/app/check_license.html
+++ b/src/app/templates/app/check_license.html
@@ -48,31 +48,31 @@ $(document).ready(function () {
     });
 </script>
 <script type="text/javascript">
-$('#checklicenseform').on('submit', function(event) {
+$('#checklicenseform').on('submit', function(event){
   event.preventDefault();
-  if ($('#licensetext').val() === '') {
-    $('#licensetext').focus();
-    $('#messages').html(
+  if ($("#licensetext").val() == "") {
+    $("#licensetext").focus();
+    $("#messages").html(
       '<div class="alert alert-danger" role="alert"><strong>Error:</strong> No text entered.</div>'
     );
-    setTimeout(function() { $('#messages').html(''); }, 5000);
+    setTimeout(function() { $("#messages").html(""); }, 5000);
     return;
   }
-  $('#checklicensebutton').text('Checking...').prop('disabled', true).attr('aria-disabled', 'true');
-  $('#messages').html('');
+  $("#checklicensebutton").text("Checking...").prop('disabled', true).attr('aria-disabled', 'true');
+  $("#messages").html("");
   hideResult();
-  var form = new FormData($('#checklicenseform')[0]);
+  var form = new FormData($("#checklicenseform")[0]);
   findLicenseMatch({
-    type: 'POST',
+    type: "POST",
     enctype: 'multipart/form-data',
-    url: '/app/diff/',
+    url: "/app/diff/",
     processData: false,
     contentType: false,
     cache: false,
     dataType: 'json',
     data: form,
   }, function() {
-    $('#checklicensebutton').text('Check license').prop('disabled', false).removeAttr('aria-disabled');
+    $("#checklicensebutton").text("Check license").prop('disabled', false).removeAttr('aria-disabled');
   });
 });
 </script>

--- a/src/app/templates/app/license_diff.html
+++ b/src/app/templates/app/license_diff.html
@@ -15,7 +15,7 @@
 <p class="lead">{{ error }}</p>
 <div class="panel panel-default">
   <div class="panel-heading">
-    <h1 class="panel-title">License Diff</h1>
+    <h1 class="panel-title">License diff</h1>
     <p>Check license text against existing SPDX licenses</p>
   </div>
   <div class="panel-body">

--- a/src/app/templates/app/license_diff.html
+++ b/src/app/templates/app/license_diff.html
@@ -14,28 +14,28 @@
 <div id="messages" class="messages" role="status" aria-live="polite"></div>
 <p class="lead">{{ error }}</p>
 <div class="panel panel-default">
-  <div class="panel-heading">
-    <h1 class="panel-title">License diff</h1>
-    <p>Check license text against existing SPDX licenses</p>
-  </div>
-  <div class="panel-body">
-    <form id="diffform" enctype="multipart/form-data" class="form-horizontal" method="post" aria-label="Check license diff">
-      {% csrf_token %}
-      <div class="form-group">
-        <label for="licensetext"><strong>License text</strong></label>
-        <textarea id="licensetext" name="licensetext" rows="18" style="width:100%" aria-required="true" placeholder="Paste the full license text here…"></textarea>
-      </div>
-      <button id="licensediffbutton" class="btn btn-md btn-info" type="submit">Check license diff</button>
-    </form>
+<div class="panel-heading">
+  <h1 class="panel-title">License diff</h1>
+  <p>Check license text against existing SPDX licenses</p>
+</div>
+<div class="panel-body">
+  <form id="diffform" enctype="multipart/form-data" class="form-horizontal" method="post" aria-label="Check license diff">
+    {% csrf_token %}
+    <div class="form-group">
+      <label for="licensetext"><strong>License text</strong></label>
+      <textarea id="licensetext" name="licensetext" rows="18" style="width:100%" aria-required="true" placeholder="Paste the full license text here…"></textarea>
+    </div>
+    <button id="licensediffbutton" class="btn btn-md btn-info" type="submit">Check license diff</button>
+  </form>
 
-    <section id="result-section" class="result-section" role="region" aria-label="License diff result" tabindex="-1" hidden>
-      <div id="result-header" class="result-header">
-        <h2 id="result-title" class="result-title"></h2>
-        <button type="button" class="result-close" aria-label="Close result" onclick="hideResult()">&times;</button>
-      </div>
-      <div id="result-body" class="result-body"></div>
-    </section>
-  </div>
+  <section id="result-section" class="result-section" role="region" aria-label="License diff result" tabindex="-1" hidden>
+    <div id="result-header" class="result-header">
+      <h2 id="result-title" class="result-title"></h2>
+      <button type="button" class="result-close" aria-label="Close result" onclick="hideResult()">&times;</button>
+    </div>
+    <div id="result-body" class="result-body"></div>
+  </section>
+</div>
 </div>
 {% endblock %}
 {% block script_block %}
@@ -58,32 +58,33 @@ function checkform() {
   }
 }
 
-$('#diffform').on('submit', function(event) {
+$('#diffform').on('submit', function(event){
   event.preventDefault();
   var check = checkform();
-  if (check=="1") {
-    $('#licensediffbutton').text('Checking…').prop('disabled', true).attr('aria-disabled', 'true');
-    $('#messages').html('');
+  if (check=="1"){
+    $("#licensediffbutton").text("Checking…").prop('disabled', true).attr('aria-disabled', 'true');
+    $("#messages").html("");
     hideResult();
 
-    var form = new FormData($('#diffform')[0]);
+    var form = new FormData($("#diffform")[0]);
     var request = {
-      type: 'POST',
-      enctype: 'multipart/form-data',
-      url: '/app/diff/',
+      type: "POST",
+      enctype: "multipart/form-data",
+      url: "/app/diff/",
       processData: false,
       contentType: false,
       cache: false,
-      dataType: 'json',
+      dataType: "json",
       data: form,
     };
     findLicenseMatch(request);
-  } else {
-    $('#messages').html(
+  }
+  else{
+    $("#messages").html(
       '<div class="alert alert-danger" role="alert"><strong>Error:</strong> ' +
       $('<span>').text(check).html() + '</div>'
     );
-    setTimeout(function() { $('#messages').html(''); }, 5000);
+    setTimeout(function() { $("#messages").html(""); }, 5000);
   }
 });
 

--- a/src/app/templates/app/license_diff.html
+++ b/src/app/templates/app/license_diff.html
@@ -87,32 +87,5 @@ $('#diffform').on('submit', function(event) {
   }
 });
 
-/* Render a side-by-side diff inline in the result section */
-function generate_text_diff(base, newtxt) {
-  var sm = new difflib.SequenceMatcher(base, newtxt);
-  var opcodes = sm.get_opcodes();
-  var diffEl = diffview.buildView({
-    baseTextLines: base,
-    newTextLines: newtxt,
-    opcodes: opcodes,
-    baseTextName: "SPDX license text",
-    newTextName: "Your license text",
-    contextSize: null,
-    viewType: 1,
-  });
-  // Strip the thead/th so only the diff body rows show
-  $(diffEl).find('thead').remove();
-  $(diffEl).find('th').remove();
-
-  var body = document.getElementById('result-body');
-  body.className = 'result-body diff-result-body';
-  body.innerHTML = '';
-  body.appendChild(diffEl);
-
-  // Scroll back to result section
-  var section = document.getElementById('result-section');
-  section.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  section.focus();
-}
 </script>
 {% endblock %}

--- a/src/app/templates/app/license_diff.html
+++ b/src/app/templates/app/license_diff.html
@@ -4,28 +4,44 @@
 {% block head_block %}
     <link href="{% static 'css/editor/editor.css' %}" rel="stylesheet" type="text/css">
     <link href="{% static 'css/editor/diffview.css' %}" rel="stylesheet" type="text/css">
+  <style>
+    .diff-result-body { padding: 0; overflow-x: auto; }
+    .diff-result-body table { font-size: 0.82em; }
+  </style>
 {% endblock %}
 
 {% block body1 %}
-<div id="messages" class="messages">
-</div>
-<p class ="lead"> {{ error }}</p>
+<div id="messages" class="messages" role="status" aria-live="polite"></div>
+<p class="lead">{{ error }}</p>
 <div class="panel panel-default">
-<div class="panel-heading">
-    <p class="lead">License Diff Section</p>
-    <p class="lead"><h4>Check license text with existing licenses</h4></p>
-</div>
-<div class="panel-body" style= "overflow:scroll;">
-<form id="diffform" enctype="multipart/form-data" class = "form-horizontal" method = "post"  >
-		{% csrf_token %}
-		<textarea id="licensetext" name="licensetext" rows="18" style="width: 100%"></textarea>
-		<button id="licensediffbutton" class=" btn btn-md btn-info" type="submit">Check license diff</button>
-</form>
-{% include "app/modal.html" %} 
+  <div class="panel-heading">
+    <h1 class="panel-title">License Diff</h1>
+    <p>Check license text against existing SPDX licenses</p>
+  </div>
+  <div class="panel-body">
+    <form id="diffform" enctype="multipart/form-data" class="form-horizontal" method="post" aria-label="Check license diff">
+      {% csrf_token %}
+      <div class="form-group">
+        <label for="licensetext"><strong>License text</strong></label>
+        <textarea id="licensetext" name="licensetext" rows="18" style="width:100%" aria-required="true" placeholder="Paste the full license text here…"></textarea>
+      </div>
+      <button id="licensediffbutton" class="btn btn-md btn-info" type="submit">Check license diff</button>
+    </form>
+
+    <section id="result-section" class="result-section" role="region" aria-label="License diff result" tabindex="-1" hidden>
+      <div id="result-header" class="result-header">
+        <h2 id="result-title" class="result-title"></h2>
+        <button type="button" class="result-close" aria-label="Close result" onclick="hideResult()">&times;</button>
+      </div>
+      <div id="result-body" class="result-body"></div>
+    </section>
+  </div>
 </div>
 {% endblock %}
 {% block script_block %}
 <script src="{% static 'js/utils.js' %}"></script>
+<script type="text/javascript" src="{% static 'js/editor/difflib.js' %}"></script>
+<script type="text/javascript" src="{% static 'js/editor/diffview.js' %}"></script>
 <script type="text/javascript">
 $(document).ready(function () {
     $("#licensediffpage").addClass('linkactive');
@@ -41,72 +57,62 @@ function checkform() {
     return "1";
   }
 }
-</script>
 
+$('#diffform').on('submit', function(event) {
+  event.preventDefault();
+  var check = checkform();
+  if (check=="1") {
+    $('#licensediffbutton').text('Checking…').prop('disabled', true).attr('aria-disabled', 'true');
+    $('#messages').html('');
+    hideResult();
 
-<script type="text/javascript">
-  $('#diffform').on('submit', function(event){
-    event.preventDefault();
-    var check = checkform();
-    console.log(check)
-    if (check=="1"){
-      $("#licensediffbutton").text("Checking...");
-      $("#licensediffbutton").prop('disabled', true);
-      $("#messages").html("");
-      var form = new FormData($("#diffform")[0]);
-      var request = {
-        type: "POST",
-        enctype: "multipart/form-data",
-        url: "/app/diff/",
-        processData: false,
-        contentType: false,
-        cache: false,
-        dataType: "json",
-        data: form,
-      };
-      findLicenseMatch(request);
-    }
-    else{
-      $("#messages").html('<div class="alert alert-danger alert-dismissable fade in"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a><strong>Error!</strong> '+check+'</div>');
-      setTimeout(function() {
-        $("#messages").html("");
-      }, 5000);
-    }
+    var form = new FormData($('#diffform')[0]);
+    var request = {
+      type: 'POST',
+      enctype: 'multipart/form-data',
+      url: '/app/diff/',
+      processData: false,
+      contentType: false,
+      cache: false,
+      dataType: 'json',
+      data: form,
+    };
+    findLicenseMatch(request);
+  } else {
+    $('#messages').html(
+      '<div class="alert alert-danger" role="alert"><strong>Error:</strong> ' +
+      $('<span>').text(check).html() + '</div>'
+    );
+    setTimeout(function() { $('#messages').html(''); }, 5000);
+  }
 });
 
-/* generate diff of input license text and spdx license list license text of closely matched licenses */
-async function generate_text_diff(base, newtxt){
-    var sm = new difflib.SequenceMatcher(base, newtxt);
-    var opcodes = sm.get_opcodes();
+/* Render a side-by-side diff inline in the result section */
+function generate_text_diff(base, newtxt) {
+  var sm = new difflib.SequenceMatcher(base, newtxt);
+  var opcodes = sm.get_opcodes();
+  var diffEl = diffview.buildView({
+    baseTextLines: base,
+    newTextLines: newtxt,
+    opcodes: opcodes,
+    baseTextName: "SPDX license text",
+    newTextName: "Your license text",
+    contextSize: null,
+    viewType: 1,
+  });
+  // Strip the thead/th so only the diff body rows show
+  $(diffEl).find('thead').remove();
+  $(diffEl).find('th').remove();
 
-    // build the diff view and add it to the current DOM
-    var diff = $(diffview.buildView({
-        baseTextLines: base,
-        newTextLines: newtxt,
-        opcodes: opcodes,
-        // set the display titles for each resource
-        baseTextName: "Base Text",
-        newTextName: "New Text",
-        contextSize: null,
-        viewType: 1
-    }))
-    diff.children().remove("thead");
-    diff.children().children().remove("th");
-    /* display result in modal */
-    displayModal("","success");
-    $("#modal-body").html(diff);
-    $("#modal-title").text("Close Match");
-    $("#modal-body").addClass("diff-modal-body");
-    $(".modal-dialog").addClass("diff-modal-dialog");
-    $("#myModal").modal({
-        backdrop: 'static',
-        keyboard: true,
-        show: true
-    });
+  var body = document.getElementById('result-body');
+  body.className = 'result-body diff-result-body';
+  body.innerHTML = '';
+  body.appendChild(diffEl);
+
+  // Scroll back to result section
+  var section = document.getElementById('result-section');
+  section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  section.focus();
 }
-
 </script>
-<script type="text/javascript" src="{% static 'js/editor/difflib.js' %}"></script>
-<script type="text/javascript" src="{% static 'js/editor/diffview.js' %}"></script>
-<script type="text/javascript" src="{% static 'js/editor/treeview.js' %}"></script>
 {% endblock %}

--- a/src/app/templates/app/submit_new_license.html
+++ b/src/app/templates/app/submit_new_license.html
@@ -398,7 +398,7 @@ function scrollUpAndHighlight(element) {
                   else if(matchType == "Close match"){
                     var inputLicenseText = data.inputLicenseText.replace(/\r\n/g,'\n');
                     var originalLicenseText = data.originalLicenseText;
-                    var matchingGuidelinesUrl = 'https://spdx.github.io/spdx-spec/v2.3/license-matching-guidelines-and-templates/'
+                    var matchingGuidelinesUrl = 'https://spdx.github.io/spdx-spec/latest/annexes/license-matching-guidelines-and-templates/'
                     var message = `Close match found.<br />The license closely matches with the license ID(s): <strong>${matchIds}</strong> based on the SPDX matching guidelines. Press show differences to continue.`
                     LicenseData.data = data;
                     if (!LicenseData.data.matchIds) {

--- a/src/app/templates/app/xml_upload.html
+++ b/src/app/templates/app/xml_upload.html
@@ -4,63 +4,72 @@
 {% block head_block %}
   <link href="{% static 'css/dragdrop.css' %}" rel="stylesheet" type="text/css">
   <link href="{% static 'css/jquery-ui.min.css' %}" rel="stylesheet" type="text/css">
+  <style>
+    .tab-pane { padding-top: 15px; }
+    .tab-pane p:first-child { margin-top: 0; }
+    #xmltext { width: 100%; resize: vertical; }
+    .license-name-field { text-align: center; }
+    label[for="licenseName"] { display: block; margin-bottom: 8px; font-weight: normal; }
+    #licenseName { width: 100%; max-width: 480px; }
+    #new p { text-align: center; }
+  </style>
 {% endblock %}
 
 {% block body1 %}
-<div id="messages" class="messages"></div>
-{% if error %}<p class="lead">{{ error }}</p>{% endif %}
+<div id="messages" class="messages" role="status" aria-live="polite"></div>
+{% if error %}<p class="lead text-danger" role="alert">{{ error }}</p>{% endif %}
 
 <div class="panel panel-default">
   <div class="panel-heading">
-    <p class="lead">License XML Editor</p>
+    <p class="lead">License XML editor</p>
   </div>
     <div class="panel-body">
 
-      <ul class="nav nav-tabs">
-        <li class="active"><a data-toggle="tab" href="#text">XML text</a></li>
-        <li><a data-toggle="tab" href="#upload">Upload file</a></li>
-        <li><a data-toggle="tab" href="#license-name">License name</a></li>
-        <li><a data-toggle="tab" href="#new">New license XML</a></li>
+      <ul class="nav nav-tabs" role="tablist">
+        <li class="active" role="presentation"><a data-toggle="tab" href="#text" role="tab" aria-controls="text" aria-selected="true" id="tab-text">XML text</a></li>
+        <li role="presentation"><a data-toggle="tab" href="#upload" role="tab" aria-controls="upload" aria-selected="false" id="tab-upload">Upload file</a></li>
+        <li role="presentation"><a data-toggle="tab" href="#license-name" role="tab" aria-controls="license-name" aria-selected="false" id="tab-license-name">License name</a></li>
+        <li role="presentation"><a data-toggle="tab" href="#new" role="tab" aria-controls="new" aria-selected="false" id="tab-new">New license XML</a></li>
       </ul>
 
       <div class="tab-content">
-        <div id="text" class="tab-pane fade in active">
-          <form id="form-text" enctype="multipart/form-data" class="form-horizontal" method="post">
+        <div id="text" class="tab-pane fade in active" role="tabpanel" aria-labelledby="tab-text">
+          <form id="form-text" enctype="multipart/form-data" class="form-horizontal" method="post" aria-label="Edit XML document text">
             {% csrf_token %}
-            <h4>Write the XML document text below: </h4>
-            <textarea id="xmltext" name="xmltext" rows="15" style="width: 90%; resize:none;"></textarea> <hr>
-            <button id="xmlTextButton" name="xmlTextButton" class=" btn btn-md btn-info" type="submit">Edit document</button>
+            <div class="form-group">
+              <label for="xmltext" class="sr-only">License XML text</label>
+              <textarea id="xmltext" name="xmltext" rows="12" aria-required="true" placeholder="Paste or type license XML here..."></textarea>
+            </div>
+            <button id="xmlTextButton" name="xmlTextButton" class="btn btn-md btn-info btn-submit-center" type="submit">Edit document</button>
           </form>
         </div>
-        <div id="upload" class="tab-pane fade">
-          <div id="drop-area" class="container">
-            <form id="form-upload" enctype="multipart/form-data" class="form-horizontal" method="post">
+        <div id="upload" class="tab-pane fade" role="tabpanel" aria-labelledby="tab-upload" >
+          <div id="drop-area" class="container" role="region" aria-label="File drop area">
+            <p>Upload XML file using the button or by dragging and dropping onto the dashed region</p>
+            <form id="form-upload" enctype="multipart/form-data" class="form-horizontal" method="post" aria-label="Upload XML file">
               {% csrf_token %}
-              <h4>Upload XML file using the button or by dragging and dropping onto the dashed region</h4>
-              <input type="file" id="file" accept="application/xml" onchange="handleFiles(this.files)">
+              <input type="file" id="file" accept="application/xml" onchange="handleFiles(this.files)" aria-describedby="file-name-status">
               <label class="button" for="file">Select XML file</label>
-              <div class="file-name">No file selected</div>
+              <div id="file-name-status" class="file-name" role="status" aria-live="polite">No file selected</div>
             </form>
           </div>
-          <button id="uploadButton" name="uploadButton" class="btn btn-md btn-info" type="submit">Edit document</button>
+          <button id="uploadButton" name="uploadButton" class="btn btn-md btn-info btn-submit-center" type="submit">Edit document</button>
         </div>
-        <div id="license-name" class="tab-pane fade">
-          <form id="form-license-name" enctype="multipart/form-data" class="form-horizontal" method="post">
+        <div id="license-name" class="tab-pane fade" role="tabpanel" aria-labelledby="tab-license-name" >
+          <form id="form-license-name" enctype="multipart/form-data" class="form-horizontal" method="post" aria-label="Look up license by name">
             {% csrf_token %}
-            <div class="container" style="margin-top:20px;">
-              <label class="control-label col-sm-6" >License full name or identifier as on SPDX License List:</label>
-              <div class="col-sm-6" style="text-align:left;"> 
-                <input type="text" id="licenseName" placeholder="License Name" name="licenseName" autocomplete="off" autofocus style="width:280px;">
-              </div>
-            </div> <hr>
-            <button id="licenseNameButton" name="licenseNameButton" class="btn btn-md btn-info" type="submit">Edit document</button>
+            <div class="license-name-field">
+              <label for="licenseName">License full name or SPDX License ID</label>
+              <input type="text" id="licenseName" placeholder="e.g. MIT, Apache-2.0" name="licenseName" autocomplete="off" autofocus aria-required="true">
+            </div>
+            <button id="licenseNameButton" name="licenseNameButton" class="btn btn-md btn-info btn-submit-center" type="submit">Edit document</button>
           </form>
         </div>
-        <div id="new" class="tab-pane fade">
-          <form id="form-new" enctype="multipart/form-data" class="form-horizontal" method="post">
+        <div id="new" class="tab-pane fade" role="tabpanel" aria-labelledby="tab-new" >
+          <form id="form-new" enctype="multipart/form-data" class="form-horizontal" method="post" aria-label="Create new license XML">
             {% csrf_token %}
-            <h3>Make a new License XML file from scratch</h3><br>
-            <button id="new-button" name="new-button" class="btn btn-l btn-info" type="submit">Go</button>
+            <p>Make a new License XML file from scratch</p>
+            <button id="new-button" name="new-button" class="btn btn-l btn-info btn-submit-center" type="submit">Go</button>
           </form>
         </div>
   </div>


### PR DESCRIPTION
> [!NOTE]
> **Depends on #655** — review/merge that first. The style infrastructure (`showResult`/`hideResult`, result-section CSS) used here lives in `base.html`.

## Summary

- `check_license.html` now render results directly below the form in a coloured result-section (success / warning / error) instead of opening a pop-up
- If it is a close match, show diff button
- `utils.js` (`findLicenseMatch`): remove modal calls, use `showResult()` from base.html; output is XSS-safe via `$('<span>').text().html()` escaping
- Update link to SPDX Matching Guidelines to https://spdx.github.io/spdx-spec/latest/annexes/license-matching-guidelines-and-templates/
- Fix layout in License XML editor, add tags for screen readers
- Change auto-close of fullscreen notice popup from 2 secs to 15 secs

## Files changed
- `src/app/static/js/utils.js`
- `src/app/templates/app/check_license.html`
- `src/app/templates/app/license_diff.html`

## Test plan
- [x] Check License: perfect match → green result
- [x] Check License: close match → orange result with "Show differences" button
- [x] Check License: no match → red result
- [x] Close result (×) hides the section

🤖 Generated with [Claude Code](https://claude.com/claude-code)