### PR TITLE
Fix large file upload issue

### DIFF
--- a/src/api/test_upload.py
+++ b/src/api/test_upload.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2026 SPDX contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for large-file uploads (issue #499).
+
+Django stores uploads above FILE_UPLOAD_MAX_MEMORY_SIZE as a TemporaryUploadedFile
+on disk. The core helper moves that temp file into media on first save, so a second
+save in the view raised FileNotFoundError. Setting the threshold to 0 forces every
+upload through that path without needing real multi-MB fixtures.
+"""
+
+import os
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.exceptions import ObjectDoesNotExist
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from api.models import CompareFileUpload, ConvertFileUpload, ValidateFileUpload
+
+
+def getExamplePath(filename):
+    return os.path.join(settings.EXAMPLES_DIR, filename)
+
+
+@override_settings(FILE_UPLOAD_MAX_MEMORY_SIZE=0)
+class ValidateLargeFileUploadTests(APITestCase):
+    """Validate API must handle uploads routed through TemporaryUploadedFile."""
+
+    def setUp(self):
+        self.username = "validateuploadtestuser"
+        self.password = "validateuploadtestpass"
+        self.tearDown()
+        self.credentials = {"username": self.username, "password": self.password}
+        u = User.objects.create_user(**self.credentials)
+        u.is_staff = True
+        u.save()
+
+    def tearDown(self):
+        try:
+            u = User.objects.get_by_natural_key(self.username)
+            u.delete()
+        except ObjectDoesNotExist:
+            pass
+        ValidateFileUpload.objects.all().delete()
+
+    def test_validate_api_large_file(self):
+        """A large (temp-file) upload must not raise FileNotFoundError."""
+        self.client.login(username=self.username, password=self.password)
+        with open(getExamplePath("SPDXTagExample-v2.0.spdx")) as f:
+            resp = self.client.post(
+                reverse("validate-api"),
+                {"file": f, "format": "TAG"},
+                format="multipart",
+            )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["result"], "This SPDX document is valid.")
+        self.client.logout()
+        self.tearDown()
+
+
+@override_settings(FILE_UPLOAD_MAX_MEMORY_SIZE=0)
+class ConvertLargeFileUploadTests(APITestCase):
+    """Convert API must handle uploads routed through TemporaryUploadedFile."""
+
+    def setUp(self):
+        self.username = "convertuploadtestuser"
+        self.password = "convertuploadtestpass"
+        self.tearDown()
+        self.credentials = {"username": self.username, "password": self.password}
+        u = User.objects.create_user(**self.credentials)
+        u.is_staff = True
+        u.save()
+        self.tag = "TAG"
+        self.rdf = "RDFXML"
+
+    def tearDown(self):
+        try:
+            u = User.objects.get_by_natural_key(self.username)
+            u.delete()
+        except ObjectDoesNotExist:
+            pass
+        ConvertFileUpload.objects.all().delete()
+
+    def test_convert_api_large_file(self):
+        """A large (temp-file) upload must not raise FileNotFoundError."""
+        self.client.login(username=self.username, password=self.password)
+        with open(getExamplePath("SPDXTagExample-v2.2.spdx"), "rb") as f:
+            resp = self.client.post(
+                reverse("convert-api"),
+                {
+                    "file": f,
+                    "from_format": self.tag,
+                    "to_format": self.rdf,
+                    "cfilename": "tagtordf-largefiletest",
+                },
+                format="multipart",
+            )
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(resp.data["message"], "Success")
+        self.client.logout()
+        self.tearDown()
+
+
+@override_settings(FILE_UPLOAD_MAX_MEMORY_SIZE=0)
+class CompareLargeFileUploadTests(APITestCase):
+    """Compare API must handle uploads routed through TemporaryUploadedFile."""
+
+    def setUp(self):
+        self.username = "compareuploadtestuser"
+        self.password = "compareuploadtestpass"
+        self.tearDown()
+        self.credentials = {"username": self.username, "password": self.password}
+        u = User.objects.create_user(**self.credentials)
+        u.is_staff = True
+        u.save()
+
+    def tearDown(self):
+        try:
+            u = User.objects.get_by_natural_key(self.username)
+            u.delete()
+        except ObjectDoesNotExist:
+            pass
+        CompareFileUpload.objects.all().delete()
+
+    def test_compare_api_large_file(self):
+        """A large (temp-file) upload must not raise FileNotFoundError."""
+        self.client.login(username=self.username, password=self.password)
+        with open(getExamplePath("SPDXRdfExample-v2.2.spdx.rdf")) as f1, \
+                open(getExamplePath("SPDXRdfExample-v2.3.spdx.rdf")) as f2:
+            resp = self.client.post(
+                reverse("compare-api"),
+                {
+                    "file1": f1,
+                    "file2": f2,
+                    "rfilename": "compare-largefiletest",
+                },
+                format="multipart",
+            )
+        self.assertEqual(resp.status_code, 200)
+        self.client.logout()
+        self.tearDown()

--- a/src/api/test_upload.py
+++ b/src/api/test_upload.py
@@ -1,12 +1,17 @@
-# SPDX-FileCopyrightText: 2026 SPDX contributors
+# SPDX-FileCopyrightText: 2026-present SPDX contributors
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 
-"""Regression tests for large-file uploads (issue #499).
+"""Regression tests for large-file uploads.
 
-Django stores uploads above FILE_UPLOAD_MAX_MEMORY_SIZE as a TemporaryUploadedFile
-on disk. The core helper moves that temp file into media on first save, so a second
-save in the view raised FileNotFoundError. Setting the threshold to 0 forces every
-upload through that path without needing real multi-MB fixtures.
+Django stores uploads above FILE_UPLOAD_MAX_MEMORY_SIZE (default: 2.5 MB) as a
+TemporaryUploadedFile on disk.
+https://docs.djangoproject.com/en/5.2/topics/http/file-uploads/#where-uploaded-data-is-stored
+
+Errors could occur if the code take wrong assumptions about the file location.
+See https://github.com/spdx/spdx-online-tools/issues/499
+
+Setting the threshold to 0 forces every upload through file on disk path.
 """
 
 import os

--- a/src/api/test_upload.py
+++ b/src/api/test_upload.py
@@ -8,7 +8,7 @@ Django stores uploads above FILE_UPLOAD_MAX_MEMORY_SIZE (default: 2.5 MB) as a
 TemporaryUploadedFile on disk.
 https://docs.djangoproject.com/en/5.2/topics/http/file-uploads/#where-uploaded-data-is-stored
 
-Errors could occur if the code take wrong assumptions about the file location.
+Errors could occur if the code takes wrong assumptions about the file location.
 See https://github.com/spdx/spdx-online-tools/issues/499
 
 Setting the threshold to 0 forces every upload through file on disk path.

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -133,16 +133,16 @@ def validate(request):
                 response = core.license_validate_helper(request)
             httpstatus, _, result = utils.get_json_response_data(response)
             returnstatus = utils.get_return_code(httpstatus)
-            uploaded_file_obj = request.FILES.get("file") or request.data.get("file")
-            query = ValidateFileUpload.objects.create(
-                owner=request.user, file=uploaded_file_obj
+            saved_file = response.get("uploaded_file")
+            query = ValidateFileUpload(
+                owner=request.user, result=result, status=httpstatus
             )
-            query.result = result
-            query.status = httpstatus
-            uploaded_file = str(query.file)
-            ValidateFileUpload.objects.filter(file=uploaded_file).update(
-                result=result, status=httpstatus
-            )
+            if saved_file:
+                # Helper already saved to media; avoid re-saving (issue #499).
+                query.file.name = saved_file
+            else:
+                query.file = request.FILES.get("file") or request.data.get("file")
+            query.save()
             serial = ValidateSerializerReturn(instance=query)
             return Response(serial.data, status=returnstatus)
         else:
@@ -208,21 +208,22 @@ def convert(request):
             
             if httpstatus != 200:
                 message = 'Failed'
-            
-            query = ConvertFileUpload.objects.create(
+
+            saved_file = response.get("uploaded_file")
+            query = ConvertFileUpload(
                 owner=request.user,
-                file=request.data.get('file'),
                 from_format=request.POST["from_format"],
                 to_format=request.POST["to_format"],
                 cfilename=request.POST["cfilename"],
+                message=message,
+                status=httpstatus,
+                result=result,
             )
-            uploaded_file = str(query.file)
-            uploaded_file_path = str(query.file.path)
-            print("uploaded_file_path:", uploaded_file_path)
-            query.message = message
-            query.status = httpstatus
-            query.result = result
-            ConvertFileUpload.objects.filter(file=uploaded_file).update(status=httpstatus, result=result, message=message)
+            if saved_file:
+                query.file.name = saved_file
+            else:
+                query.file = request.data.get('file')
+            query.save()
             serial = ConvertSerializerReturn(instance=query)
             return Response(
                 serial.data,status=returnstatus
@@ -296,22 +297,21 @@ def compare(request):
                 message = 'Failed'
 
             rfilename = request.POST["rfilename"]
-            file1_obj = request.FILES.get("file1") or file1
-            file2_obj = request.FILES.get("file2") or file2
-            query = CompareFileUpload.objects.create(
+            saved_files = response.get("uploaded_files") or []
+            query = CompareFileUpload(
                 owner=request.user,
-                file1=file1_obj,
-                file2=file2_obj,
                 rfilename=rfilename,
+                message=message,
+                result=result,
+                status=httpstatus,
             )
-            uploaded_file1 = str(query.file1)
-            uploaded_file2 = str(query.file2)
-            query.message = message
-            query.result = result
-            query.status = httpstatus
-            CompareFileUpload.objects.filter(file1=uploaded_file1).filter(
-                file2=uploaded_file2
-            ).update(message=message, result=result, status=httpstatus)
+            if len(saved_files) >= 2:
+                query.file1.name = saved_files[0]
+                query.file2.name = saved_files[1]
+            else:
+                query.file1 = request.FILES.get("file1") or file1
+                query.file2 = request.FILES.get("file2") or file2
+            query.save()
             serial = CompareSerializerReturn(instance=query)
             return Response(serial.data, status=returnstatus)
         else:

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2017 Rohit Lodha
 # SPDX-FileCopyrightText: 2025-present SPDX Contributors
+# SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2017 Rohit Lodha
 

--- a/src/app/core.py
+++ b/src/app/core.py
@@ -100,9 +100,7 @@ def license_compare_helper(request):
             fs = FileSystemStorage(location=folder_path, base_url=folder_url)
             saved_files = []
             for myfile in request.FILES.getlist("files"):
-                filename = fs.save(utils.removeSpecialCharacters(myfile.name), myfile)
-                local_path = fs.path(filename)
-                saved_files.append(os.path.join(folder, filename))
+                saved_files.append(f"{folder}/{filename}")
                 callfunc.append(str(local_path))
                 nameoffile, fileext = os.path.splitext(filename)
                 if (nameoffile.endswith(".rdf") and fileext == ".xml") or fileext == ".rdf":
@@ -355,9 +353,7 @@ def license_validate_helper(request):
             folder_path = os.path.join(settings.MEDIA_ROOT, folder)
             folder_url = urljoin(settings.MEDIA_URL, folder + '/')
             fs = FileSystemStorage(location=folder_path, base_url=folder_url)
-            filename = fs.save(utils.removeSpecialCharacters(myfile.name), myfile)
-            local_path = fs.path(filename)
-            result['uploaded_file'] = os.path.join(folder, filename)
+            result['uploaded_file'] = f"{folder}/{filename}"
             formatstr = request.POST["format"]
             serFileTypeEnum = jpype.JClass("org.spdx.tools.SpdxToolsHelper$SerFileType")
             fileformat = serFileTypeEnum.valueOf(formatstr)
@@ -532,9 +528,7 @@ def license_convert_helper(request):
             folder_url = urljoin(settings.MEDIA_URL, folder + '/')
             myfile = request.FILES['file']
             fs = FileSystemStorage(location=folder_path, base_url=folder_url)
-            filename = fs.save(utils.removeSpecialCharacters(myfile.name), myfile)
-            local_path = fs.path(filename)
-            result['uploaded_file'] = os.path.join(folder, filename)
+            result['uploaded_file'] = f"{folder}/{filename}"
             option1 = request.POST["from_format"]
             option2 = request.POST["to_format"]
             content_type = utils.formatToContentType(option2)

--- a/src/app/core.py
+++ b/src/app/core.py
@@ -100,6 +100,8 @@ def license_compare_helper(request):
             fs = FileSystemStorage(location=folder_path, base_url=folder_url)
             saved_files = []
             for myfile in request.FILES.getlist("files"):
+                filename = fs.save(utils.removeSpecialCharacters(myfile.name), myfile)
+                local_path = fs.path(filename)
                 saved_files.append(f"{folder}/{filename}")
                 callfunc.append(str(local_path))
                 nameoffile, fileext = os.path.splitext(filename)
@@ -353,6 +355,8 @@ def license_validate_helper(request):
             folder_path = os.path.join(settings.MEDIA_ROOT, folder)
             folder_url = urljoin(settings.MEDIA_URL, folder + '/')
             fs = FileSystemStorage(location=folder_path, base_url=folder_url)
+            filename = fs.save(utils.removeSpecialCharacters(myfile.name), myfile)
+            local_path = fs.path(filename)
             result['uploaded_file'] = f"{folder}/{filename}"
             formatstr = request.POST["format"]
             serFileTypeEnum = jpype.JClass("org.spdx.tools.SpdxToolsHelper$SerFileType")
@@ -528,6 +532,8 @@ def license_convert_helper(request):
             folder_url = urljoin(settings.MEDIA_URL, folder + '/')
             myfile = request.FILES['file']
             fs = FileSystemStorage(location=folder_path, base_url=folder_url)
+            filename = fs.save(utils.removeSpecialCharacters(myfile.name), myfile)
+            local_path = fs.path(filename)
             result['uploaded_file'] = f"{folder}/{filename}"
             option1 = request.POST["from_format"]
             option2 = request.POST["to_format"]

--- a/src/app/core.py
+++ b/src/app/core.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2025 SPDX contributors
+# SPDX-FileCopyrightText: 2022-present SPDX contributors
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 

--- a/src/app/core.py
+++ b/src/app/core.py
@@ -98,9 +98,11 @@ def license_compare_helper(request):
                 return result
             # Loop through the list of files
             fs = FileSystemStorage(location=folder_path, base_url=folder_url)
+            saved_files = []
             for myfile in request.FILES.getlist("files"):
                 filename = fs.save(utils.removeSpecialCharacters(myfile.name), myfile)
                 local_path = fs.path(filename)
+                saved_files.append(os.path.join(folder, filename))
                 callfunc.append(str(local_path))
                 nameoffile, fileext = os.path.splitext(filename)
                 if (nameoffile.endswith(".rdf") and fileext == ".xml") or fileext == ".rdf":
@@ -135,6 +137,7 @@ def license_compare_helper(request):
                     filelist.append(myfile.name)
                     errorlist.append("Invalid file extension for "+filename+".  Must be .xls, .xlsx, .xml, .json, .yaml, .spdx, .rdfxml")
                     errorlist.append(UNEXPECTED_ERROR_MSG + format_exc())
+            result['uploaded_files'] = saved_files
             if erroroccurred is False:
                 # If no errors in any of the file,call the java function with parameters as list
                 try :
@@ -354,6 +357,7 @@ def license_validate_helper(request):
             fs = FileSystemStorage(location=folder_path, base_url=folder_url)
             filename = fs.save(utils.removeSpecialCharacters(myfile.name), myfile)
             local_path = fs.path(filename)
+            result['uploaded_file'] = os.path.join(folder, filename)
             formatstr = request.POST["format"]
             serFileTypeEnum = jpype.JClass("org.spdx.tools.SpdxToolsHelper$SerFileType")
             fileformat = serFileTypeEnum.valueOf(formatstr)
@@ -530,6 +534,7 @@ def license_convert_helper(request):
             fs = FileSystemStorage(location=folder_path, base_url=folder_url)
             filename = fs.save(utils.removeSpecialCharacters(myfile.name), myfile)
             local_path = fs.path(filename)
+            result['uploaded_file'] = os.path.join(folder, filename)
             option1 = request.POST["from_format"]
             option2 = request.POST["to_format"]
             content_type = utils.formatToContentType(option2)


### PR DESCRIPTION
When uploading file larger than 2.5 MB, the online tools will failed with "file not found" error.

Root cause
- Django stores uploads >2.5 MB as a TemporaryUploadedFile on disk.
- The core helpers (license_validate_helper, license_convert_helper, license_compare_helper) move that temp file into the media directory on first save.
- The API views try to do another save of the same upload object, but the file is no longer there -- failed.

Records the upload path in `result['uploaded_file']` and let views use that path directly (instead of re-saving from no longer existing location)

To fix #499 as reported and analysed root cause by @NiViggiano 