### PR TITLE
Update JPype to 1.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Django>=5.2.13,<5.3.0
 djangorestframework>=3.17.1,<4.0.0
 gevent>=26.4.0,<27.0.0
 gunicorn>=25.3.0,<26.0.0
-jpype1==1.7.0
+jpype1>=1.7.1,<1.8.0
 lxml>=5.4.0,<6.0.0
 ntia-conformance-checker>=5.0.2,<6.0.0
 python-dotenv>=1.0.1,<2.0.0


### PR DESCRIPTION
JPype 1.7.1 now supports Python 3.14