### PR TITLE
Move TODO to GitHub issues

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -1,8 +1,0 @@
-# TODO
-
-- TagToRdf takes max 3 arguments. Include output format field in forms and call method accordingly.
-- In api, create models function is saving the files again. So files sent to API is saved to 2 folders
-    media/api/<username>/<time> --> This contains the result files too.
-    media/apifiles/<username>/<time>
-- API for check license
-- Implement scancode-toolkit in online tools (Maybe using something similar to aboutcode-manager to display results)


### PR DESCRIPTION
Remove 3 resolved issues:

- [x] TagToRdf takes max 3 arguments...
  - Obsolete: The system now uses the unified SpdxConverter in core.py, which natively handles converting Tag-Value to specific RDF formats like RDFXML or RDFTTL using the standard target dropdown options.
- [x] In api, create models function is saving the files again.
  - Fixed in commit dc979f0: files are only saved once under `media/<username>/<time>/`.
- [x] API for check license
  - Implemented at `/api/check_license/` endpoint.

Move 1 unresolved issue to GitHub issues:

- Implement scancode-toolkit in online tools (Maybe using something similar to aboutcode-manager to display results) --> https://github.com/spdx/spdx-online-tools/issues/702

Remove the now empty TODO file.