### PR TITLE
Add minimal linter and format check for Python tests

### DIFF
--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -1,4 +1,4 @@
-name: Python formatter
+name: Python format
 
 on:
   push:
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 jobs:
-  lint:
+  black:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Black Python code formatter
         uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e  # v26.5.1
         with:
-          src: "src/*.py src/tests/*.py src/tests/api"
+          src: "src"

--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -1,0 +1,40 @@
+name: Python formatter
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/*.py'
+      - 'src/tests/*.py'
+      - 'src/tests/api/**/*.py'
+      - 'pyproject.toml'
+      - '.github/workflows/python-format.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'src/*.py'
+      - 'src/tests/*.py'
+      - 'src/tests/api/**/*.py'
+      - 'pyproject.toml'
+      - '.github/workflows/python-format.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Black Python code formatter
+        uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e  # v26.5.1
+        with:
+          src: "src/*.py src/tests/*.py src/tests/api"

--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -29,9 +29,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
       - name: Black Python code formatter

--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Black Python code formatter
         uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e  # v26.5.1
         with:
-          src: "src"
+          src: "src/manage.py src/populate.py src/tests"

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,4 +1,4 @@
-name: Pylint
+name: Python lint
 
 on:
   push:

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,47 @@
+name: Pylint
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/*.py'
+      - 'src/tests/**/*.py'
+      - 'pyproject.toml'
+      - 'requirements-dev.txt'
+      - '.github/workflows/python-lint.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'src/*.py'
+      - 'src/tests/**/*.py'
+      - 'pyproject.toml'
+      - 'requirements-dev.txt'
+      - '.github/workflows/python-lint.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
+    - name: Analysing the code with Pylint
+      run: |
+        pylint src/*.py src/tests/*.py src/tests/api

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -32,9 +32,9 @@ jobs:
         python-version: ["3.12"]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -27,16 +27,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        python-version: ["3.12"]
     steps:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,11 @@
 [tool.black]
 target-version = ['py312']
+exclude = '''
+(
+  ^/src/(api|app|com|config|examples)/
+  | ^/src/tests/(app|fixtures)/
+)
+'''
 
 [tool.pylint.main]
 load-plugins = ["pylint_per_file_ignores"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.black]
+target-version = ['py312']
+
+[tool.pylint.main]
+load-plugins = ["pylint_per_file_ignores"]
+
+[tool.pylint."messages control"]
+per-file-ignores = [
+    "src/tests/*:invalid-name,attribute-defined-outside-init,duplicate-code,no-member,missing-module-docstring,missing-class-docstring,missing-function-docstring,unspecified-encoding,consider-using-with,too-many-instance-attributes,super-with-arguments,too-few-public-methods,not-callable,broad-exception-caught,too-many-return-statements,line-too-long,consider-using-f-string,missing-timeout",
+    "src/tests/**/*:invalid-name,attribute-defined-outside-init,duplicate-code,no-member,missing-module-docstring,missing-class-docstring,missing-function-docstring,unspecified-encoding,consider-using-with,too-many-instance-attributes,super-with-arguments,too-few-public-methods,not-callable,broad-exception-caught,too-many-return-statements,line-too-long,consider-using-f-string,missing-timeout",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,5 @@ load-plugins = ["pylint_per_file_ignores"]
 
 [tool.pylint."messages control"]
 per-file-ignores = [
-    "src/tests/*:invalid-name,attribute-defined-outside-init,duplicate-code,no-member,missing-module-docstring,missing-class-docstring,missing-function-docstring,unspecified-encoding,consider-using-with,too-many-instance-attributes,super-with-arguments,too-few-public-methods,not-callable,broad-exception-caught,too-many-return-statements,line-too-long,consider-using-f-string,missing-timeout",
     "src/tests/**/*:invalid-name,attribute-defined-outside-init,duplicate-code,no-member,missing-module-docstring,missing-class-docstring,missing-function-docstring,unspecified-encoding,consider-using-with,too-many-instance-attributes,super-with-arguments,too-few-public-methods,not-callable,broad-exception-caught,too-many-return-statements,line-too-long,consider-using-f-string,missing-timeout",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,4 @@
+black>=26.5.1
+pylint>=4.0.6
+pylint-per-file-ignores>=3.2.1
 selenium>=4.43.0,<5.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 black>=26.5.1,<27
 pylint>=4.0.6,<5
-pylint-per-file-ignores>=3.2.1
+pylint-per-file-ignores>=3.2.1,<4
 selenium>=4.43.0,<5.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black>=26.5.1
-pylint>=4.0.6
+black>=26.5.1,<27
+pylint>=4.0.6,<5
 pylint-per-file-ignores>=3.2.1
 selenium>=4.43.0,<5.0.0

--- a/src/manage.py
+++ b/src/manage.py
@@ -16,11 +16,18 @@ def main():
         # pylint: disable=import-outside-toplevel
         from django.core.management import execute_from_command_line
     except ImportError as exc:
-        raise ImportError(
-            "Couldn't import Django. Are you sure it's installed and "
-            "available on your PYTHONPATH environment variable? Did you "
-            "forget to activate a virtual environment?"
-        ) from exc
+        # The above import may fail for some other reason. Ensure that the
+        # issue is really that Django is missing.
+        try:
+            # pylint: disable=import-outside-toplevel,unused-import
+            import django
+        except ImportError as exc_django:
+            raise ImportError(
+                "Couldn't import Django. Are you sure it's installed and "
+                "available on your PYTHONPATH environment variable? Did you "
+                "forget to activate a virtual environment?"
+            ) from exc_django
+        raise exc
     execute_from_command_line(sys.argv)
 
 

--- a/src/manage.py
+++ b/src/manage.py
@@ -13,9 +13,8 @@ def main():
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
     try:
-        from django.core.management import (  # pylint: disable=import-outside-toplevel
-            execute_from_command_line,
-        )
+        # pylint: disable=import-outside-toplevel
+        from django.core.management import execute_from_command_line
     except ImportError as exc:
         raise ImportError(
             "Couldn't import Django. Are you sure it's installed and "

--- a/src/manage.py
+++ b/src/manage.py
@@ -8,20 +8,22 @@
 import os
 import sys
 
-if __name__ == "__main__":
+
+def main():
+    """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
     try:
-        from django.core.management import execute_from_command_line
-    except ImportError:
-        # The above import may fail for some other reason. Ensure that the
-        # issue is really that Django is missing.
-        try:
-            import django
-        except ImportError:
-            raise ImportError(
-                "Couldn't import Django. Are you sure it's installed and "
-                "available on your PYTHONPATH environment variable? Did you "
-                "forget to activate a virtual environment?"
-            )
-        raise
+        from django.core.management import (  # pylint: disable=import-outside-toplevel
+            execute_from_command_line,
+        )
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
     execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/populate.py
+++ b/src/populate.py
@@ -20,9 +20,8 @@ EXCEPTION_URL = "https://raw.githubusercontent.com/spdx/license-list-data/master
 
 def populate(url, item_type):
     """Fetch license or exception data from URL and populate the database."""
-    from app.models import (  # pylint: disable=import-outside-toplevel
-        LicenseNames,
-    )
+    # pylint: disable=import-outside-toplevel
+    from app.models import LicenseNames
 
     response = requests.get(url, timeout=30)
     data = json.loads(response.text)
@@ -30,19 +29,16 @@ def populate(url, item_type):
     new_count = 0
     for item in data[item_type]:
         total_count += 1
-        created = LicenseNames.objects.get_or_create(  # pylint: disable=no-member
-            name=item["name"]
-        )[1]
+        # pylint: disable=no-member
+        created = LicenseNames.objects.get_or_create(name=item["name"])[1]
         if created:
             new_count += 1
         if item_type == "licenses":
-            LicenseNames.objects.get_or_create(  # pylint: disable=no-member
-                name=item["licenseId"]
-            )
+            # pylint: disable=no-member
+            LicenseNames.objects.get_or_create(name=item["licenseId"])
         else:
-            LicenseNames.objects.get_or_create(  # pylint: disable=no-member
-                name=item["licenseExceptionId"]
-            )
+            # pylint: disable=no-member
+            LicenseNames.objects.get_or_create(name=item["licenseExceptionId"])
     return (total_count, new_count)
 
 

--- a/src/populate.py
+++ b/src/populate.py
@@ -5,38 +5,66 @@
 """Script to populate the database with license and exception names
 from SPDX data."""
 
+import json
 import os
+
 import django
 import requests
-import json
 
-def populate(url, type):
-    data = requests.get(url).text
-    data = json.loads(data)
+# pylint: disable=line-too-long
+LICENSE_URL = (
+    "https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json"
+)
+EXCEPTION_URL = "https://raw.githubusercontent.com/spdx/license-list-data/master/json/exceptions.json"
+
+
+def populate(url, item_type):
+    """Fetch license or exception data from URL and populate the database."""
+    from app.models import (  # pylint: disable=import-outside-toplevel
+        LicenseNames,
+    )
+
+    response = requests.get(url, timeout=30)
+    data = json.loads(response.text)
     total_count = 0
     new_count = 0
-    for i in data[type]:
+    for item in data[item_type]:
         total_count += 1
-        response = LicenseNames.objects.get_or_create(name=i["name"])[1]
-        if(response==True):
+        created = LicenseNames.objects.get_or_create(  # pylint: disable=no-member
+            name=item["name"]
+        )[1]
+        if created:
             new_count += 1
-        if type=="licenses":
-            LicenseNames.objects.get_or_create(name=i["licenseId"])
+        if item_type == "licenses":
+            LicenseNames.objects.get_or_create(  # pylint: disable=no-member
+                name=item["licenseId"]
+            )
         else:
-            LicenseNames.objects.get_or_create(name=i["licenseExceptionId"])
+            LicenseNames.objects.get_or_create(  # pylint: disable=no-member
+                name=item["licenseExceptionId"]
+            )
     return (total_count, new_count)
 
-if __name__ == "__main__":
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+
+def main():
+    """Setup Django environment and run population tasks."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
     django.setup()
-    from app.models import LicenseNames
-    license_url = "https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json"
-    exception_url = "https://raw.githubusercontent.com/spdx/license-list-data/master/json/exceptions.json"
-    
+
     print("Adding License names (this might take some time if running for first time)")
-    total_count, new_count = populate(license_url, "licenses")
-    print(("Total Licenses Found: %d\nNew Licenses added to database: %d"%(total_count, new_count)))
-    
+    licenses_total, licenses_new = populate(LICENSE_URL, "licenses")
+    print(
+        f"Total Licenses Found: {licenses_total}\n"
+        f"New Licenses added to database: {licenses_new}"
+    )
+
     print("Adding Exception names")
-    total_count, new_count = populate(exception_url, "exceptions")
-    print(("Total Exceptions Found: %d\nNew Exceptions added to database: %d"%(total_count, new_count)))
+    exceptions_total, exceptions_new = populate(EXCEPTION_URL, "exceptions")
+    print(
+        f"Total Exceptions Found: {exceptions_total}\n"
+        f"New Exceptions added to database: {exceptions_new}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/populate.py
+++ b/src/populate.py
@@ -27,17 +27,15 @@ def populate(url, item_type):
     data = json.loads(response.text)
     total_count = 0
     new_count = 0
+    # pylint: disable=no-member
     for item in data[item_type]:
         total_count += 1
-        # pylint: disable=no-member
         created = LicenseNames.objects.get_or_create(name=item["name"])[1]
         if created:
             new_count += 1
         if item_type == "licenses":
-            # pylint: disable=no-member
             LicenseNames.objects.get_or_create(name=item["licenseId"])
         else:
-            # pylint: disable=no-member
             LicenseNames.objects.get_or_create(name=item["licenseExceptionId"])
     return (total_count, new_count)
 

--- a/src/populate.py
+++ b/src/populate.py
@@ -27,6 +27,7 @@ def populate(url, item_type):
     data = json.loads(response.text)
     total_count = 0
     new_count = 0
+    # Django ORM; .objects not visible to static analysis
     # pylint: disable=no-member
     for item in data[item_type]:
         total_count += 1

--- a/src/tests/api/test_compare_api.py
+++ b/src/tests/api/test_compare_api.py
@@ -7,7 +7,6 @@
 Tests for Compare API views and file upload.
 """
 
-
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
@@ -135,8 +134,10 @@ class CompareLargeFileUploadTests(APITestCase):
         """A large (temp-file) upload must not raise FileNotFoundError."""
 
         self.client.login(username=self.username, password=self.password)
-        with open(getExamplePath("SPDXRdfExample-v2.2.spdx.rdf")) as f1, \
-                open(getExamplePath("SPDXRdfExample-v2.3.spdx.rdf")) as f2:
+        with (
+            open(getExamplePath("SPDXRdfExample-v2.2.spdx.rdf")) as f1,
+            open(getExamplePath("SPDXRdfExample-v2.3.spdx.rdf")) as f2,
+        ):
             resp = self.client.post(
                 reverse("compare-api"),
                 {

--- a/src/tests/api/test_convert_api.py
+++ b/src/tests/api/test_convert_api.py
@@ -7,7 +7,6 @@
 Tests for Convert API views and file upload.
 """
 
-
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist

--- a/src/tests/api/test_validate_api.py
+++ b/src/tests/api/test_validate_api.py
@@ -7,7 +7,6 @@
 Tests for Validate API views and file upload.
 """
 
-
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from django.test import override_settings

--- a/src/tests/app/test_check_license.py
+++ b/src/tests/app/test_check_license.py
@@ -29,7 +29,9 @@ class CheckLicenseViewsTestCase(TestCase):
             self.assertEqual(resp.status_code, 200)
             self.assertNotEqual(resp.redirect_chain, [])
             self.assertIn(settings.LOGIN_URL, (i[0] for i in resp.redirect_chain))
-            self.client.force_login(User.objects.get_or_create(username='checklicensetestuser')[0])
+            self.client.force_login(
+                User.objects.get_or_create(username="checklicensetestuser")[0]
+            )
         resp2 = self.client.get(reverse("check-license"), follow=True, secure=True)
         self.assertEqual(resp2.status_code, 200)
         self.assertEqual(resp2.redirect_chain, [])

--- a/src/tests/test_helpers.py
+++ b/src/tests/test_helpers.py
@@ -29,17 +29,23 @@ from django.conf import settings
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import User
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+
 try:
     from selenium import webdriver
     from selenium.webdriver.chrome.options import Options as ChromeOptions
     from selenium.webdriver.firefox.options import Options as FirefoxOptions
+
     SELENIUM_IMPORTED = True
 except ImportError:
     SELENIUM_IMPORTED = False
 from social_django.models import UserSocialAuth
 
-from config.secret import getAccessToken, getGithubUserId, getGithubUserName, getRedisHost
-
+from config.secret import (
+    getAccessToken,
+    getGithubUserId,
+    getGithubUserName,
+    getRedisHost,
+)
 
 # ---------------------------------------------------------------------------
 # Path helpers
@@ -76,7 +82,14 @@ def github_creds_available():
 
 def _detect_browser():
     # 1. Try resolving via PATH (works on Linux/macOS, and Windows if on PATH)
-    for browser in ["chrome", "google-chrome", "chromium", "chrome.exe", "google-chrome.exe", "chromium.exe"]:
+    for browser in [
+        "chrome",
+        "google-chrome",
+        "chromium",
+        "chrome.exe",
+        "google-chrome.exe",
+        "chromium.exe",
+    ]:
         if shutil.which(browser):
             return "chrome"
     for browser in ["firefox", "firefox.exe"]:
@@ -92,9 +105,13 @@ def _detect_browser():
     # 3. Try standard Windows paths
     if os.name == "nt":
         program_files = os.environ.get("ProgramFiles", "C:\\Program Files")
-        program_files_x86 = os.environ.get("ProgramFiles(x86)", "C:\\Program Files (x86)")
-        local_app_data = os.environ.get("LocalAppData", os.path.expanduser("~\\AppData\\Local"))
-        
+        program_files_x86 = os.environ.get(
+            "ProgramFiles(x86)", "C:\\Program Files (x86)"
+        )
+        local_app_data = os.environ.get(
+            "LocalAppData", os.path.expanduser("~\\AppData\\Local")
+        )
+
         chrome_paths = [
             os.path.join(program_files, "Google\\Chrome\\Application\\chrome.exe"),
             os.path.join(program_files_x86, "Google\\Chrome\\Application\\chrome.exe"),
@@ -103,7 +120,7 @@ def _detect_browser():
         for path in chrome_paths:
             if os.path.exists(path):
                 return "chrome"
-                
+
         firefox_paths = [
             os.path.join(program_files, "Mozilla Firefox\\firefox.exe"),
             os.path.join(program_files_x86, "Mozilla Firefox\\firefox.exe"),


### PR DESCRIPTION
Limited the Python lint and format checks only for

- `src/*.py` (excluding subdirs) = 2 files
- `src/tests/*.py` (excluding subdirs) = 1 file
- `src/tests/api/` (including subdirs) = 3 files

Other files are unaffected.

Can gradually expand later when ready.
For example, expand to the small `src/config` dir in another PR.
The `pylint_per_file_ignores` plugin allows to set "lint ignores" per file.

First step to address #472 