### PR TITLE
Correct osiApproved test data to fix test_post_submit

### DIFF
--- a/src/app/tests.py
+++ b/src/app/tests.py
@@ -1337,7 +1337,7 @@ class SubmitNewLicenseViewsTestCase(TestCase):
         self.exampleUrl = "testUrl"
         self.sourceUrl = "http://landley.net/toybox/license.html"
         self.urls = [self.sourceUrl]
-        self.osiApproved = "no"
+        self.osiApproved = "Unknown"
         self.comments = "Test Comment"
         self.notes = ""
         self.licenseHeader = ""
@@ -1578,7 +1578,7 @@ class SubmitNewLicenseNamespaceViewsTestCase(TestCase):
         self.sourceUrl = "http://landley.net/toybox/license.html"
         self.license_list_url = self.sourceUrl
         self.github_repo_url = self.sourceUrl
-        self.osiApproved = "no"
+        self.osiApproved = "Unknown"
         self.comments = ""
         self.notes = ""
         self.licenseHeader = ""


### PR DESCRIPTION
osiApproved is set to "no" in test data.

But "no" is not OSI_CHOICES value.
So it failed the form validation and return None,
and then further fails test_post_submit because it tries to access `licenseAuthorName` from `licenseRequest` (which is None)

Fix #202 