### PR TITLE
License info page: Add link to GitHub issue

### DIFF
--- a/src/api/views.py
+++ b/src/api/views.py
@@ -539,7 +539,10 @@ def submit_license(request):
             if 'urlType' in request.POST:
                 # This is present only when executing submit license via tests
                 urlType = request.POST["urlType"]
-            statusCode, githubIssueId = createIssue(licenseAuthorName, licenseName, licenseIdentifier, licenseComments, licenseSourceUrls, licenseHeader, licenseOsi, licenseRequestUrl, token, urlType)
+            statusCode, githubIssueId, githubIssueUrl = createIssue(licenseAuthorName, licenseName, licenseIdentifier, licenseComments, licenseSourceUrls, licenseHeader, licenseOsi, licenseRequestUrl, token, urlType)
+            licenseRequest.github_issue_number = githubIssueId
+            licenseRequest.github_issue_url = githubIssueUrl
+            licenseRequest.save()
             if str(statusCode) == '201':
                 result = "Success! The license request has been successfully submitted."
                 query.result = result

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -539,7 +539,19 @@ def submit_license(request):
             if 'urlType' in request.POST:
                 # This is present only when executing submit license via tests
                 urlType = request.POST["urlType"]
-            statusCode, githubIssueId, githubIssueUrl = createIssue(licenseAuthorName, licenseName, licenseIdentifier, licenseComments, licenseSourceUrls, licenseHeader, licenseOsi, licenseRequestUrl, token, urlType)
+            statusCode, githubIssueId, githubIssueUrl = createIssue(
+                licenseAuthorName,
+                licenseName,
+                licenseIdentifier,
+                licenseComments,
+                licenseSourceUrls,
+                licenseHeader,
+                licenseOsi,
+                [],  # empty licenseExamples
+                licenseRequestUrl,
+                token,
+                urlType,
+            )
             licenseRequest.github_issue_number = githubIssueId
             licenseRequest.github_issue_url = githubIssueUrl
             licenseRequest.save()

--- a/src/app/migrations/0005_licenserequest_github_issue_fields.py
+++ b/src/app/migrations/0005_licenserequest_github_issue_fields.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026-present SPDX Contributors
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('app', '0004_auto_20240102_1751'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='licenserequest',
+            name='github_issue_url',
+            field=models.URLField(blank=True, default='', max_length=500),
+        ),
+        migrations.AddField(
+            model_name='licenserequest',
+            name='github_issue_number',
+            field=models.IntegerField(blank=True, null=True),
+        ),
+    ]

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -32,6 +32,8 @@ class License(models.Model):
         abstract = True
 
 class LicenseRequest(License):
+    github_issue_url = models.URLField(max_length=500, blank=True, default="")
+    github_issue_number = models.IntegerField(null=True, blank=True)
 
     def __str__(self):
         return self.fullname

--- a/src/app/templates/app/license_information.html
+++ b/src/app/templates/app/license_information.html
@@ -32,9 +32,9 @@
         gap: 16px;
         margin-top: 20px;
     }
-    /* unwrap forms so buttons lay out directly */
     .licenseInfoActions form {
-        display: contents;
+        display: flex;
+        margin: 0;
     }
     /* shared box so <a> and <button> render identically */
     .actionBtn {

--- a/src/app/templates/app/license_information.html
+++ b/src/app/templates/app/license_information.html
@@ -2,6 +2,76 @@
 {% load static %}
 {% block body1 %}
 
+<style>
+    .licenseInfoTable {
+        border: 1px solid #e1e6e9;
+        border-radius: 4px;
+        overflow: hidden;
+        margin-bottom: 15px;
+    }
+    .licenseInfoField {
+        padding: 10px 14px;
+    }
+    /* zebra striping; colors below meet WCAG AA contrast */
+    .licenseInfoTable > .licenseInfoField:nth-child(even) {
+        background: #f4f7f8;
+    }
+    .licenseInfoField .fieldKey {
+        font-weight: 600;
+        color: #006d8c;
+        margin-bottom: 2px;
+    }
+    .licenseInfoField .fieldValue {
+        word-break: break-word;
+        color: #333;
+        margin: 0;
+    }
+    .licenseInfoActions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 20px;
+    }
+    /* unwrap forms so buttons lay out directly */
+    .licenseInfoActions form {
+        display: contents;
+    }
+    /* shared box so <a> and <button> render identically */
+    .actionBtn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        height: 38px;
+        padding: 0 18px;
+        border: 1px solid transparent;
+        border-radius: 4px;
+        font-size: 14px;
+        line-height: 1;
+        text-decoration: none;
+        cursor: pointer;
+        box-sizing: border-box;
+    }
+    .actionBtn--primary {
+        background: #0097c4;
+        color: #fff;
+    }
+    .actionBtn--primary:hover,
+    .actionBtn--primary:focus {
+        background: #007ba1;
+        color: #fff;
+    }
+    .actionBtn--secondary {
+        background: #fff;
+        color: #333;
+        border-color: #c8d0d4;
+    }
+    .actionBtn--secondary:hover,
+    .actionBtn--secondary:focus {
+        background: #f4f7f8;
+        color: #333;
+    }
+</style>
+
 <div id="messages" class="messages">
 </div>
 <p class ="lead"> {{ medialink }}</p>
@@ -17,62 +87,66 @@
     {% endif %}
 <div class="panel-body">
     {% if licenseInformation %}
-    <div class="licenseField col-sm-12">
-        <p class="fieldName">Fullname</p>
-        <p>{{licenseInformation.fullname}}</p>
+    <div class="licenseInfoTable">
+    <div class="licenseInfoField">
+        <div class="fieldKey">Fullname</div>
+        <div class="fieldValue">{{licenseInformation.fullname}}</div>
     </div>
-    <div class="licenseField col-sm-12">
-        <p class="fieldName">License author name</p>
-        <p>{{licenseInformation.licenseAuthorName}}</p>
+    <div class="licenseInfoField">
+        <div class="fieldKey">License author name</div>
+        <div class="fieldValue">{{licenseInformation.licenseAuthorName}}</div>
     </div>
-    <div class="licenseField col-sm-12">
-        <p class="fieldName">Short Identifier</p>
-        <p>{{licenseInformation.shortIdentifier}}</p>
+    <div class="licenseInfoField">
+        <div class="fieldKey">Short identifier</div>
+        <div class="fieldValue">{{licenseInformation.shortIdentifier}}</div>
     </div>
-    <div class="licenseField col-sm-12">
-        <p class="fieldName">Source/URL</p>
-        {% for crossRef in licenseInformation.crossRefs %}
-        <p>{{crossRef}}</p>
-        {% endfor %}
-    </div>
-    <div class="licenseField col-sm-12">
-        <p class="fieldName">Osi Approved</p>
-        <p>{{licenseInformation.osiApproved}}</p>
-    </div>
-    <div class="licenseField col-sm-12">
-        <p class="fieldName">Notes</p>
-        <p>{{licenseInformation.notes}}</p>
-    </div>
-    <div class="licenseField col-sm-12">
-        <p class="fieldName">Standard License Header</p>
-        <p>{{licenseInformation.standardLicenseHeader}}</p>
-    </div>
-    <div class="licenseField col-sm-12">
-        <p class="fieldName">Text</p>
-        <p>{{licenseInformation.text|safe}}</p>
-    </div>
-    <div class="licenseField col-sm-12">
-        <p class="fieldName">Submission Date</p>
-        <p>{{licenseInformation.submissionDatetime}}</p>
-    </div>
-    <div class="col-sm-12">
-        <div class="col-sm-12">
-            <a href="/app/license_requests/" class="btn">Go Back</a>
+    <div class="licenseInfoField">
+        <div class="fieldKey">Source/URL</div>
+        <div class="fieldValue">
+            {% for crossRef in licenseInformation.crossRefs %}
+            <div>{{crossRef}}</div>
+            {% endfor %}
         </div>
-        <div class="col-sm-12">
-            <form name="download_xml" method="post" action=''>
-                {% csrf_token %}
-                <input type="hidden" name="supporttype" />
-                <button type="submit" class="btn btn-md btn-info" id="downloadBtn">Download the XML</button>
-            </form>
-        </div>
-        <div class="col-sm-12" style="margin-top: 5px">
-            <form id="edit-license-xml" name="edit_license_xml" method="post" enctype="multipart/form-data">
-                {% csrf_token %}
-                <input type="hidden" name="supporttype" />
-                <button id="editButton" class="btn btn-md btn-info">Edit the XML</button>
-            </form>
-        </div>
+    </div>
+    <div class="licenseInfoField">
+        <div class="fieldKey">OSI approved</div>
+        <div class="fieldValue">{{licenseInformation.osiApproved}}</div>
+    </div>
+    <div class="licenseInfoField">
+        <div class="fieldKey">Notes</div>
+        <div class="fieldValue">{{licenseInformation.notes}}</div>
+    </div>
+    <div class="licenseInfoField">
+        <div class="fieldKey">Standard license header</div>
+        <div class="fieldValue">{{licenseInformation.standardLicenseHeader}}</div>
+    </div>
+    <div class="licenseInfoField">
+        <div class="fieldKey">Text</div>
+        <div class="fieldValue">{{licenseInformation.text|safe}}</div>
+    </div>
+    <div class="licenseInfoField">
+        <div class="fieldKey">Submission date</div>
+        <div class="fieldValue">{{licenseInformation.submissionDatetime}}</div>
+    </div>
+    {% if licenseInformation.githubIssueUrl %}
+    <div class="licenseInfoField">
+        <div class="fieldKey">GitHub issue</div>
+        <div class="fieldValue"><a href="{{licenseInformation.githubIssueUrl}}" target="_blank">#{{licenseInformation.githubIssueNumber}}</a></div>
+    </div>
+    {% endif %}
+    </div>
+    <div class="col-sm-12 licenseInfoActions">
+        <a href="/app/license_requests/" class="actionBtn actionBtn--secondary">Go back</a>
+        <form name="download_xml" method="post" action=''>
+            {% csrf_token %}
+            <input type="hidden" name="supporttype" />
+            <button type="submit" class="actionBtn actionBtn--primary" id="downloadBtn">Download the XML</button>
+        </form>
+        <form id="edit-license-xml" name="edit_license_xml" method="post" enctype="multipart/form-data">
+            {% csrf_token %}
+            <input type="hidden" name="supporttype" />
+            <button id="editButton" class="actionBtn actionBtn--primary">Edit the XML</button>
+        </form>
     </div>
     {% endif %}
 </div>

--- a/src/app/templates/app/license_information.html
+++ b/src/app/templates/app/license_information.html
@@ -131,7 +131,7 @@
     {% if licenseInformation.githubIssueUrl %}
     <div class="licenseInfoField">
         <div class="fieldKey">GitHub issue</div>
-        <div class="fieldValue"><a href="{{licenseInformation.githubIssueUrl}}" target="_blank">#{{licenseInformation.githubIssueNumber}}</a></div>
+        <div class="fieldValue"><a id="githubIssueLink" href="{{licenseInformation.githubIssueUrl}}" target="_blank">#{{licenseInformation.githubIssueNumber}}</a></div>
     </div>
     {% endif %}
     </div>

--- a/src/app/templates/app/license_information.html
+++ b/src/app/templates/app/license_information.html
@@ -29,7 +29,7 @@
     .licenseInfoActions {
         display: flex;
         flex-wrap: wrap;
-        gap: 8px;
+        gap: 16px;
         margin-top: 20px;
     }
     /* unwrap forms so buttons lay out directly */

--- a/src/app/templates/app/license_information.html
+++ b/src/app/templates/app/license_information.html
@@ -131,7 +131,7 @@
     {% if licenseInformation.githubIssueUrl %}
     <div class="licenseInfoField">
         <div class="fieldKey">GitHub issue</div>
-        <div class="fieldValue"><a id="githubIssueLink" href="{{licenseInformation.githubIssueUrl}}" target="_blank">#{{licenseInformation.githubIssueNumber}}</a></div>
+        <div class="fieldValue"><a id="githubIssueLink" href="{{licenseInformation.githubIssueUrl}}" target="_blank" rel="noopener noreferrer">#{{licenseInformation.githubIssueNumber}}</a></div>
     </div>
     {% endif %}
     </div>

--- a/src/app/tests.py
+++ b/src/app/tests.py
@@ -1250,22 +1250,6 @@ class LicenseRequestsViewsTestCase(TestCase):
         self.assertIn("app/license_requests.html",(i.name for i in resp.templates))
         self.assertEqual(resp.resolver_match.func.__name__,"licenseRequests")
 
-    def test_license_information_displays_github_issue_link(self):
-        """GET license information page shows a link to the linked GitHub issue when present"""
-        license_obj = LicenseRequest.objects.create(
-            fullname="BSD Zero Clause License-00",
-            shortIdentifier="0BSD",
-            xml="<root></root>",
-            github_issue_number=42,
-            github_issue_url="https://github.com/spdx/license-list-XML/issues/42",
-        )
-        resp = self.client.get(reverse("license-information", args=(license_obj.id,)),follow=True,secure=True)
-        self.assertEqual(resp.status_code,200)
-        self.assertIn("app/license_information.html",(i.name for i in resp.templates))
-        self.assertEqual(resp.resolver_match.func.__name__,"licenseInformation")
-        self.assertContains(resp, "https://github.com/spdx/license-list-XML/issues/42")
-        self.assertContains(resp, "#42")
-
 
 class ArchiveLicenseRequestsViewsTestCase(TestCase):
 

--- a/src/app/tests.py
+++ b/src/app/tests.py
@@ -1250,6 +1250,22 @@ class LicenseRequestsViewsTestCase(TestCase):
         self.assertIn("app/license_requests.html",(i.name for i in resp.templates))
         self.assertEqual(resp.resolver_match.func.__name__,"licenseRequests")
 
+    def test_license_information_displays_github_issue_link(self):
+        """GET license information page shows a link to the linked GitHub issue when present"""
+        license_obj = LicenseRequest.objects.create(
+            fullname="BSD Zero Clause License-00",
+            shortIdentifier="0BSD",
+            xml="<root></root>",
+            github_issue_number=42,
+            github_issue_url="https://github.com/spdx/license-list-XML/issues/42",
+        )
+        resp = self.client.get(reverse("license-information", args=(license_obj.id,)),follow=True,secure=True)
+        self.assertEqual(resp.status_code,200)
+        self.assertIn("app/license_information.html",(i.name for i in resp.templates))
+        self.assertEqual(resp.resolver_match.func.__name__,"licenseInformation")
+        self.assertContains(resp, "https://github.com/spdx/license-list-XML/issues/42")
+        self.assertContains(resp, "#42")
+
 
 class ArchiveLicenseRequestsViewsTestCase(TestCase):
 

--- a/src/app/tests/test_legacy.py
+++ b/src/app/tests/test_legacy.py
@@ -1166,6 +1166,22 @@ class LicenseRequestsViewsTestCase(TestCase):
         self.assertIn("app/license_requests.html",(i.name for i in resp.templates))
         self.assertEqual(resp.resolver_match.func.__name__,"licenseRequests")
 
+    def test_license_information_displays_github_issue_link(self):
+        """GET license information page shows a link to the linked GitHub issue when present"""
+        license_obj = LicenseRequest.objects.create(
+            fullname="BSD Zero Clause License-00",
+            shortIdentifier="0BSD",
+            xml="<root></root>",
+            github_issue_number=42,
+            github_issue_url="https://github.com/spdx/license-list-XML/issues/42",
+        )
+        resp = self.client.get(reverse("license-information", args=(license_obj.id,)),follow=True,secure=True)
+        self.assertEqual(resp.status_code,200)
+        self.assertIn("app/license_information.html",(i.name for i in resp.templates))
+        self.assertEqual(resp.resolver_match.func.__name__,"licenseInformation")
+        self.assertContains(resp, "https://github.com/spdx/license-list-XML/issues/42")
+        self.assertContains(resp, "#42")
+
 
 class ArchiveLicenseRequestsViewsTestCase(TestCase):
 

--- a/src/app/utils.py
+++ b/src/app/utils.py
@@ -393,7 +393,7 @@ def createIssue(
             response_json = r.json()
         except ValueError:
             # Handle JSON parsing error
-            return None, None, ""
+            return status_code, None, ""
 
     issue_html_url = ""
     if status_code in [200, 201] and "number" in response_json:

--- a/src/app/utils.py
+++ b/src/app/utils.py
@@ -338,9 +338,23 @@ def createLicenseNamespaceIssue(licenseNamespace, token, urlType):
     return r.status_code
 
 
-
-def createIssue(licenseAuthorName, licenseName, licenseIdentifier, licenseComments, licenseSourceUrls, licenseHeader, licenseOsi, licenseExamples, licenseRequestUrl, token, urlType, matchId=None, diffUrl=None, msg=None):
-    """ View for creating an GitHub issue
+def createIssue(
+        licenseAuthorName,
+        licenseName,
+        licenseIdentifier,
+        licenseComments,
+        licenseSourceUrls,
+        licenseHeader,
+        licenseOsi,
+        licenseExamples,
+        licenseRequestUrl,
+        token,
+        urlType,
+        matchId=None,
+        diffUrl=None,
+        msg=None,
+    ):
+    """View for creating an GitHub issue
     when submitting a new license request
     """
     licenseUrls = ""
@@ -349,14 +363,14 @@ def createIssue(licenseAuthorName, licenseName, licenseIdentifier, licenseCommen
         for i in range(1, len(licenseSourceUrls)):
             licenseUrls += ', '
             licenseUrls += licenseSourceUrls[i]
-            
+
     licenseExampleUrls = ""
     if licenseExamples != None and len(licenseExamples) > 0:
         licenseExampleUrls = licenseExamples[0]
         for i in range(1, len(licenseExamples)):
             licenseExampleUrls += ', '
             licenseExampleUrls += licenseExamples[i]
-  
+
     body = "**1.** License name: {0}\n**2.** Short identifier: {1}\n**3.** License author or steward: {2}\n**4.** Comments: {3}\n**5.** License request Url: {4}\n**6.** URL(s): {5}\n**7.** OSI status: {6}\n**8.** Example projects: {7}".format(licenseName, licenseIdentifier, licenseAuthorName, licenseComments, licenseRequestUrl, licenseUrls, licenseOsi, licenseExampleUrls)
     if diffUrl:
         body = body + "\n**8.** License text diff: {0}".format(diffUrl)

--- a/src/app/utils.py
+++ b/src/app/utils.py
@@ -379,15 +379,16 @@ def createIssue(licenseAuthorName, licenseName, licenseIdentifier, licenseCommen
             response_json = r.json()
         except ValueError:
             # Handle JSON parsing error
-            return None, None
-            
+            return None, None, ""
 
+    issue_html_url = ""
     if status_code in [200, 201] and "number" in response_json:
         issue_id = response_json["number"]
+        issue_html_url = response_json.get("html_url", "")
     else:
         issue_id = None
 
-    return status_code, issue_id
+    return status_code, issue_id, issue_html_url
 
 
 def postToGithub(message, encodedContent, filename):

--- a/src/app/views.py
+++ b/src/app/views.py
@@ -154,11 +154,14 @@ def submitNewLicense(request):
                         licenseId = licenseRequest.id
                         serverUrl = request.build_absolute_uri('/')
                         licenseRequestUrl = os.path.join(serverUrl, reverse('license-requests')[1:], str(licenseId))
-                        statusCode, githubIssueId = utils.createIssue(
+                        statusCode, githubIssueId, githubIssueUrl = utils.createIssue(
                             licenseAuthorName, licenseName, licenseIdentifier,
                             licenseComments, licenseSourceUrls, licenseHeader,
                             licenseOsi, licenseExamples, licenseRequestUrl,
                             token, urlType)
+                        licenseRequest.github_issue_number = githubIssueId
+                        licenseRequest.github_issue_url = githubIssueUrl
+                        licenseRequest.save()
 
                     # If the license text matches with either rejected or yet not approved license then return 409 Conflict
                     else:
@@ -352,6 +355,8 @@ def licenseInformation(request, licenseId):
     licenseInformation['notes'] = data['notes']
     licenseInformation['standardLicenseHeader'] = data['standardLicenseHeader']
     licenseInformation['text'] = data['text']
+    licenseInformation['githubIssueUrl'] = licenseRequest.github_issue_url
+    licenseInformation['githubIssueNumber'] = licenseRequest.github_issue_number
     context_dict ={'licenseInformation': licenseInformation}
     if request.method == 'POST':
         tempFilename = 'output.xml'
@@ -999,7 +1004,7 @@ def promoteNamespaceRequests(request, license_id=None):
             if "urlType" in request.POST:
                 # This is present only when executing submit license via tests
                 urlType = request.POST["urlType"]
-            statusCode, _ = utils.createIssue(
+            statusCode, githubIssueId, githubIssueUrl = utils.createIssue(
                 licenseAuthorName,
                 licenseName,
                 licenseIdentifier,
@@ -1012,6 +1017,9 @@ def promoteNamespaceRequests(request, license_id=None):
                 token,
                 urlType,
             )
+            licenseRequest.github_issue_number = githubIssueId
+            licenseRequest.github_issue_url = githubIssueUrl
+            licenseRequest.save()
             return_tuple = (statusCode, licenseRequest)
             statusCode = return_tuple[0]
             if statusCode == 201:
@@ -1192,11 +1200,14 @@ def issue(request):
                     licenseRequestId = licenseRequest.id
                     serverUrl = request.build_absolute_uri('/')
                     licenseRequestUrl = os.path.join(serverUrl, reverse('license-requests')[1:], str(licenseRequestId))
-                    statusCode, _ = utils.createIssue(
+                    statusCode, githubIssueId, githubIssueUrl = utils.createIssue(
                         licenseAuthorName, licenseName, licenseIdentifier,
                         licenseComments, licenseSourceUrls, licenseHeader,
                         licenseOsi, licenseExamples, licenseRequestUrl, token,
                         urlType, matchId, diffUrl, msg)
+                    licenseRequest.github_issue_number = githubIssueId
+                    licenseRequest.github_issue_url = githubIssueUrl
+                    licenseRequest.save()
                     data['statusCode'] = str(statusCode)
                     return JsonResponse(data)
                 except UserSocialAuth.DoesNotExist:


### PR DESCRIPTION
- To resolve #453
- This may make it more convenient for license reviewer.
- With this PR, GitHub issue number is added, with link (screenshot with mock data):

<img width="485" height="282" src="https://github.com/user-attachments/assets/4e196262-7d4f-425b-ae04-cd09b1ce2cc2" />
