### PR TITLE
Update spdx-license-matcher to 2.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ gevent>=26.4.0,<27.0.0
 gunicorn>=25.3.0,<26.0.0
 jpype1>=1.7.1,<2.0.0
 lxml>=5.4.0,<6.0.0
-ntia-conformance-checker>=5.0.2,<6.0.0
+ntia-conformance-checker>=5.0.3,<6.0.0
 python-dotenv>=1.0.1,<2.0.0
-redis==4.4.4 # spdx-license-matcher depends on this specific version
+redis>=4.4.4,<9
 requests>=2.33.1,<3.0.0
 # Pinned <6.0.0: social-auth-app-django 6.0.0 requires social-auth-core>=5.0.0,
 # which removed GooglePlusAuth, but drf-social-oauth2 3.4.1 still imports it.
@@ -20,4 +20,4 @@ social-auth-app-django>=5.9.0,<6.0.0
 social-auth-core>=4.9.1,<5.0.0
 spdx-python-model>=0.0.4,<1.0.0
 spdx-tools>=0.8.5,<1.0.0
-https://github.com/spdx/spdx-license-matcher/archive/refs/tags/v2.9.tar.gz#egg=spdx-license-matcher
+https://github.com/spdx/spdx-license-matcher/archive/refs/tags/v2.11.tar.gz#egg=license-matcher

--- a/src/config/version.py
+++ b/src/config/version.py
@@ -39,5 +39,5 @@ spdx_online_tools_version = "1.4.0"  # Update this when releasing new version
 java_tools_version = get_tools_version("tool.jar")
 ntia_conformance_checker_version = version("ntia-conformance-checker")
 python_tools_version = version("spdx-tools")
-spdx_license_matcher_version = version("spdx-license-matcher")
+spdx_license_matcher_version = version("license-matcher")
 spdx_python_model_version = version("spdx-python-model")


### PR DESCRIPTION
Update spdx-license-matcher.

Since spdx-license-matcher is now using `redis>=4.4.4,<9`,
we will update deps of spdx-online-tools to `redis>=4.4.4,<9` too.