### PR TITLE
Speed up test CI - use cache

### DIFF
--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -36,6 +36,10 @@ on:
       - "requirements.txt"
       - "pyproject.toml"
 
+concurrency:
+  group: test-api-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -55,6 +59,7 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
       - name: Set up Java
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
@@ -78,4 +83,4 @@ jobs:
           cd src
           python manage.py makemigrations
           python manage.py migrate
-          python manage.py test tests.api -v 2
+          python manage.py test tests.api -v 2 --parallel auto

--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -37,6 +37,10 @@ on:
       - "requirements-dev.txt"
       - "pyproject.toml"
 
+concurrency:
+  group: test-app-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -56,6 +60,7 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
       - name: Set up Java
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:


### PR DESCRIPTION
- Use pip cache to avoid re-downloads
- Cancel jobs from previous commits in the same PR, so the most recent job can get pick up quicker
- Enable parallel for API tests / No parallel for app tests because parallel with browser sessions can be flaky