### PR TITLE
Force redis to use protocol 2

### DIFF
--- a/src/app/utils/__init__.py
+++ b/src/app/utils/__init__.py
@@ -673,8 +673,8 @@ def _ensure_license_db_current(
 def check_spdx_license(licenseText):
     """Check the license text against the SPDX License List.
     """
-    r = redis.StrictRedis(host=getRedisHost(), port=6379, db=0)
-    r_meta = redis.StrictRedis(host=getRedisHost(), port=6379, db=1)
+    r = redis.StrictRedis(host=getRedisHost(), port=6379, db=0, protocol=2)
+    r_meta = redis.StrictRedis(host=getRedisHost(), port=6379, db=1, protocol=2)
     _ensure_license_db_current(r, r_meta)
 
     spdxLicenseIds = list(r.keys())


### PR DESCRIPTION
Maintains compatibility with the redis version we are using in Docker

Fixes #712