### PR TITLE
Convert: fix "to" to stay same line with target drop down

### DIFF
--- a/src/app/templates/app/convert.html
+++ b/src/app/templates/app/convert.html
@@ -16,8 +16,9 @@
 <form id="convertform" enctype="multipart/form-data" class="form-horizontal" method="post" aria-label="Convert SPDX document">
 		{% csrf_token %}
 		<div class="form-narrow">
-			<div class="form-group text-center">
-				<label for="from_format">From</label>&nbsp;
+			<div class="form-group" style="display:flex; flex-wrap:wrap; align-items:center; justify-content:center; gap:6px 10px;">
+				<span style="display:inline-flex; align-items:center; gap:4px;">
+				<label for="from_format">From</label>
 			<select name="from_format" id="from_format" aria-required="true">
 			 	  <option value="0" selected="">— Select source format —</option>
 				  <option value="JSON">V2 JSON</option>
@@ -29,7 +30,9 @@
 				  <option value="XML">V2 XML</option>
 				  <option value="YAML">V2 YAML</option>
 			</select>
-			&nbsp;<label for="to_format">to</label>&nbsp;
+			</span>
+			<span style="display:inline-flex; align-items:center; gap:4px;">
+			<label for="to_format">to</label>
 			<select name="to_format" id="to_format" aria-required="true">
 			 	  <option value="0" data-value="INGORE" data-ext="" selected="">— Select target format —</option>
 			 	  <option value="JSONLD" data-value="JSONLD" data-ext=".spdx3.json">V3 JSON-LD</option>
@@ -42,6 +45,7 @@
 				  <option value="XML" data-value="XML" data-ext=".xml">V2 XML</option>
 				  <option value="YAML" data-value="YAML" data-ext=".yaml">V2 YAML</option>
       </select>
+	    </span>
 	    </div>
 		</div>
     <div id="drop-area" class="container" role="region" aria-label="File upload area">


### PR DESCRIPTION
Make the "to" label and the target format drop down list stay in the same line, in a narrow window.

Before this PR:

<img width="452" height="197" src="https://github.com/user-attachments/assets/226bee7d-e340-4161-8feb-25e2872c3d34" />

With this PR:

<img width="537" height="195" src="https://github.com/user-attachments/assets/6d24b40a-f2be-4ba0-9720-da3c86238294" />