### PR TITLE
License XML editor: Fix fullscreen popup and tool bar

### DIFF
--- a/src/app/static/css/editor/fullscreen.css
+++ b/src/app/static/css/editor/fullscreen.css
@@ -1,7 +1,15 @@
 .CodeMirror-fullscreen {
   position: fixed;
-  margin-top: 50px;
-  top: 0; left: 0; right: 0; bottom: 0;
+  top: var(--navbar-height, 50px);
+  left: 0; right: 0; bottom: 0;
   height: auto;
   z-index: 9;
+}
+
+/* In fullscreen mode: hide navbar and use full viewport height */
+body:has(.CodeMirror-fullscreen) .navbar-fixed-top {
+  display: none;
+}
+body:has(.CodeMirror-fullscreen) .CodeMirror-fullscreen {
+  top: 0;
 }

--- a/src/app/static/js/editor/ns_script.js
+++ b/src/app/static/js/editor/ns_script.js
@@ -393,10 +393,10 @@ $(document).ready(function(){
             data: form,
             success: function (data) {
                 if(data.type=="valid"){
-                    displayModal("<h3>"+data.data+"</h3>","success");
+                    displayModal("<p>"+data.data+"</p>","success");
                 }
                 else{
-                    displayModal("<h3>"+data.data+"</h3>","alert");
+                    displayModal("<p>"+data.data+"</p>","alert");
                 }
                 $("#validateXML").text("Validate");
                 $("#validateXML").prop('disabled', false);
@@ -405,14 +405,14 @@ $(document).ready(function(){
                 try {
                     var obj = JSON.parse(e.responseText);
                     if (obj.type=="warning"){
-                        displayModal(obj.data, "alert");
+                        displayModal("<p>"+obj.data+"</p>", "alert");
                     }
                     else if (obj.type=="error"){
-                        displayModal(obj.data, "error");
+                        displayModal("<p>"+obj.data+"</p>", "error");
                     }
                 }
                 catch (e){
-                    displayModal("The application could not be connected. Please try later.","error");
+                    displayModal("<p>The application could not be connected. Please try later.</p>","error");
                 }
                 $("#validateXML").text("Validate");
                 $("#validateXML").prop('disabled', false);
@@ -714,8 +714,8 @@ function display_message(message){
     $("#modal-header").removeClass("red-modal");
     $("#modal-header").removeClass("yellow-modal");
     $("#modal-header").addClass("green-modal");
-    $("#modal-title").html("SPDX License XML Editor");
-    $("#modal-body").html("<h3>"+message+"</h3>");
+    $("#modal-title").html("License XML editor");
+    $("#modal-body").html("<p>"+message+"</p>");
     $('button.close').remove();
     $('<button type="button" class="close" data-dismiss="modal">&times;</button>').insertBefore($("h4.modal-title"));
     $(".modal-footer").html('<button class="btn btn-default" data-dismiss="modal">OK</button>')
@@ -726,7 +726,7 @@ function display_message(message){
     });
     setTimeout(function() {
         $(".close").click();
-    }, 2000);
+    }, 15000);
     $(".close").click(function(){
         editor.focus();
     })

--- a/src/app/static/js/editor/script.js
+++ b/src/app/static/js/editor/script.js
@@ -202,9 +202,16 @@ $(document).ready(function(){
         editor.focus();
     }
     function exitFullScreen(){
-        if (editor.getOption("fullScreen")) editor.setOption("fullScreen", false);
-        fullscreen = false;
-        editor.focus();
+        if (editor.getOption("fullScreen")) {
+            editor.setOption("fullScreen", false);
+            fullscreen = false;
+            editor.focus();
+        } else {
+            /* Not in fullscreen — release focus back to the active tab link
+               so the user can Tab forward to the action buttons. */
+            var activeTabLink = document.querySelector('.nav-tabs [role="tab"][aria-selected="true"]');
+            if (activeTabLink) activeTabLink.focus();
+        }
     }
 
     /* make editor responsive, whenever browser is resized,

--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -578,6 +578,9 @@ h4 { font-size: 1.2em !important; }
           const navHeight = $('.navbar-fixed-top').height();
           const newPadding = navHeight + 10; // Add 10px for extra space
           $('body').css('padding-top', newPadding + 'px');
+          // Expose navbar height as CSS custom property so fullscreen overlays
+          // (e.g. CodeMirror fullscreen) can stay below the navbar on any screen width.
+          document.documentElement.style.setProperty('--navbar-height', navHeight + 'px');
           var $dotsIframe = $('#dots-iframe');
           if ($dotsIframe.length) {
             $dotsIframe.css('height', 'calc(100vh - ' + newPadding + 'px)');

--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -290,10 +290,12 @@ label.control-label { font-weight: 600; color: #444; font-size: 0.92em; }
 .btn-primary { background-color: #2a6496; border-color: #2a6496; color: #fff; }
 .btn-primary:hover,
 .btn-primary:focus { background-color: #1e4d73; border-color: #1e4d73; color: #fff; }
-/* btn-warning: white on #856500 ≈ 5.4:1 ✓  (Bootstrap default #f0ad4e ≈ 1.9:1 ✗) */
-.btn-warning { background-color: #856500; border-color: #856500; color: #fff; }
+/* btn-warning: white on #c04000 ≈ 5.3:1 ✓  (Bootstrap default #f0ad4e ≈ 1.9:1 ✗) */
+/* #c04000 is the brightest achievable orange where white text passes WCAG AA;         */
+/* adding more green shifts toward yellow and blows past the luminance ceiling.        */
+.btn-warning { background-color: #c04000; border-color: #c04000; color: #fff; }
 .btn-warning:hover,
-.btn-warning:focus { background-color: #6b5200; border-color: #6b5200; color: #fff; }
+.btn-warning:focus { background-color: #963200; border-color: #963200; color: #fff; }
 /* btn-info: white on #007aa0 ≈ 4.9:1 ✓  (white on #0097c4 ≈ 3.4:1 ✗) */
 .btn-info { background-color: #007aa0; border: none; padding: 8px 20px; color: #fff; }
 .btn-info:hover,

--- a/src/app/templates/app/base.html
+++ b/src/app/templates/app/base.html
@@ -255,13 +255,49 @@ textarea:focus {
 }
 label.control-label { font-weight: 600; color: #444; font-size: 0.92em; }
 
+/* skip-to-main link for keyboard users */
+.skip-link {
+    position: absolute;
+    top: -100px;
+    left: 0;
+    z-index: 9999;
+    padding: 8px 18px;
+    background: #0097c4;
+    color: #fff !important;
+    font-weight: 700;
+    font-size: 16px !important;
+    text-decoration: none;
+    border-radius: 0 0 4px 0;
+    transition: top 0.1s;
+}
+.skip-link:focus {
+    top: 0;
+    outline: 3px solid #fff;
+    outline-offset: 2px;
+    color: #fff !important;
+}
+
 /* buttons */
 .btn { border-radius: 5px; font-weight: 600; transition: background 0.12s, box-shadow 0.12s; }
 .btn:focus,
-.btn:active:focus { outline: 3px solid rgba(0,151,196,0.35); outline-offset: 2px; }
-.btn-info { background-color: #0097c4; border: none; padding: 8px 20px; color: #fff; }
+.btn:active:focus { outline: 3px solid rgba(0,151,196,0.85); outline-offset: 2px; }
+/* WCAG AA contrast overrides — all ratios verified ≥ 4.5:1 */
+/* btn-success: white on #2e7d32 ≈ 5.1:1 ✓  (Bootstrap default #5cb85c ≈ 2.5:1 ✗) */
+.btn-success { background-color: #2e7d32; border-color: #2e7d32; color: #fff; }
+.btn-success:hover,
+.btn-success:focus { background-color: #1b5e20; border-color: #1b5e20; color: #fff; }
+/* btn-primary: white on #2a6496 ≈ 5.1:1 ✓  (Bootstrap default #337ab7 ≈ 4.6:1, barely) */
+.btn-primary { background-color: #2a6496; border-color: #2a6496; color: #fff; }
+.btn-primary:hover,
+.btn-primary:focus { background-color: #1e4d73; border-color: #1e4d73; color: #fff; }
+/* btn-warning: white on #856500 ≈ 5.4:1 ✓  (Bootstrap default #f0ad4e ≈ 1.9:1 ✗) */
+.btn-warning { background-color: #856500; border-color: #856500; color: #fff; }
+.btn-warning:hover,
+.btn-warning:focus { background-color: #6b5200; border-color: #6b5200; color: #fff; }
+/* btn-info: white on #007aa0 ≈ 4.9:1 ✓  (white on #0097c4 ≈ 3.4:1 ✗) */
+.btn-info { background-color: #007aa0; border: none; padding: 8px 20px; color: #fff; }
 .btn-info:hover,
-.btn-info:focus { background-color: #007aa0; color: #fff; }
+.btn-info:focus { background-color: #005f7d; color: #fff; }
 .btn-default { padding: 7px 16px; }
 .btn-default:focus { outline: 3px solid rgba(0,0,0,0.18); outline-offset: 2px; }
 
@@ -461,6 +497,8 @@ h4 { font-size: 1.2em !important; }
   </head>
   <body>
 
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+
     <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation" aria-label="Main navigation">
       <div class="container-fluid">
         <div class="navbar-header">
@@ -528,7 +566,7 @@ h4 { font-size: 1.2em !important; }
       </div>
     </nav>
 
-  <div class="container body1">
+  <div class="container body1" id="main-content" tabindex="-1">
 
       <div class="starter-template">
         {% block body1 %}{% endblock %}

--- a/src/app/templates/app/compare.html
+++ b/src/app/templates/app/compare.html
@@ -50,11 +50,15 @@
     transition: background 0.12s, color 0.12s;
   }
 
-  .file-remove-btn:hover,
+  .file-remove-btn:hover {
+    background: #c0392b;
+    color: #fff;
+  }
   .file-remove-btn:focus {
     background: #c0392b;
     color: #fff;
-    outline: none;
+    outline: 2px solid #8b0000;
+    outline-offset: 2px;
   }
 
   .file-list-empty {

--- a/src/app/templates/app/editor.html
+++ b/src/app/templates/app/editor.html
@@ -53,22 +53,10 @@
         </div>
     </div><hr>
     <div class="document-options text-center" role="toolbar" aria-label="Document actions">
-            <button type="button" class="btn btn-success" id="download"
-                    data-toggle="tooltip" data-placement="left"
-                    title="Download the XML document"
-                    aria-label="Download XML document">Download</button>
-            <button type="button" class="btn btn-primary" id="generateDiff"
-                    data-toggle="tooltip" data-placement="top"
-                    title="Generate a diff to see all the changes made"
-                    aria-label="Generate diff of all changes made">Generate diff</button>
-            <button type="button" class="btn btn-warning" id="validateXML"
-                    data-toggle="tooltip" data-placement="top"
-                    title="Validate the XML against the SPDX License Schema"
-                    aria-label="Validate XML against SPDX License Schema">Validate</button>
-            <button type="button" class="btn btn-info" id="makePullRequest"
-                    data-toggle="tooltip" data-placement="right"
-                    title="Submit changes as a pull request to the SPDX License List repository"
-                    aria-label="Submit changes as a pull request">Submit changes</button>
+            <button type="button" class="btn btn-success" id="download" data-toggle="tooltip" data-placement="left" title="Download the XML document" aria-label="Download XML document">Download</button>
+            <button type="button" class="btn btn-primary" id="generateDiff" data-toggle="tooltip" data-placement="top" title="Generate a diff to see all the changes made" aria-label="Generate diff of all changes made">Generate diff</button>
+            <button type="button" class="btn btn-warning" id="validateXML" data-toggle="tooltip" data-placement="top" title="Validate the XML against the SPDX License Schema" aria-label="Validate XML against SPDX License Schema">Validate</button>
+            <button type="button" class="btn btn-info" id="makePullRequest" data-toggle="tooltip" data-placement="right" title="Submit changes as a pull request to the SPDX License List repository" aria-label="Submit changes as a pull request">Submit changes</button>
     </div>
     <form style="display:none" id="form">
         {% csrf_token %}

--- a/src/app/templates/app/editor.html
+++ b/src/app/templates/app/editor.html
@@ -9,7 +9,27 @@
     <link href="{% static 'css/editor/foldgutter.css' %}" rel="stylesheet" type="text/css">
     <link href="{% static 'css/editor/treeview.css' %}" rel="stylesheet" type="text/css">
     <link href="{% static 'css/editor/diffview.css' %}" rel="stylesheet" type="text/css">
-    <style>.starter-template { padding: 0; }</style>
+    <style>
+        .starter-template { padding: 0; }
+        .skip-to-actions {
+            position: absolute;
+            left: -9999px;
+            top: auto;
+            width: 1px;
+            height: 1px;
+            overflow: hidden;
+        }
+        .skip-to-actions:focus {
+            position: static;
+            width: auto;
+            height: auto;
+            overflow: visible;
+            display: block;
+            margin: 4px auto;
+            text-align: center;
+            font-size: 0.9em;
+        }
+    </style>
 {% endblock %}
 
 {% block body1 %}
@@ -31,7 +51,9 @@
                     <button type="button" id="fullscreen" class="btn btn-default">Fullscreen</button>
                     <button type="button" class="btn btn-md btn-default" id="beautify">Beautify</button>
                 </div>
-                <textarea class="codemirror-textarea">{{xml_text}}</textarea>
+                <a href="#document-options" class="skip-to-actions">Skip to document actions</a>
+                <p class="sr-only" id="editor-kb-hint">Press Escape to leave the editor and return focus to the tab bar. Or use the Skip to document actions link above.</p>
+                <textarea class="codemirror-textarea" aria-describedby="editor-kb-hint">{{xml_text}}</textarea>
             </div>
             <div id="tree" class="tab-pane fade" role="tabpanel" aria-labelledby="tabTreeEditor" tabindex="0">
                 <div class="treeContainer">
@@ -52,7 +74,7 @@
             </div>
         </div>
     </div><hr>
-    <div class="document-options text-center" role="toolbar" aria-label="Document actions">
+    <div class="document-options text-center" role="toolbar" aria-label="Document actions" id="document-options" tabindex="-1">
             <button type="button" class="btn btn-success" id="download" data-toggle="tooltip" data-placement="left" title="Download the XML document" aria-label="Download XML document">Download</button>
             <button type="button" class="btn btn-primary" id="generateDiff" data-toggle="tooltip" data-placement="top" title="Generate a diff to see all the changes made" aria-label="Generate diff of all changes made">Generate diff</button>
             <button type="button" class="btn btn-warning" id="validateXML" data-toggle="tooltip" data-placement="top" title="Validate the XML against the SPDX License Schema" aria-label="Validate XML against SPDX License Schema">Validate</button>
@@ -146,8 +168,11 @@
     else if (e.key === 'End')        next = tabs.length - 1;
     else return;
     e.preventDefault();
-    tabs[next].click();
-    tabs[next].focus();
+    var toFocus = tabs[next];
+    toFocus.click();
+    /* script.js calls editor.focus() inside setTimeout(..., 200) after tab switch.
+       Re-focus the tab link at 250ms to reclaim focus after CodeMirror steals it. */
+    setTimeout(function () { toFocus.focus(); }, 250);
   });
 
   /* Keep aria-selected + tabindex in sync after Bootstrap activates a tab */

--- a/src/app/templates/app/editor.html
+++ b/src/app/templates/app/editor.html
@@ -19,28 +19,28 @@
 {% block body2 %}
     <div class="container-fluid editor-container">
         <input type="hidden" id="xmlText" value="{{xml_text}}">
-        <ul class="nav nav-tabs">
-            <li class="active"><a href="#text" id="tabTextEditor">Text editor</a></li>
-            <li><a data-toggle="tab" href="#tree" id="tabTreeEditor">Tree editor</a></li>
-            <li><a data-toggle="tab" href="#split" id="tabSplitView">Split view</a></li>
+        <ul class="nav nav-tabs" role="tablist">
+            <li class="active" role="presentation"><a href="#text" id="tabTextEditor" role="tab" aria-selected="true" aria-controls="text" data-toggle="tab" tabindex="0">Text editor</a></li>
+            <li role="presentation"><a data-toggle="tab" href="#tree" id="tabTreeEditor" role="tab" aria-selected="false" aria-controls="tree" tabindex="-1">Tree editor</a></li>
+            <li role="presentation"><a data-toggle="tab" href="#split" id="tabSplitView" role="tab" aria-selected="false" aria-controls="split" tabindex="-1">Split view</a></li>
         </ul>
         <div class="tab-content">
-            <div id="text" class="tab-pane fade in active">
+            <div id="text" class="tab-pane fade in active" role="tabpanel" aria-labelledby="tabTextEditor" tabindex="0">
                 <div class="text-editor-options text-center">
-                    <button id="dec-fontsize" class="btn"> <b>-</b> </button> Font size <button id="inc-fontsize" class="btn"> <b>+</b> </button>&nbsp;
-                    <button id="fullscreen" class="btn btn-default">Fullscreen</button>
-                    <button class="btn btn-md btn-default" id="beautify">Beautify</button>
+                    <button type="button" id="dec-fontsize" class="btn" aria-label="Decrease font size"><b aria-hidden="true">-</b></button> Font size <button type="button" id="inc-fontsize" class="btn" aria-label="Increase font size"><b aria-hidden="true">+</b></button>&nbsp;
+                    <button type="button" id="fullscreen" class="btn btn-default">Fullscreen</button>
+                    <button type="button" class="btn btn-md btn-default" id="beautify">Beautify</button>
                 </div>
                 <textarea class="codemirror-textarea">{{xml_text}}</textarea>
             </div>
-            <div id="tree" class="tab-pane fade">
+            <div id="tree" class="tab-pane fade" role="tabpanel" aria-labelledby="tabTreeEditor" tabindex="0">
                 <div class="treeContainer">
                     <ul id="treeView" class="treeView">
                         <li></li>
                     </ul>
                 </div>
             </div>
-            <div id="split" class="tab-pane fade">
+            <div id="split" class="tab-pane fade" role="tabpanel" aria-labelledby="tabSplitView" tabindex="0">
                 <div class="col-md-6 splitTextEditorContainer">
                     <textarea class="codemirror-textarea">{{xml_text}}</textarea>
                 </div>
@@ -52,11 +52,23 @@
             </div>
         </div>
     </div><hr>
-    <div class="document-options text-center">
-            <button class="btn btn-success" id="download" data-toggle="tooltip" data-placement="left" title="Download the XML Document">Download</button>
-            <button class="btn btn-primary" id="generateDiff" data-toggle="tooltip" title="Generate a diff to see all the changes made" data-placement="top">Generate diff</button>
-            <button class="btn btn-warning" id="validateXML" data-toggle="tooltip" title="Validate the XML against the SPDX License Schema" data-placement="top">Validate</button>
-            <button class="btn btn-info" id="makePullRequest" data-toggle="tooltip" title="Make a Pull Request in the SPDX XML License Repository to get your changes reviewed and merged" data-placement="right">Submit changes</button>
+    <div class="document-options text-center" role="toolbar" aria-label="Document actions">
+            <button type="button" class="btn btn-success" id="download"
+                    data-toggle="tooltip" data-placement="left"
+                    title="Download the XML document"
+                    aria-label="Download XML document">Download</button>
+            <button type="button" class="btn btn-primary" id="generateDiff"
+                    data-toggle="tooltip" data-placement="top"
+                    title="Generate a diff to see all the changes made"
+                    aria-label="Generate diff of all changes made">Generate diff</button>
+            <button type="button" class="btn btn-warning" id="validateXML"
+                    data-toggle="tooltip" data-placement="top"
+                    title="Validate the XML against the SPDX License Schema"
+                    aria-label="Validate XML against SPDX License Schema">Validate</button>
+            <button type="button" class="btn btn-info" id="makePullRequest"
+                    data-toggle="tooltip" data-placement="right"
+                    title="Submit changes as a pull request to the SPDX License List repository"
+                    aria-label="Submit changes as a pull request">Submit changes</button>
     </div>
     <form style="display:none" id="form">
         {% csrf_token %}
@@ -71,30 +83,30 @@
             {% csrf_token %}
             <div class="form-group">
                 <label for="branchName">Branch Name:</label>
-                <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" title="Pull Request will be made from this branch to the main branch" style="font-size:12px;"></span>
+                <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip" title="Pull Request will be made from this branch to the main branch" style="font-size:12px;"></span>
                 <input type="text" class="form-control" id="branchName" name="branchName">
             </div><br>
             <div class="checkbox">
-                <label><input type="checkbox" id="updateUpstream">Update with upstream main</label> <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" title="Select this if you want to update your forked repo with the upstream repo, before making the pull request" style="font-size:12px;"></span>
+                <label><input type="checkbox" id="updateUpstream">Update with upstream main</label> <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip" title="Select this if you want to update your forked repo with the upstream repo, before making the pull request" style="font-size:12px;"></span>
             </div>
             <div class="form-group">
                 <label for="fileName">File Name:</label>
-                <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" title="Name of the XML file" style="font-size:12px;"></span>
+                <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip" title="Name of the XML file" style="font-size:12px;"></span>
                 <input type="text" class="form-control" id="fileName" name="fileName" value={{license_name}}> .xml
             </div><br>
             <div class="form-group">
                 <label for="commitMessage">Commit Message:</label>
-                <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" title="Git commit message, a brief description of your changes" style="font-size:12px;"></span>
+                <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip" title="Git commit message, a brief description of your changes" style="font-size:12px;"></span>
                 <input type="text" class="form-control" id="commitMessage" name="commitMessage">
             </div><br>
             <div class="form-group">
                 <label for="prTitle">Pull Request Title:</label>
-                <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" title="GitHub Pull Request title, can be edited later." style="font-size:12px;"></span>
+                <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip" title="GitHub Pull Request title, can be edited later." style="font-size:12px;"></span>
                 <input type="text" class="form-control" id="prTitle" name="prTitle">
             </div><br>
             <div class="form-group">
                 <label for="prBody">Pull Request Body:</label>
-                <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" title="GitHub Pull Request body, can be edited later." style="font-size:12px;"></span>
+                <span class="glyphicon glyphicon-info-sign" aria-hidden="true" data-toggle="tooltip" title="GitHub Pull Request body, can be edited later." style="font-size:12px;"></span>
                 <textarea class="form-control" rows="5" id="prBody" name="prBody" style="resize:none; width:200px;"></textarea>
             </div><br>
             <input type="hidden" name="hidden_license_id" value="{{license_id}}">
@@ -127,5 +139,38 @@
   $(document).ready(function () {
     $("#license-xml-editor").addClass('linkactive');
   });
+</script>
+<script type="text/javascript">
+/* Tab keyboard navigation — ARIA Authoring Practices §3.22 */
+(function () {
+  var tabList = document.querySelector('[role="tablist"]');
+  if (!tabList) return;
+
+  /* Arrow keys move focus and activate tab */
+  tabList.addEventListener('keydown', function (e) {
+    var tabs = Array.from(tabList.querySelectorAll('[role="tab"]'));
+    var idx  = tabs.indexOf(document.activeElement);
+    if (idx === -1) return;
+    var next;
+    if      (e.key === 'ArrowRight') next = (idx + 1) % tabs.length;
+    else if (e.key === 'ArrowLeft')  next = (idx - 1 + tabs.length) % tabs.length;
+    else if (e.key === 'Home')       next = 0;
+    else if (e.key === 'End')        next = tabs.length - 1;
+    else return;
+    e.preventDefault();
+    tabs[next].click();
+    tabs[next].focus();
+  });
+
+  /* Keep aria-selected + tabindex in sync after Bootstrap activates a tab */
+  $('[role="tab"]').on('shown.bs.tab', function () {
+    var tabs = Array.from(tabList.querySelectorAll('[role="tab"]'));
+    tabs.forEach(function (t) {
+      var active = t.parentElement.classList.contains('active');
+      t.setAttribute('aria-selected', active ? 'true' : 'false');
+      t.setAttribute('tabindex',      active ? '0'    : '-1');
+    });
+  });
+}());
 </script>
 {% endblock %}

--- a/src/app/templates/app/index.html
+++ b/src/app/templates/app/index.html
@@ -65,7 +65,6 @@
     transition: transform 0.08s ease, box-shadow 0.08s ease, filter 0.08s ease;
     cursor: pointer;
     border: none;
-    outline: none;
 }
 .tool-btn:hover, .tool-btn:focus {
     text-decoration: none;
@@ -73,6 +72,15 @@
     transform: translateY(-2px);
     box-shadow: 0 6px 16px rgba(0,0,0,0.24);
     filter: brightness(1.08);
+}
+.tool-btn:focus {
+    outline: 3px solid #fff;
+    outline-offset: 3px;
+}
+.tool-btn:focus:not(:focus-visible) { outline: none; }
+.tool-btn:focus-visible {
+    outline: 3px solid #fff;
+    outline-offset: 3px;
 }
 .tool-btn:active {
     transform: translateY(0);

--- a/src/app/templates/app/modal.html
+++ b/src/app/templates/app/modal.html
@@ -1,11 +1,11 @@
 <!-- Modal -->
-<div id="myModal" class="modal fade" role="dialog">
+<div id="myModal" class="modal fade" role="dialog" aria-labelledby="modal-title" aria-modal="true">
   <div class="modal-dialog" style="width: 70rem;">
 
     <!-- Modal content-->
     <div class="modal-content">
       <div id="modal-header" class="modal-header">
-        <button type="button" class="close" data-dismiss="modal">&times;</button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">&times;</button>
         <h4 id="modal-title" class="modal-title"></h4>
       </div>
        <div id="modal-body" class="modal-body" style="font-size:24px;">

--- a/src/app/templates/app/xml_upload.html
+++ b/src/app/templates/app/xml_upload.html
@@ -26,10 +26,10 @@
     <div class="panel-body">
 
       <ul class="nav nav-tabs" role="tablist">
-        <li class="active" role="presentation"><a data-toggle="tab" href="#text" role="tab" aria-controls="text" aria-selected="true" id="tab-text">XML text</a></li>
-        <li role="presentation"><a data-toggle="tab" href="#upload" role="tab" aria-controls="upload" aria-selected="false" id="tab-upload">Upload file</a></li>
-        <li role="presentation"><a data-toggle="tab" href="#license-name" role="tab" aria-controls="license-name" aria-selected="false" id="tab-license-name">License name</a></li>
-        <li role="presentation"><a data-toggle="tab" href="#new" role="tab" aria-controls="new" aria-selected="false" id="tab-new">New license XML</a></li>
+        <li class="active" role="presentation"><a data-toggle="tab" href="#text" role="tab" aria-controls="text" aria-selected="true" id="tab-text" tabindex="0">XML text</a></li>
+        <li role="presentation"><a data-toggle="tab" href="#upload" role="tab" aria-controls="upload" aria-selected="false" id="tab-upload" tabindex="-1">Upload file</a></li>
+        <li role="presentation"><a data-toggle="tab" href="#license-name" role="tab" aria-controls="license-name" aria-selected="false" id="tab-license-name" tabindex="-1">License name</a></li>
+        <li role="presentation"><a data-toggle="tab" href="#new" role="tab" aria-controls="new" aria-selected="false" id="tab-new" tabindex="-1">New license XML</a></li>
       </ul>
 
       <div class="tab-content">
@@ -53,7 +53,7 @@
               <div id="file-name-status" class="file-name" role="status" aria-live="polite">No file selected</div>
             </form>
           </div>
-          <button id="uploadButton" name="uploadButton" class="btn btn-md btn-info btn-submit-center" type="submit">Edit document</button>
+          <button id="uploadButton" name="uploadButton" class="btn btn-md btn-info btn-submit-center" type="button">Edit document</button>
         </div>
         <div id="license-name" class="tab-pane fade" role="tabpanel" aria-labelledby="tab-license-name" >
           <form id="form-license-name" enctype="multipart/form-data" class="form-horizontal" method="post" aria-label="Look up license by name">
@@ -297,6 +297,35 @@
     });
     $("#license-xml-editor").addClass('linkactive');
   });
+</script>
+
+<script type="text/javascript">
+  (function () {
+    var tabList = document.querySelector('[role="tablist"]');
+    if (!tabList) return;
+    tabList.addEventListener('keydown', function (e) {
+      var tabs = Array.from(tabList.querySelectorAll('[role="tab"]'));
+      var idx  = tabs.indexOf(document.activeElement);
+      if (idx === -1) return;
+      var next;
+      if      (e.key === 'ArrowRight') next = (idx + 1) % tabs.length;
+      else if (e.key === 'ArrowLeft')  next = (idx - 1 + tabs.length) % tabs.length;
+      else if (e.key === 'Home')       next = 0;
+      else if (e.key === 'End')        next = tabs.length - 1;
+      else return;
+      e.preventDefault();
+      tabs[next].click();
+      tabs[next].focus();
+    });
+    $('[role="tab"]').on('shown.bs.tab', function () {
+      var tabs = Array.from(tabList.querySelectorAll('[role="tab"]'));
+      tabs.forEach(function (t) {
+        var active = t.parentElement.classList.contains('active');
+        t.setAttribute('aria-selected', active ? 'true' : 'false');
+        t.setAttribute('tabindex',      active ? '0'    : '-1');
+      });
+    });
+  }());
 </script>
 
 {% endblock %}


### PR DESCRIPTION
- Change message wrapper from `<h3>` to `<p>` for consistency
- Increase auto-close timeout from 2 secs to 15 secs so users have time to read
- Make the top menu bar disappear as well in fullscreen mode
- Add accessibility label to buttons to assist screen reader
- Fix keyboard navigation; Use Esc to exit text area + add a skip link so that Download/Submit buttons are be accessible by keyboard

### Fullscreen before this PR

<img width="788" height="389" src="https://github.com/user-attachments/assets/bfa8b51b-6763-4c94-b557-c1e37f71187e" />

### Fullscreen with this PR

<img width="788" height="474" src="https://github.com/user-attachments/assets/30cf9d83-ca6f-4c12-8e65-f8ff34d4477b" />

### Buttons before this PR

"Validate" is low contrast (light text over light background)

<img width="603" height="78" src="https://github.com/user-attachments/assets/7ce4a446-4088-4f25-9e44-1e042d34abb1" />

### Buttons with this PR

"Validate" is higher contrast (darker background), keep it over 5.1:1 WCAG recommended ratio. 

<img width="608" height="92" src="https://github.com/user-attachments/assets/85f464a4-e28a-4cdb-b4d7-cb66024146cf" />
